### PR TITLE
fixed: allow .csv files in windows despite no mime type

### DIFF
--- a/src/apps/seo/src/store/imports.js
+++ b/src/apps/seo/src/store/imports.js
@@ -138,7 +138,6 @@ export function CSVImporter(evt) {
 
           fileReader.readAsText(file, "UTF-8");
         } else {
-          console.log(file);
           dispatch({
             type: IMPORT_REDIRECTS,
             redirects: []


### PR DESCRIPTION
Bug: for some reason, windows upload .csv file with chrome has no mime type detected

Fix: so we will try to parse a CSV also if the filename simply has a .csv extension