### PR TITLE
fixed indented content in dropdown links

### DIFF
--- a/src/apps/content-editor/src/app/views/LinkEdit/LinkEdit.js
+++ b/src/apps/content-editor/src/app/views/LinkEdit/LinkEdit.js
@@ -258,7 +258,7 @@ class LinkEdit extends Component {
               {this.state.type === "internal" && <h2>Internal Link</h2>}
               {this.state.type === "external" && <h2>External Link</h2>}
             </CardHeader>
-            <CardContent>
+            <CardContent className={styles.CardContent}>
               <FieldTypeInternalLink
                 className={styles.Row}
                 name="parent_zuid"

--- a/src/apps/content-editor/src/app/views/LinkEdit/LinkEdit.less
+++ b/src/apps/content-editor/src/app/views/LinkEdit/LinkEdit.less
@@ -5,6 +5,12 @@
     .Row {
       margin: 16px 0;
     }
+
+    .CardContent {
+      ul {
+        padding-left: 0;
+      }
+    }
     .Checkboxes {
       cursor: pointer;
       display: flex;


### PR DESCRIPTION
Fixed the indented dropdown links 

<img width="816" alt="Screen Shot 2020-11-03 at 3 01 02 PM" src="https://user-images.githubusercontent.com/22800749/98049905-7bffa580-1de5-11eb-9fc8-59ef0868382f.png">
