### PR TITLE
webpack: remove moment locales

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11613,6 +11613,12 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -12162,6 +12168,15 @@
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
+    "moment-locales-webpack-plugin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz",
+      "integrity": "sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==",
+      "dev": true,
+      "requires": {
+        "lodash.difference": "^4.5.0"
+      }
     },
     "moment-timezone": {
       "version": "0.5.28",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "less": "3.11.1",
     "less-loader": "5.0.0",
     "mini-css-extract-plugin": "^0.9.0",
+    "moment-locales-webpack-plugin": "^1.2.0",
     "monaco-editor-webpack-plugin": "1.7.0",
     "ncp": "2.0.0",
     "prettier": "1.19.1",

--- a/src/shell/webpack.config.js
+++ b/src/shell/webpack.config.js
@@ -6,6 +6,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 const CleanupStatsPlugin = require("./CleanupStatsPlugin");
+const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
 
 const CONFIG = require("./app.config");
 
@@ -45,6 +46,7 @@ module.exports = env => {
       }
     },
     plugins: [
+      new MomentLocalesPlugin(),
       new MiniCssExtractPlugin({
         ignoreOrder: true,
         filename:


### PR DESCRIPTION
removing moment locales reduces vendor bundle size from 5.96MB min to 5.73MB min