### PR TITLE
removed transform scale on search and uploade icons in Code view

### DIFF
--- a/src/apps/code-editor/src/app/components/FileList/FileList.less
+++ b/src/apps/code-editor/src/app/components/FileList/FileList.less
@@ -70,16 +70,14 @@
 
     .Files {
       margin-bottom: 40px;
-    }
-  }
-
-  .Action {
-    color: @zesty-orange;
-    opacity: 0.6;
-    transition: all 0.2s ease-in-out;
-    &:hover {
-      opacity: 1;
-      transform: scale(1.1);
+      i {
+        color: @zesty-orange;
+        opacity: 0.6;
+        transition: all 0.2s ease-in-out;
+        &:hover {
+          opacity: 1;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
REMOVED transform scale on upload icons and search bar in Code view 

<img width="339" alt="Screen Shot 2020-10-06 at 3 26 18 PM" src="https://user-images.githubusercontent.com/22800749/95266574-54b6b800-07e8-11eb-98f7-bc2110cb4375.png">
