### PR TITLE
fixing: breadcrumbs in content create view

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemCreate/Header/Header.less
+++ b/src/apps/content-editor/src/app/views/ItemCreate/Header/Header.less
@@ -11,6 +11,12 @@
   z-index: 10;
   position: relative;
 
+  a {
+    margin-right: 4px;
+  }
+  svg {
+    margin-right: 4px;
+  }
   .Actions {
     flex-wrap: nowrap;
   }


### PR DESCRIPTION
Added equal margin space to breadcrumbs in  Content create view
 
<img width="208" alt="Screen Shot 2020-10-30 at 2 15 26 PM" src="https://user-images.githubusercontent.com/22800749/97757732-8e62a200-1aba-11eb-9521-530ca5bc355d.png">

