### PR TITLE
Fixed publish status icons on headless sets

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/PublishStatusCell/PublishStatusCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/PublishStatusCell/PublishStatusCell.js
@@ -2,35 +2,26 @@ import React from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faClock, faEye } from "@fortawesome/free-solid-svg-icons";
+import { faClock, faEye, faCircle } from "@fortawesome/free-solid-svg-icons";
 import { Url } from "@zesty-io/core/Url";
 
 import styles from "./PublishStatusCell.less";
 export const PublishStatusCell = React.memo(function PublishStatusCell(props) {
   if (props.type === "dataset") {
     return (
-      <span className={cx(styles.PublishStatusCell)}>
+      <Url className={cx(styles.PublishStatusCell)} href={`${props.url}`}>
         {props.item &&
         props.item.scheduling &&
         props.item.scheduling.isScheduled ? (
-          <i
-            className={cx("fas fa-clock", styles.Scheduled)}
-            aria-hidden="true"
-          />
+          <FontAwesomeIcon icon={faClock} className={styles.Scheduled} />
         ) : props.item &&
           props.item.publishing &&
           props.item.publishing.isPublished ? (
-          <i
-            className={cx("fas fa-circle", styles.Published)}
-            aria-hidden="true"
-          />
+          <FontAwesomeIcon icon={faCircle} className={styles.Published} />
         ) : (
-          <i
-            className={cx("fas fa-circle", styles.Unpublished)}
-            aria-hidden="true"
-          />
+          <FontAwesomeIcon icon={faCircle} className={styles.Unpublished} />
         )}
-      </span>
+      </Url>
     );
   } else {
     return (

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/PublishStatusCell/PublishStatusCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/PublishStatusCell/PublishStatusCell.js
@@ -3,13 +3,15 @@ import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClock, faEye, faCircle } from "@fortawesome/free-solid-svg-icons";
+
 import { Url } from "@zesty-io/core/Url";
+import { AppLink } from "@zesty-io/core/AppLink";
 
 import styles from "./PublishStatusCell.less";
 export const PublishStatusCell = React.memo(function PublishStatusCell(props) {
   if (props.type === "dataset") {
     return (
-      <Url className={cx(styles.PublishStatusCell)} href={`${props.url}`}>
+      <AppLink className={cx(styles.PublishStatusCell)} to={`${props.url}`}>
         {props.item &&
         props.item.scheduling &&
         props.item.scheduling.isScheduled ? (
@@ -21,7 +23,7 @@ export const PublishStatusCell = React.memo(function PublishStatusCell(props) {
         ) : (
           <FontAwesomeIcon icon={faCircle} className={styles.Unpublished} />
         )}
-      </Url>
+      </AppLink>
     );
   } else {
     return (

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/SetRow.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/SetRow.js
@@ -40,6 +40,7 @@ export default connect()(function SetRow(props) {
       <PublishStatusCell
         type={props.model && props.model.type ? props.model.type : null}
         item={item}
+        url={`/content/${props.modelZUID}/${props.itemZUID}`}
       />
       <div className={styles.Cells} onClick={selectRow}>
         {props.fields.map(field => {


### PR DESCRIPTION
The table view in Content App for headless sets was not displaying the publish status icons. This has been updated using the fontawesome component to display the proper status icon.