### PR TITLE
fixed height calc for schema nav

### DIFF
--- a/src/apps/schema/src/app/components/Nav/SchemaNav.less
+++ b/src/apps/schema/src/app/components/Nav/SchemaNav.less
@@ -5,12 +5,11 @@
     background-color: #4b5468;
     display: flex;
     flex-direction: column;
-    padding: 4px 8px 4px 8px;
+    padding: 8px;
 
     @media (min-width: 2000px) {
       align-items: center;
       flex-direction: row;
-      padding: 8px;
     }
 
     .Search {
@@ -40,7 +39,7 @@
   }
 
   .ModelList {
-    height: calc(100vh - 54px - 86px);
+    height: calc(100vh - 54px - 102px);
 
     margin: 0;
     overflow-y: scroll;

--- a/src/apps/schema/src/app/components/Nav/SchemaNav.less
+++ b/src/apps/schema/src/app/components/Nav/SchemaNav.less
@@ -8,7 +8,6 @@
     padding: 8px;
 
     @media (min-width: 2000px) {
-      align-items: center;
       flex-direction: row;
     }
 
@@ -27,7 +26,7 @@
       margin: 8px 0 0 0;
 
       @media (min-width: 2000px) {
-        margin: 0 0 0 8px;
+        margin: 0 0 0 4px;
       }
     }
 

--- a/src/apps/schema/src/app/components/Nav/SchemaNav.less
+++ b/src/apps/schema/src/app/components/Nav/SchemaNav.less
@@ -1,13 +1,16 @@
 .SchemaNav {
   background-color: #404759;
-  padding: 8px;
+
   .Actions {
     background-color: #4b5468;
     display: flex;
     flex-direction: column;
+    padding: 4px 8px 4px 8px;
 
     @media (min-width: 2000px) {
+      align-items: center;
       flex-direction: row;
+      padding: 8px;
     }
 
     .Search {

--- a/src/apps/schema/src/app/components/Nav/SchemaNav.less
+++ b/src/apps/schema/src/app/components/Nav/SchemaNav.less
@@ -41,6 +41,10 @@
   .ModelList {
     height: calc(100vh - 54px - 102px);
 
+    @media only screen and (min-width: 2000px) {
+      height: calc(100vh - 54px - 56px);
+    }
+
     margin: 0;
     overflow-y: scroll;
     overflow-x: hidden;

--- a/src/apps/schema/src/app/components/Nav/SchemaNav.less
+++ b/src/apps/schema/src/app/components/Nav/SchemaNav.less
@@ -1,11 +1,10 @@
 .SchemaNav {
   background-color: #404759;
-
+  padding: 8px;
   .Actions {
     background-color: #4b5468;
     display: flex;
     flex-direction: column;
-    padding: 8px;
 
     @media (min-width: 2000px) {
       flex-direction: row;
@@ -38,7 +37,8 @@
   }
 
   .ModelList {
-    height: calc(100vh - 54px - 57px);
+    height: calc(100vh - 54px - 86px);
+
     margin: 0;
     overflow-y: scroll;
     overflow-x: hidden;


### PR DESCRIPTION
Adjusted the height calc to fit more list items in the container that were originally being cut off.
fixed #422 

<img width="1287" alt="Screen Shot 2020-12-10 at 10 35 15 AM" src="https://user-images.githubusercontent.com/22800749/101814735-66ac2400-3ad3-11eb-8f49-1c771bd3962d.png">
CC: @kakoga 