### PR TITLE
Content: remove ItemEdit NotFound logic

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -21,7 +21,6 @@ import { LockedItem } from "../../components/LockedItem";
 import { Content } from "./Content";
 import { Meta } from "./Meta";
 import { Head } from "./Head";
-import { NotFound } from "shell/components/NotFound";
 
 class ItemEdit extends Component {
   _isMounted = false;


### PR DESCRIPTION
on new instance creation where there are no item publish records and therefore state.content is empty, this bug caused an erroneous Not Found view