### PR TITLE
removing fit-content 

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ScheduleFlyout/ScheduleFlyout.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ScheduleFlyout/ScheduleFlyout.less
@@ -1,7 +1,6 @@
 @import "~@zesty-io/core/colors.less";
 
 .Modal {
-  max-width: fit-content;
   .Row {
     margin: 8px 0;
   }


### PR DESCRIPTION
Removing `fit-content` since it's not supported for IE, the fix is now in design-systems

https://caniuse.com/?search=fit-content



PR: https://github.com/zesty-io/design-system/pull/74