### PR TITLE
Settings: fix data shape for styles

### DIFF
--- a/src/apps/settings/src/store/settings.js
+++ b/src/apps/settings/src/store/settings.js
@@ -27,7 +27,7 @@ export function settings(
     instance: [],
 
     catStyles: [],
-    styles: {}
+    styles: []
   },
   action
 ) {


### PR DESCRIPTION
This fixes a sentry bug https://sentry.io/share/issue/e164e1ba4f504748ba7f98d447874ee6/ where settings/styles/1 throws a fatal error on load because it tries to run `filter` on an object instead of an array