### PR TITLE
added autofocus for login manager

### DIFF
--- a/src/shell/components/login/Login.js
+++ b/src/shell/components/login/Login.js
@@ -120,12 +120,19 @@ export default connect(state => {
               </p>
 
               <FieldTypeText
+                tabIndex="1"
                 type="email"
                 name="email"
                 label="Email"
                 placeholder="e.g. hello@zesty.io"
+                autofocus
               />
-              <FieldTypeText type="password" name="password" label="Password" />
+              <FieldTypeText
+                type="password"
+                name="password"
+                label="Password"
+                tabIndex="2"
+              />
               <Button>
                 {loading ? (
                   <FontAwesomeIcon icon={faSpinner} />


### PR DESCRIPTION
fixes #433 

Added autofocus for email on manager -ui and able to tab into password for a mouse free experience on load.

CC: @kakoga  