### PR TITLE
tightening up node height to be more consistent for schema and content view

### DIFF
--- a/src/apps/code-editor/src/app/components/FileList/FileList.less
+++ b/src/apps/code-editor/src/app/components/FileList/FileList.less
@@ -70,6 +70,7 @@
 
     .Files {
       margin-bottom: 40px;
+      line-height: 15px;
       li i {
         color: @zesty-green;
         cursor: pointer;


### PR DESCRIPTION
decreased the line height so the node nav height can be more consistent among schema and code view
fixes #278 

<img width="324" alt="Screen Shot 2020-10-20 at 2 16 51 PM" src="https://user-images.githubusercontent.com/22800749/96645076-e8a37c00-12de-11eb-986c-4d955282689f.png">
