### PR TITLE
fixed: spacing on save button

### DIFF
--- a/src/apps/settings/src/app/views/Instance/Instance.js
+++ b/src/apps/settings/src/app/views/Instance/Instance.js
@@ -200,6 +200,7 @@ export default connect(state => {
         }
       })}
       <Button
+        className={styles.ButtonSave}
         id="saveSettings"
         kind="save"
         onClick={saveFields}

--- a/src/apps/settings/src/app/views/Instance/SettingsStyles.less
+++ b/src/apps/settings/src/app/views/Instance/SettingsStyles.less
@@ -1,3 +1,7 @@
 .selectProtocol {
   max-width: 200px;
 }
+
+.ButtonSave {
+  margin-top: 8px;
+}


### PR DESCRIPTION
added margin to save button to prevent it from being flush with dropdown field 

<img width="340" alt="Screen Shot 2020-10-30 at 2 37 19 PM" src="https://user-images.githubusercontent.com/22800749/97759097-8a844f00-1abd-11eb-9761-397db109ba89.png">
 