### PR TITLE
made meta content and head match button group styles

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Head/Head.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Head/Head.less
@@ -8,6 +8,7 @@
   .Head {
     display: flex;
     flex-direction: column-reverse;
+    padding: 16px;
 
     @media screen and (min-width: 2000px) {
       flex-direction: row;

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.less
@@ -3,18 +3,48 @@
 
 .ItemNav {
   display: flex;
-  margin: 0 16px 0 0;
 
   a {
     padding: 0 4px;
-    font-size: 14\6px;
+    font-size: 14px;
+    align-items: center;
+    background-color: #404759;
+    border: 0;
+    border-radius: 4px;
+    box-shadow: inset 0 -2px 2px 0 rgba(26, 32, 44, 0.24),
+      inset 0 0 2px 0 rgba(26, 32, 44, 0.12);
+    color: #ffffff;
+    cursor: pointer;
+    display: flex;
+    font-size: @font-size-button;
+    font-weight: @font-weight-bold;
+    font-style: normal;
+    font-stretch: normal;
+    line-height: 24px;
+    letter-spacing: 0.1px;
+    padding: 8px 16px 8px 16px;
+    flex-direction: row;
+    justify-content: center;
+    transition: all 0.2s;
+    text-transform: uppercase;
+    text-shadow: none;
+    min-width: 70px;
+
+    &:not(:first-child) {
+      margin-left: 8px;
+    }
+
+    &:hover {
+      box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.24),
+        0 0 2px 0 rgba(26, 32, 44, 0.12);
+    }
 
     @media screen and (min-width: 2000px) {
-      font-size: 18px;
+      font-size: 16px;
     }
   }
 
   .Selected {
-    border-bottom: 2px solid @zesty-orange;
+    background-color: @zesty-blue;
   }
 }


### PR DESCRIPTION
added styles to Content, Meta, Head now matching Button Groups and fixed alignment.


<img width="2554" alt="content-meta-head-btn" src="https://user-images.githubusercontent.com/22800749/95780545-f030a880-0c80-11eb-9710-85c28b505491.png">
 