### PR TITLE
Shell: favicon h1 target margin

### DIFF
--- a/src/shell/components/favicon/favicon.less
+++ b/src/shell/components/favicon/favicon.less
@@ -12,7 +12,7 @@
     overflow-y: auto;
     max-height: 80vh;
 
-    h1 {
+    > header h1 {
       margin-bottom: 8px;
     }
 


### PR DESCRIPTION
h1 inside the Favicon Modal -> Media Modal was being styled incorrectly, so I targeted the rule more specifically to target the h1 of just the Favicon Modal