### PR TITLE
swapped: image upload favicon

### DIFF
--- a/src/shell/components/favicon/favicon.js
+++ b/src/shell/components/favicon/favicon.js
@@ -7,7 +7,8 @@ import {
   faBan,
   faGlobe,
   faUpload,
-  faSpinner
+  faSpinner,
+  faFileImage
 } from "@fortawesome/free-solid-svg-icons";
 
 import { request } from "utility/request";
@@ -161,7 +162,7 @@ export default connect(state => {
         {hover ? (
           <FontAwesomeIcon
             title="Select Instance Favicon"
-            icon={faUpload}
+            icon={faFileImage}
             onClick={() => setOpen(!open)}
           />
         ) : faviconURL ? (
@@ -226,7 +227,7 @@ export default connect(state => {
               {loading ? (
                 <FontAwesomeIcon icon={faSpinner} />
               ) : (
-                <FontAwesomeIcon icon={faUpload} />
+                <FontAwesomeIcon icon={faFileImage} />
               )}
               Save Favicon
             </Button>


### PR DESCRIPTION
Fixes #369 Swapped the the upload icon to an file image icon to prevent confusion on the icon 

<img width="163" alt="Screen Shot 2020-11-09 at 1 54 01 PM" src="https://user-images.githubusercontent.com/22800749/98601180-86151e80-2293-11eb-99cd-1a0cc44c6f1e.png">
<img width="222" alt="Screen Shot 2020-11-09 at 1 55 44 PM" src="https://user-images.githubusercontent.com/22800749/98601181-86adb500-2293-11eb-9aaa-e64c083afacf.png">


CC: @kakoga 