### PR TITLE
edit the button z-index allowing for the brush button to seem clickable

### DIFF
--- a/src/apps/settings/src/app/views/Styles/Styles.js
+++ b/src/apps/settings/src/app/views/Styles/Styles.js
@@ -162,6 +162,7 @@ export default connect(state => {
       case "color":
         return (
           <FieldTypeColor
+            className={styles.FieldTypeColorButton}
             key={field.ZUID}
             value={state[field.referenceName]}
             description={field.description}

--- a/src/apps/settings/src/app/views/Styles/Styles.less
+++ b/src/apps/settings/src/app/views/Styles/Styles.less
@@ -18,3 +18,14 @@
   font-size: 14px;
   margin-top: 20px;
 }
+
+.FieldTypeColorButton {
+  input[type="color"]:hover {
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.24),
+      0 0 2px 0 rgba(26, 32, 44, 0.12);
+  }
+  button {
+    position: relative;
+    z-index: -1;
+  }
+}


### PR DESCRIPTION
fixes #285 
The button lives outside of the input label in design-systems, I lowered the z-index on the brush button making the brush button seem clickable(magic). 

https://github.com/zesty-io/design-system/blob/v1.0.0/core/src/FieldTypeColor/FieldTypeColor.js#L40-L42

<img width="325" alt="Screen Shot 2020-10-20 at 3 04 07 PM" src="https://user-images.githubusercontent.com/22800749/96649234-9580f780-12e5-11eb-8cc0-bb4591d9bf5e.png">

CC: @kakoga 
