### PR TITLE
adding titles to global sidebar for small viewports

### DIFF
--- a/src/shell/components/global-menu/styles.less
+++ b/src/shell/components/global-menu/styles.less
@@ -16,7 +16,7 @@
     text-align: center;
 
     .title {
-      display: none;
+      display: block;
     }
     svg {
       margin-right: 0;

--- a/src/shell/components/global-sidebar/GlobalSidebar.less
+++ b/src/shell/components/global-sidebar/GlobalSidebar.less
@@ -2,6 +2,7 @@
 .GlobalSidebar {
   display: flex;
   background-color: @globalMenuBkgColor;
+  overflow-y: auto;
 
   .topMenu {
     display: grid;

--- a/src/shell/views/Shell/Shell.less
+++ b/src/shell/views/Shell/Shell.less
@@ -24,7 +24,7 @@
   height: 100vh;
   overflow: hidden;
   display: grid;
-  grid-template-columns: 60px 1fr;
+  grid-template-columns: min-content 1fr;
 
   scrollbar-color: @zesty-grey @zesty-light-grey;
   scrollbar-width: thin;
@@ -51,7 +51,6 @@
       position: relative;
       z-index: 30;
 
-      width: calc(100vw - 60px);
       @media (min-width: 2000px) {
         width: calc(100vw - 170px);
       }


### PR DESCRIPTION
CC: @kakoga 

feature, fixes #454 

Titles for global sidebar are now shown for smaller window viewport. I tested this on a window view 1280 x 720 as the smallest view port. I will still need a second pair of eyes on this when available. 2000px + is not affected and remains the same. 

*smaller windows will have scroll bar populate to Global sub Menu

![Screen Shot 2021-01-07 at 2 52 43 PM](https://user-images.githubusercontent.com/22800749/103955987-661ba300-50fc-11eb-9dfe-0e50241c19e6.png)
