### PR TITLE
Feature/#347 favicon cog

### DIFF
--- a/src/shell/components/favicon/favicon.less
+++ b/src/shell/components/favicon/favicon.less
@@ -9,7 +9,7 @@
 
   .Modal {
     max-width: 800px;
-    overflow-y: scroll;
+    overflow-y: auto;
     max-height: 80vh;
 
     h1 {


### PR DESCRIPTION
fixed #347  alignment on setting cog and swapped overflow scroll to auto to remove unnecessary scroll bar.

<img width="885" alt="Screen Shot 2020-11-07 at 7 44 18 AM" src="https://user-images.githubusercontent.com/22800749/98445547-19e8be00-20cd-11eb-9350-6be15ae66931.png">
