### PR TITLE
fixed media height not fitting content in window

### DIFF
--- a/src/apps/media/src/index.js
+++ b/src/apps/media/src/index.js
@@ -13,7 +13,8 @@ export default class MediaApp extends React.Component {
 
   render() {
     return (
-      <div id="media" style={{ height: "100%" }}>
+      /* total height minus header minus control-bar */
+      <div id="media" style={{ height: "calc(100vh - 54px - 58px)" }}>
         {/* Yup. React syntax inline styles on a custom element. */}
         {/* <media-app style={{ display: "block", height: "100%" }}></media-app> */}
       </div>


### PR DESCRIPTION
fixes #437 

This also fixes the height on the sidebar if the instance has large amounts of folders.

<img width="1474" alt="Screen Shot 2020-12-16 at 2 58 05 PM" src="https://user-images.githubusercontent.com/22800749/102416671-1b9c8000-3faf-11eb-8541-1dcb48ce7993.png">


CC: @kakoga 