### PR TITLE
invert on hover and selected colors nav

### DIFF
--- a/src/shell/components/global-menu/styles.less
+++ b/src/shell/components/global-menu/styles.less
@@ -29,7 +29,7 @@
   .optimize,
   .settings {
     &:hover {
-      color: @zesty-orange;
+      color: @zesty-green;
     }
   }
   .control,
@@ -38,7 +38,7 @@
   .settings {
     &:active,
     &:focus {
-      color: @zesty-green;
+      color: @zesty-orange;
     }
   }
 }


### PR DESCRIPTION
Inverted on hover colors, green lets user know to goto nav section while the orange selected matches the orange border left for more visual consistency.

![Screen Shot 2020-10-13 at 9 56 35 AM](https://user-images.githubusercontent.com/22800749/95891765-634a2580-0d3a-11eb-9737-ae30bede300d.png)
