### PR TITLE
h2s were taking in user agent stylesheet made a deafult size for h2s …

### DIFF
--- a/src/apps/analytics/src/components/TopPerforming/TopPerforming.js
+++ b/src/apps/analytics/src/components/TopPerforming/TopPerforming.js
@@ -2,6 +2,8 @@ import React from "react";
 
 import { Card, CardHeader, CardContent, CardFooter } from "@zesty-io/core/Card";
 import { WithLoader } from "@zesty-io/core/WithLoader";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowCircleUp } from "@fortawesome/free-solid-svg-icons";
 
 export class TopPerforming extends React.PureComponent {
   state = {
@@ -82,7 +84,7 @@ export class TopPerforming extends React.PureComponent {
       <Card>
         <CardHeader>
           <h2>
-            <span className="fa fa-arrow-circle-o-up" /> Top Performing Content
+            <FontAwesomeIcon icon={faArrowCircleUp} /> Top Performing Content
           </h2>
         </CardHeader>
         <CardContent>

--- a/src/apps/content-editor/src/app/views/Dashboard/Dashboard.less
+++ b/src/apps/content-editor/src/app/views/Dashboard/Dashboard.less
@@ -50,10 +50,6 @@
   }
 
   h2 {
-    font-size: 12px;
-    @media only screen and (min-width: 2000px) {
-      font-size: 16px;
-    }
     .icon {
       padding-right: 5px;
     }

--- a/src/shell/views/Shell/Shell.less
+++ b/src/shell/views/Shell/Shell.less
@@ -43,4 +43,10 @@
       height: calc(100vh - 54px);
     }
   }
+  h2 {
+    font-size: 12px;
+    @media only screen and (min-width: 2000px) {
+      font-size: 16px;
+    }
+  }
 }


### PR DESCRIPTION
H2s were defaulting to browser user agent styles sheet made a global default h2 font-size in shell to keep consistency.
Most H2 that require a custom size already have a custom class on them.

Also fixed broken svg in analytics Top Performing Content
<img width="1184" alt="Screen Shot 2020-10-16 at 9 51 59 AM" src="https://user-images.githubusercontent.com/22800749/96286689-9f2cf700-0f95-11eb-9f1f-c33dacdc03e1.png">
