### PR TITLE
removing: z-index on span

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.less
@@ -3,7 +3,4 @@
     display: flex;
     font-size: 16px;
   }
-  span {
-    z-index: 90;
-  }
 }


### PR DESCRIPTION
Removed unnecessary z-index on span.

fixes #333 


<img width="699" alt="Screen Shot 2020-11-02 at 2 26 57 PM" src="https://user-images.githubusercontent.com/22800749/97926141-78055200-1d17-11eb-875e-0192ebdc7eae.png">
  