### PR TITLE
fixed GlobalSubMenu from being cut off at 1680 and below

### DIFF
--- a/src/shell/components/global-menu/styles.less
+++ b/src/shell/components/global-menu/styles.less
@@ -5,13 +5,21 @@
   display: flex;
   flex: 1;
   flex-direction: column;
-  padding: 8px 32px;
+  align-items: center;
+  justify-content: space-around;
+  @media only screen and (min-width: 1680px) {
+    justify-content: initial;
+  }
 
   a {
     color: @zesty-field-blue;
     text-decoration: none;
     letter-spacing: 1px;
-    padding: 1rem 0.5rem;
+
+    @media only screen and (min-width: 1680px) {
+      padding: 1rem 0.5rem;
+    }
+
     svg {
       margin-right: 8px;
     }


### PR DESCRIPTION
fixed the global sub nav from being cut off at 1680 and below

<img width="649" alt="Screen Shot 2020-09-29 at 12 55 37 PM" src="https://user-images.githubusercontent.com/22800749/94609002-143cc480-0253-11eb-88fa-62c0d6dae839.png">
