### PR TITLE
added href to manager-ui github for zesty img logo in GlobalSubMenu

### DIFF
--- a/src/shell/components/global-actions/index.js
+++ b/src/shell/components/global-actions/index.js
@@ -3,6 +3,8 @@ import cx from "classnames";
 import { connect } from "react-redux";
 import useOnclickOutside from "react-cool-onclickoutside";
 
+import { Url } from "@zesty-io/core/Url";
+
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faQuestion, faEye } from "@fortawesome/free-solid-svg-icons";
 
@@ -43,16 +45,21 @@ export default connect(state => {
             {openMenu && <GlobalHelpMenu />}
           </span>
         </div>
-
-        <span className={cx(styles.AppVersion)}>
-          <img
-            src="https://brand.zesty.io/zesty-io-logo.svg"
-            alt={`Zesty.io version ${CONFIG.VERSION}`}
-            width="24px"
-            height="24px"
-          />
-          <span className={styles.VersionNumber}>{CONFIG.VERSION}</span>
-        </span>
+        <Url
+          href="https://github.com/zesty-io/manager-ui"
+          title="Zesty Manager-ui Github"
+          target="_blank"
+        >
+          <span className={cx(styles.AppVersion)}>
+            <img
+              src="https://brand.zesty.io/zesty-io-logo.svg"
+              alt={`Zesty.io version ${CONFIG.VERSION}`}
+              width="24px"
+              height="24px"
+            />
+            <span className={styles.VersionNumber}>{CONFIG.VERSION}</span>
+          </span>
+        </Url>
       </div>
     );
   })


### PR DESCRIPTION
Zesty Logo now href to  https://github.com/zesty-io/manager-ui

<img width="111" alt="Screen Shot 2020-10-02 at 2 31 52 PM" src="https://user-images.githubusercontent.com/22800749/94971517-050c7f80-04bc-11eb-8fda-525a752368a7.png">
