### PR TITLE
fixed line-height and utilize design-system font styles

### DIFF
--- a/src/apps/media-2/src/app/components/MediaWorkspace.js
+++ b/src/apps/media-2/src/app/components/MediaWorkspace.js
@@ -129,11 +129,11 @@ export const MediaWorkspace = React.memo(function MediaWorkspace(props) {
                 })}
               </section>
             ) : search.term ? (
-              <div className={cx(styles.title, styles.Headline)}>
+              <div className={cx(styles.display, styles.Headline)}>
                 No results
               </div>
             ) : (
-              <div className={styles.UploadMessage}>
+              <div className={cx(styles.UploadMessage, styles.display)}>
                 <div>Drag and drop files here</div>
                 <div>or</div>
                 <Button onClick={chooseFile}>

--- a/src/apps/media-2/src/app/components/MediaWorkspace.less
+++ b/src/apps/media-2/src/app/components/MediaWorkspace.less
@@ -51,7 +51,4 @@
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  line-height: 5rem;
-  font-weight: 900;
-  font-size: 24px;
 }


### PR DESCRIPTION
Fixed line height and font-size for No results(search) and "Drag and drop Files"
Both not utilizing design-systems `.display` styles


![Screen Shot 2021-02-09 at 10 18 42 AM](https://user-images.githubusercontent.com/22800749/107409116-a89c1b00-6ac0-11eb-9da4-ae08b81f3ca1.png)
![Screen Shot 2021-02-09 at 10 18 33 AM](https://user-images.githubusercontent.com/22800749/107409117-a934b180-6ac0-11eb-937d-d9dbd41d6737.png)
