### PR TITLE
Settings: fix 'intance' typo in store

### DIFF
--- a/src/apps/settings/src/store/settings.js
+++ b/src/apps/settings/src/store/settings.js
@@ -81,7 +81,7 @@ export function settings(
       ] = action.payload;
       return {
         ...state,
-        intance: arrInstances
+        instance: arrInstances
       };
 
     default:


### PR DESCRIPTION
closes #196 