### PR TITLE
refactored width in Content Head view to fit for 1280px and up

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Head/Head.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Head/Head.js
@@ -50,13 +50,20 @@ export default class Head extends React.Component {
           <div className={styles.Head}>
             <main className={styles.Tags}>
               <h1 className={styles.Warn}>
-                <Button kind="secondary" onClick={this.onCreate}>
+                <Button
+                  className={styles.Button}
+                  kind="secondary"
+                  onClick={this.onCreate}
+                >
                   <FontAwesomeIcon icon={faPlus} />
                   New head tag
                 </Button>
-                <FontAwesomeIcon icon={faExclamationTriangle} /> &nbsp; Head
-                tags are not versioned or published. Changes to head tags take
-                effect immediately on your live instance.
+                <FontAwesomeIcon
+                  className={styles.ExclamationTriangle}
+                  icon={faExclamationTriangle}
+                />{" "}
+                &nbsp; Head tags are not versioned or published. Changes to head
+                tags take effect immediately on your live instance.
               </h1>
               {this.props.tags.length ? (
                 this.props.tags.map((tag, index) => {

--- a/src/apps/content-editor/src/app/views/ItemEdit/Head/Head.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Head/Head.less
@@ -7,7 +7,7 @@
 }
 
 .HeadWrap {
-  height: calc(100vh - 64px - 9px - 68px);
+  height: calc(100vh - 61px - 44px);
   overflow-y: scroll;
 
   .Head {
@@ -16,7 +16,7 @@
     .Tags {
       margin: 0 16px;
       float: left;
-      width: calc(100vw - 33vw - 15vw - 64px);
+      width: 60%;
 
       article:first-child {
         margin-top: 0;
@@ -38,7 +38,14 @@
   display: flex;
   align-items: center;
   margin: 16px;
+
   button {
+    margin-right: 8px;
+  }
+  .Button {
+    min-width: 160px;
+  }
+  .ExclamationTriangle {
     margin-right: 8px;
   }
 }

--- a/src/apps/content-editor/src/app/views/ItemEdit/Head/HeadTag/HeadTag.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Head/HeadTag/HeadTag.less
@@ -5,6 +5,7 @@
     .CardHeader {
       button {
         display: flex;
+        flex-wrap: wrap;
       }
     }
   }

--- a/src/apps/content-editor/src/app/views/ItemEdit/Head/Preview/Preview.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Head/Preview/Preview.less
@@ -1,12 +1,12 @@
 .TagPreviewWrap {
   background: #333;
-  height: calc(100vh - 64px - 9px - 68px);
+  height: calc(100vh - 61px - 45px);
   overflow: scroll;
   // margin-right: 24px;
-  width: calc(33% - 24px);
-  z-index: 20;
-  position: fixed;
-  right: 0;
+  // width: calc(33% - 24px);
+  // z-index: 20;
+  // position: fixed;
+  // right: 0;
 
   .TagPreview {
     font-size: 14px;


### PR DESCRIPTION
Removed old calc width and used a 60/40 percent view for content > Head view. Resolved red delete button from overflowing in smaller window view sizes.

<img width="643" alt="Screen Shot 2020-10-05 at 4 52 43 PM" src="https://user-images.githubusercontent.com/22800749/95143552-3fc81f00-072b-11eb-9176-2052b974753d.png">
