### PR TITLE
Feature/#334 spacing meta

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/CanonicalTag.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/CanonicalTag.less
@@ -2,15 +2,15 @@
   label {
     display: flex;
     font-size: 16px;
-    padding-bottom: 5px;
+    padding-bottom: 8px;
   }
   .settings {
     & > * {
-      padding-bottom: 5px;
+      padding-bottom: 8px;
     }
     .Input {
       width: 90%;
-      margin-top: 5px;
+      margin-top: 8px;
     }
   }
 }

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/SitemapPriority.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/SitemapPriority.less
@@ -2,6 +2,6 @@
   label {
     display: flex;
     font-size: 16px;
-    padding-bottom: 5px;
+    padding-bottom: 8px;
   }
 }


### PR DESCRIPTION
fixed #334  spacing to match zeplins form styleguide sections Meta Sitemap Priority & Canonical Tag


<img width="820" alt="Screen Shot 2020-11-02 at 2 51 22 PM" src="https://user-images.githubusercontent.com/22800749/97927968-e1d32b00-1d1a-11eb-8d20-388c6b8d4cdf.png">

PR in design-systems for remaining fields to match up https://github.com/zesty-io/design-system/pull/76

