### PR TITLE
Feature/158 audit trail button colors

### DIFF
--- a/src/apps/audit-trail/src/components/controls/index.js
+++ b/src/apps/audit-trail/src/components/controls/index.js
@@ -18,7 +18,6 @@ export default React.memo(function AuditControls(props) {
       />
       <ButtonGroup className={styles.btnGroup}>
         <Button
-          kind="secondary"
           className={cx(styles.child, {
             [styles.selected]: props.filter === 1
           })}
@@ -33,7 +32,6 @@ export default React.memo(function AuditControls(props) {
           Today
         </Button>
         <Button
-          kind="secondary"
           className={cx(styles.child, {
             [styles.selected]: props.filter === 7
           })}
@@ -48,7 +46,6 @@ export default React.memo(function AuditControls(props) {
           Last Week
         </Button>
         <Button
-          kind="secondary"
           className={cx(styles.child, {
             [styles.selected]: props.filter === 30
           })}

--- a/src/apps/audit-trail/src/components/controls/styles.less
+++ b/src/apps/audit-trail/src/components/controls/styles.less
@@ -19,7 +19,7 @@
       flex: inherit;
       margin-right: 8px;
       &.selected {
-        background-color: @zesty-green;
+        background-color: @zesty-blue;
       }
     }
   }


### PR DESCRIPTION
added correct colors to audit trail buttons  kind="secondary 

<img width="1145" alt="Screen Shot 2020-10-06 at 10 37 19 AM" src="https://user-images.githubusercontent.com/22800749/95239508-ec53e080-07bf-11eb-8dc1-0052a7489d8e.png">
