### PR TITLE
Added kind colors to notifications

### DIFF
--- a/src/shell/components/global-actions/components/global-notifications/GlobalNotifications.less
+++ b/src/shell/components/global-actions/components/global-notifications/GlobalNotifications.less
@@ -19,10 +19,12 @@
       margin: 8px 0;
       font-weight: 500;
     }
-    li.save {
+    li.save,
+    li.success {
       color: @zesty-green;
     }
-    li.warn {
+    li.warn,
+    li.error {
       color: @zesty-red;
     }
   }


### PR DESCRIPTION
@shrunyan correct notification colors for kind are in
SIde Note* Some notifications don't have a kind set on them hence why they are black.  Let me know if black is fine and leave as is.
CC: @kakoga 

Test: goto Code and select a publish upload icon 
Test Error: goto Content > dropdown > All Field Types > select Create Item button 

![Screen Shot 2020-10-22 at 3 24 30 PM](https://user-images.githubusercontent.com/22800749/96937151-5df88380-147c-11eb-8da4-b9f230800975.png)
