### PR TITLE
added: check live url headers to determine if page cache was busted

### DIFF
--- a/src/apps/content-editor/src/app/components/PendingEditsModal/PendingEditsModal.js
+++ b/src/apps/content-editor/src/app/components/PendingEditsModal/PendingEditsModal.js
@@ -82,7 +82,7 @@ export default React.memo(function PendingEditsModal(props) {
           <ButtonGroup className={styles.Actions}>
             <Button disabled={loading} kind="save" onClick={handler}>
               {loading ? (
-                <FontAwesomeIcon icon={faSpinner} />
+                <FontAwesomeIcon icon={faSpinner} spin />
               ) : (
                 <FontAwesomeIcon icon={faSave} />
               )}
@@ -90,7 +90,7 @@ export default React.memo(function PendingEditsModal(props) {
             </Button>
             <Button disabled={loading} kind="warn" onClick={handler}>
               {loading ? (
-                <FontAwesomeIcon icon={faSpinner} />
+                <FontAwesomeIcon icon={faSpinner} spin />
               ) : (
                 <FontAwesomeIcon icon={faTrash} />
               )}

--- a/src/apps/content-editor/src/app/views/ItemCreate/Header/Header.js
+++ b/src/apps/content-editor/src/app/views/ItemCreate/Header/Header.js
@@ -40,7 +40,7 @@ export default connect(state => {
           onClick={props.onSave}
         >
           {props.saving ? (
-            <FontAwesomeIcon icon={faSpinner} />
+            <FontAwesomeIcon icon={faSpinner} spin />
           ) : (
             <FontAwesomeIcon icon={faSave} />
           )}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Actions.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Actions.js
@@ -22,14 +22,14 @@ export function Actions(props) {
   const canPublish = usePermission("PUBLISH");
   const canDelete = usePermission("DELETE");
   const canUpdate = usePermission("UPDATE");
-
   const domain = useDomain();
 
   const { type } = props.model;
   const { publishing, scheduling, siblings } = props.item;
   const { listed, sort, updatedAt, version } = props.item.meta;
   const { path, metaTitle, metaLinkText } = props.item.web;
-  const { preview_domain, basicApi } = props.instance;
+  const { basicApi } = props.instance;
+  const liveURL = domain ? `${domain}${path}` : "";
 
   return (
     <aside className={styles.Actions}>
@@ -43,8 +43,8 @@ export function Actions(props) {
         publishing={publishing}
         scheduling={scheduling}
         siblings={siblings}
-        preview_domain={preview_domain}
         basicApi={basicApi}
+        liveURL={liveURL}
       />
 
       <WidgetPublishHistory
@@ -60,10 +60,7 @@ export function Actions(props) {
       />
 
       {props.set.type !== "dataset" && domain && (
-        <WidgetQuickShare
-          url={`${domain}/${path}`}
-          metaLinkText={metaLinkText}
-        />
+        <WidgetQuickShare url={liveURL} metaLinkText={metaLinkText} />
       )}
 
       {canUpdate && (

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/QuickView/QuickView.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/QuickView/QuickView.js
@@ -1,4 +1,4 @@
-import React, { useState, Fragment, useEffect } from "react";
+import React, { useState, Fragment } from "react";
 import moment from "moment-timezone";
 import cx from "classnames";
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/QuickView/QuickView.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/QuickView/QuickView.js
@@ -1,4 +1,4 @@
-import React, { useState, Fragment } from "react";
+import React, { useState, Fragment, useEffect } from "react";
 import moment from "moment-timezone";
 import cx from "classnames";
 
@@ -26,10 +26,10 @@ export const QuickView = React.memo(function QuickView(props) {
   const isPublished = props.publishing && props.publishing.isPublished;
   const isScheduled = props.scheduling && props.scheduling.isScheduled;
 
-  const [workflowRequestOpen, setWorkFlowRequestOpen] = useState(false);
   const codeAccess = usePermission("CODE");
   const domain = useDomain();
 
+  const [workflowRequestOpen, setWorkFlowRequestOpen] = useState(false);
   const handleWorkflow = () => {
     setWorkFlowRequestOpen(!workflowRequestOpen);
   };
@@ -82,9 +82,9 @@ export const QuickView = React.memo(function QuickView(props) {
                 <Url
                   target="_blank"
                   title="Instant API"
-                  href={`${domain ? domain : props.preview_domain}/-/instant/${
-                    props.itemZUID
-                  }.json`}
+                  href={`${
+                    domain ? domain : __CONFIG__.URL_PREVIEW_FULL
+                  }/-/instant/${props.itemZUID}.json`}
                 >
                   <FontAwesomeIcon icon={faBolt} />
                   &nbsp;{`/-/instant/${props.itemZUID}.json`}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/Unpublish/Unpublish.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/Unpublish/Unpublish.js
@@ -50,7 +50,7 @@ export const Unpublish = React.memo(function Unpublish(props) {
           disabled={loading || !isPublished}
         >
           {loading ? (
-            <FontAwesomeIcon icon={faSpinner} />
+            <FontAwesomeIcon icon={faSpinner} spin />
           ) : (
             <FontAwesomeIcon icon={faUnlink} />
           )}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
@@ -50,7 +50,7 @@ export const WidgetDeleteItem = React.memo(function WidgetDeleteItem(props) {
             disabled={deleting}
           >
             {deleting ? (
-              <FontAwesomeIcon icon={faSpinner} />
+              <FontAwesomeIcon icon={faSpinner} spin />
             ) : (
               <FontAwesomeIcon icon={faTrashAlt} />
             )}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPurgeItem/WidgetPurgeItem.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPurgeItem/WidgetPurgeItem.js
@@ -27,7 +27,7 @@ export const WidgetPurgeItem = React.memo(function WidgetPurgeItem(props) {
       <CardFooter className={SharedWidgetStyles.FooterSpacing}>
         {loading ? (
           <Button className={SharedWidgetStyles.Button} disabled={loading}>
-            <FontAwesomeIcon icon={faSpinner} />
+            <FontAwesomeIcon icon={faSpinner} spin />
             Refreshing Cached Item&hellip;
           </Button>
         ) : (

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WorkflowRequest/WorkflowRequest.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WorkflowRequest/WorkflowRequest.js
@@ -173,7 +173,7 @@ export default connect(state => {
               >
                 {this.state.sending ? (
                   <Fragment>
-                    <FontAwesomeIcon icon={faSpinner} />
+                    <FontAwesomeIcon icon={faSpinner} spin />
                     &nbsp;Sending
                   </Fragment>
                 ) : (

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.less
@@ -4,7 +4,7 @@
 
   .MainEditor {
     display: grid;
-    grid-template-columns: minmax(400px, auto) minmax(200px, 15vw);
+    grid-template-columns: minmax(400px, auto) minmax(250px, 15vw);
     margin: 16px 32px;
     grid-gap: 32px;
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemRoute.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemRoute.js
@@ -132,7 +132,7 @@ export const ItemRoute = connect(state => {
 
               {loading && (
                 <InputIcon className={styles.Checking}>
-                  <FontAwesomeIcon icon={faSpinner} />
+                  <FontAwesomeIcon icon={faSpinner} spin />
                 </InputIcon>
               )}
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -118,7 +118,9 @@ export default connect(state => {
             disabled={publishingDisabled || false}
             onClick={handlePublish}
           >
-            {cached ? (
+            {publishing ? (
+              <FontAwesomeIcon icon={faSpinner} spin />
+            ) : cached ? (
               <FontAwesomeIcon icon={faCheckCircle} className={styles.Cached} />
             ) : (
               <FontAwesomeIcon icon={faCloudUploadAlt} />

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -7,7 +7,8 @@ import {
   faSpinner,
   faCalendar,
   faCheckCircle,
-  faCloudUploadAlt
+  faCloudUploadAlt,
+  faMinusCircle
 } from "@fortawesome/free-solid-svg-icons";
 import { ButtonGroup } from "@zesty-io/core/ButtonGroup";
 import { Button } from "@zesty-io/core/Button";
@@ -31,7 +32,7 @@ export default connect(state => {
 
   const [open, setOpen] = useState(false);
   const [publishing, setPublishing] = useState(false);
-  const [cached, setCached] = useState(false);
+  const [cached, setCached] = useState(true);
 
   const checkCache = () => {
     fetch(
@@ -42,7 +43,6 @@ export default connect(state => {
         const isOk = json["x-status"] === 200;
         const isBusted = Number(json.age) === 0;
         // const isLang = json['content-language'] ===
-
         setCached(isOk && isBusted);
       });
   };
@@ -101,6 +101,8 @@ export default connect(state => {
     schedulingDisabled = handleScheduleDisable();
   }
 
+  useEffect(() => checkCache(), []);
+
   return (
     <ButtonGroup className={styles.Actions}>
       <VersionSelector modelZUID={props.modelZUID} itemZUID={props.itemZUID} />
@@ -117,9 +119,16 @@ export default connect(state => {
             {publishing ? (
               <FontAwesomeIcon icon={faSpinner} spin />
             ) : cached ? (
-              <FontAwesomeIcon icon={faCheckCircle} className={styles.Cached} />
+              <FontAwesomeIcon
+                icon={faCheckCircle}
+                className={styles.Cached}
+                title="CDN in sync"
+              />
             ) : (
-              <FontAwesomeIcon icon={faCloudUploadAlt} />
+              <FontAwesomeIcon
+                icon={faCloudUploadAlt}
+                title="CDN out of sync"
+              />
             )}
             Publish <span>&nbsp;Version&nbsp;</span>
             {props.item.meta.version}

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -154,7 +154,7 @@ export default connect(state => {
         id="SaveItemButton"
       >
         {props.saving ? (
-          <FontAwesomeIcon icon={faSpinner} />
+          <FontAwesomeIcon icon={faSpinner} spin />
         ) : (
           <FontAwesomeIcon icon={faSave} />
         )}

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -100,10 +100,6 @@ export default connect(state => {
     publishingDisabled = handlePublishDisable();
     schedulingDisabled = handleScheduleDisable();
   }
-
-  useEffect(() => {
-    checkCache();
-  }, [props.item]);
 
   return (
     <ButtonGroup className={styles.Actions}>

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -33,29 +33,17 @@ export default connect(state => {
   const [publishing, setPublishing] = useState(false);
   const [cached, setCached] = useState(false);
 
-  const isPublished = () => {
+  const checkCache = () => {
     fetch(
       `${CONFIG.CLOUD_FUNCTIONS_DOMAIN}/head?url=${domain}${props.item.web.path}`
     )
       .then(res => res.json())
       .then(json => {
-        console.log(props, json);
-
         const isOk = json["x-status"] === 200;
         const isBusted = Number(json.age) === 0;
         // const isLang = json['content-language'] ===
-        const isMiss = json["x-cache"] === "MISS, MISS";
 
-        console.log("isOk", isOk);
-        console.log("isBusted", isBusted);
-        console.log("isMiss", isMiss);
-
-        if (isOk && isBusted) {
-          console.log("Published successfully");
-          setCached(true);
-        } else {
-          setCached(false);
-        }
+        setCached(isOk && isBusted);
       });
   };
 
@@ -70,7 +58,7 @@ export default connect(state => {
       )
       // fetch new publish history
       .then(() => {
-        isPublished();
+        checkCache();
         props.dispatch(fetchAuditTrailPublish(props.itemZUID));
       })
       .finally(() => {
@@ -114,7 +102,7 @@ export default connect(state => {
   }
 
   useEffect(() => {
-    isPublished();
+    checkCache();
   }, [props.item]);
 
   return (

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.less
@@ -12,9 +12,6 @@
   }
 
   .Publish {
-    .Cached {
-      color: @zesty-green;
-    }
     .PublishButton {
       border-radius: 3px 0 0 3px;
       border-right: 1px solid #fff;

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.less
@@ -12,6 +12,9 @@
   }
 
   .Publish {
+    .Cached {
+      color: @zesty-green;
+    }
     .PublishButton {
       border-radius: 3px 0 0 3px;
       border-right: 1px solid #fff;

--- a/src/apps/content-editor/src/app/views/ItemList/SetActions/SetActions.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetActions/SetActions.js
@@ -93,7 +93,7 @@ export class SetActions extends Component {
             )}
             {this.props.loading && (
               <span className={styles.Loading}>
-                <FontAwesomeIcon icon={faSpinner} />
+                <FontAwesomeIcon icon={faSpinner} spin />
                 <span>Loading items</span>
               </span>
             )}

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldEdit/FieldEdit.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldEdit/FieldEdit.js
@@ -147,7 +147,7 @@ const Footer = connect(state => {
       <ButtonGroup className={styles.FieldActions}>
         <Button kind="save" disabled={!props.field.dirty} onClick={onSave}>
           {loading ? (
-            <FontAwesomeIcon icon={faSpinner} />
+            <FontAwesomeIcon icon={faSpinner} spin />
           ) : (
             <FontAwesomeIcon icon={faSave} />
           )}
@@ -165,7 +165,7 @@ const Footer = connect(state => {
             }}
           >
             {loading ? (
-              <FontAwesomeIcon icon={faSpinner} />
+              <FontAwesomeIcon icon={faSpinner} spin />
             ) : (
               <FontAwesomeIcon icon={faPlayCircle} />
             )}
@@ -184,7 +184,7 @@ const Footer = connect(state => {
             }}
           >
             {loading ? (
-              <FontAwesomeIcon icon={faSpinner} />
+              <FontAwesomeIcon icon={faSpinner} spin />
             ) : (
               <FontAwesomeIcon icon={faPauseCircle} />
             )}

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Settings/Settings.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Settings/Settings.js
@@ -185,7 +185,7 @@ function Footer(props) {
           }}
         >
           {loading ? (
-            <FontAwesomeIcon icon={faSpinner} />
+            <FontAwesomeIcon icon={faSpinner} spin />
           ) : (
             <FontAwesomeIcon icon={faSave} />
           )}
@@ -193,7 +193,7 @@ function Footer(props) {
         </Button>
         <Button onClick={duplicate} disabled={loading}>
           {loading ? (
-            <FontAwesomeIcon icon={faSpinner} />
+            <FontAwesomeIcon icon={faSpinner} spin />
           ) : (
             <FontAwesomeIcon icon={faClone} />
           )}

--- a/src/shell/components/favicon/favicon.js
+++ b/src/shell/components/favicon/favicon.js
@@ -246,7 +246,7 @@ export default connect(state => {
           <ButtonGroup className={styles.Actions}>
             <Button kind="save" className={styles.Button} onClick={handleSave}>
               {loading ? (
-                <FontAwesomeIcon icon={faSpinner} />
+                <FontAwesomeIcon icon={faSpinner} spin />
               ) : (
                 <FontAwesomeIcon icon={faFileImage} />
               )}

--- a/src/shell/components/login/Login.js
+++ b/src/shell/components/login/Login.js
@@ -135,7 +135,7 @@ export default connect(state => {
               />
               <Button>
                 {loading ? (
-                  <FontAwesomeIcon icon={faSpinner} />
+                  <FontAwesomeIcon icon={faSpinner} spin />
                 ) : (
                   <FontAwesomeIcon icon={faSignInAlt} />
                 )}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/208819/107864232-e2e22100-6e0e-11eb-81d8-b653c4cf02b7.png)

After a publish action the editor will now get the live urls HEAD info and determine if the cache has been busted by checking the `Age` header. If the page serves a `200` and the cache was busted it will display a green check.

Adds a new cloud function to support bypassing public URL CORS. 
- https://us-central1-zesty-prod.cloudfunctions.net/head?url=https://zesty.pw

Resolves https://github.com/zesty-io/manager-ui/issues/99
