### PR TITLE
Settings: support dirty state, refactors and bugfixes

### DIFF
--- a/src/apps/settings/src/app/views/Fonts/Browse.js
+++ b/src/apps/settings/src/app/views/Fonts/Browse.js
@@ -209,7 +209,6 @@ export default connect(state => {
       }
     }
     setVariants(newVariants);
-    console.log("variants selected", newVariants);
   }
 
   function renderFontsList() {
@@ -243,7 +242,7 @@ export default connect(state => {
                   disabled={saving || !variantsSelected[itemFont.family]}
                 >
                   {saving ? (
-                    <FontAwesomeIcon icon={faSpinner} />
+                    <FontAwesomeIcon spin={true} icon={faSpinner} />
                   ) : (
                     <FontAwesomeIcon icon={faPlus} />
                   )}{" "}

--- a/src/apps/settings/src/app/views/Fonts/Browse.js
+++ b/src/apps/settings/src/app/views/Fonts/Browse.js
@@ -29,7 +29,7 @@ export default connect(state => {
     data: []
   });
   const [variantsSelected, setVariants] = useState({});
-  const [isLoading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
 
   // when google fonts are ready, create pagination, tags state
   // and inject first page of font tags
@@ -120,11 +120,11 @@ export default connect(state => {
   }
 
   function onUpdateFont(font) {
-    setLoading(true);
+    setSaving(true);
 
     installSiteFont(font, variantsSelected[font])
       .then(res => {
-        setLoading(false);
+        setSaving(false);
 
         filterFontsInstalled(
           res.attributes.href.split("=")[1].split(":")[0],
@@ -149,7 +149,7 @@ export default connect(state => {
       })
       .catch(err => {
         console.log(err);
-        setLoading(false);
+        setSaving(false);
         props.dispatch(
           notify({
             kind: "success",
@@ -231,9 +231,13 @@ export default connect(state => {
                   id="InstallFont"
                   className={styles.SaveBtn}
                   onClick={() => onUpdateFont(itemFont.family)}
-                  disabled={isLoading}
+                  disabled={
+                    saving ||
+                    !variantsSelected[itemFont.family] ||
+                    variantsSelected[itemFont.family].length === 0
+                  }
                 >
-                  {isLoading ? (
+                  {saving ? (
                     <FontAwesomeIcon icon={faSpinner} />
                   ) : (
                     <FontAwesomeIcon icon={faPlus} />

--- a/src/apps/settings/src/app/views/Fonts/Browse.js
+++ b/src/apps/settings/src/app/views/Fonts/Browse.js
@@ -122,7 +122,8 @@ export default connect(state => {
   function onUpdateFont(font) {
     setSaving(true);
 
-    installSiteFont(font, variantsSelected[font])
+    props
+      .dispatch(installSiteFont(font, variantsSelected[font]))
       .then(res => {
         setSaving(false);
 

--- a/src/apps/settings/src/app/views/Fonts/Browse.js
+++ b/src/apps/settings/src/app/views/Fonts/Browse.js
@@ -136,7 +136,9 @@ export default connect(state => {
           )
         );
 
-        setVariants({ [font]: null });
+        const newVariants = { ...variantsSelected };
+        delete newVariants[font];
+        setVariants(newVariants);
         props.dispatch(
           notify({
             kind: "success",
@@ -192,12 +194,18 @@ export default connect(state => {
         };
       }
     } else {
+      const fontVariants = variantsSelected[font].filter(
+        variant => variant !== variantValidation(e.target.name)
+      );
+
       newVariants = {
-        ...variantsSelected,
-        [font]: variantsSelected[font].filter(
-          variant => variant !== variantValidation(e.target.name)
-        )
+        ...variantsSelected
       };
+      if (fontVariants.length) {
+        newVariants[font] = fontVariants;
+      } else {
+        delete newVariants[font];
+      }
     }
     setVariants(newVariants);
     console.log("variants selected", newVariants);
@@ -213,7 +221,7 @@ export default connect(state => {
                 <h3 className={styles.FontFamily}>{itemFont.family}</h3>
                 <ul className={styles.FontVariants}>
                   {itemFont.variants.map((item, index) => (
-                    <li key={`${itemFont.family}-${index}`}>
+                    <li key={`${itemFont.family}-${item}`}>
                       <input
                         type="checkbox"
                         onChange={e => selectFontVariant(itemFont.family, e)}
@@ -231,11 +239,7 @@ export default connect(state => {
                   id="InstallFont"
                   className={styles.SaveBtn}
                   onClick={() => onUpdateFont(itemFont.family)}
-                  disabled={
-                    saving ||
-                    !variantsSelected[itemFont.family] ||
-                    variantsSelected[itemFont.family].length === 0
-                  }
+                  disabled={saving || !variantsSelected[itemFont.family]}
                 >
                   {saving ? (
                     <FontAwesomeIcon icon={faSpinner} />

--- a/src/apps/settings/src/app/views/Fonts/Installed.js
+++ b/src/apps/settings/src/app/views/Fonts/Installed.js
@@ -203,7 +203,11 @@ export default connect(state => {
         ))}
         {fonts.length === 0 && (
           <Notice>
-            <p>That font doesn't exist</p>
+            {search.length === 0 ? (
+              <p>No fonts installed</p>
+            ) : (
+              <p>No matching fonts found</p>
+            )}
           </Notice>
         )}
       </div>

--- a/src/apps/settings/src/app/views/Fonts/Installed.js
+++ b/src/apps/settings/src/app/views/Fonts/Installed.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBolt, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 
 import { Button } from "@zesty-io/core/Button";
 import { Search } from "@zesty-io/core/Search";
@@ -54,7 +54,7 @@ export default connect(state => {
 
       document.head.appendChild(style);
     });
-  }, []);
+  }, [props.fontsInstalled]);
 
   function parseVariant(variant) {
     if (variant.split("").includes("i")) {
@@ -143,11 +143,15 @@ export default connect(state => {
 
   function toggleEnableFont(variant, value, font) {
     if (window.confirm("Do you really want to uninstall this font?")) {
+      console.log(fonts);
       const copyFonts = fonts
         .map(f => {
           if (f.font === font) {
             const pos = f.variants.map(v => v.label).indexOf(variant);
-            f.variants[pos].value = value.toString();
+            // handle broken installed fonts with no variants
+            if (pos !== -1) {
+              f.variants[pos].value = value.toString();
+            }
             f.variants = f.variants.filter(variant => variant.value === "1");
           }
           return f;
@@ -170,13 +174,32 @@ export default connect(state => {
                 <h3>{font.font}</h3>
               </div>
             </header>
+            {font.variants.length === 0 && (
+              <div style={{ display: "flex", justifyContent: "space-between" }}>
+                <p
+                  className={styles.ParagraphFontInstalled}
+                  style={{
+                    fontFamily: font.font.replace("+", " ")
+                  }}
+                >
+                  All their equipment and instruments are alive.
+                </p>
+                <Button
+                  kind="warn"
+                  onClick={() => toggleEnableFont(null, "0", font.font)}
+                  className={styles.ButtonRemoveFont}
+                >
+                  <FontAwesomeIcon icon={faTrashAlt} />
+                  Remove
+                </Button>
+              </div>
+            )}
             {font.variants.map((variant, idx) => (
               <div
                 key={idx}
                 style={{ display: "flex", justifyContent: "space-between" }}
               >
                 <p
-                  key={idx}
                   className={styles.ParagraphFontInstalled}
                   style={{
                     fontFamily: font.font.replace("+", " "),

--- a/src/apps/settings/src/app/views/Fonts/Installed.js
+++ b/src/apps/settings/src/app/views/Fonts/Installed.js
@@ -143,7 +143,6 @@ export default connect(state => {
 
   function toggleEnableFont(variant, value, font) {
     if (window.confirm("Do you really want to uninstall this font?")) {
-      console.log(fonts);
       const copyFonts = fonts
         .map(f => {
           if (f.font === font) {

--- a/src/apps/settings/src/app/views/Styles/Styles.js
+++ b/src/apps/settings/src/app/views/Styles/Styles.js
@@ -62,13 +62,17 @@ export default connect(state => {
         const url = headTag.attributes.href;
         const fontVariants = url.split("=")[1];
         const font = fontVariants.split(":")[0];
-        const variants = fontVariants.split(":")[1].split(",");
-        // We only need first variant of a font
-        return {
+        const variants = fontVariants.split(":")[1];
+        const fontOption = {
           label: font.replace("+", " "),
-          family: font.replace("+", " "),
-          weight: variants[0]
+          family: font.replace("+", " ")
         };
+        if (variants) {
+          const variantsArr = variants.split(",");
+          // We only need first variant of a font
+          fontOption.weight = variantsArr[0];
+        }
+        return fontOption;
       })
     );
   }, [props.fontsInstalled]);
@@ -222,7 +226,11 @@ export default connect(state => {
                 {fonts.map((option, index) => (
                   <Option
                     key={index}
-                    value={`${option.family}:${option.weight}`}
+                    value={
+                      option.weight
+                        ? `${option.family}:${option.weight}`
+                        : option.family
+                    }
                     text={option.family}
                   />
                 ))}

--- a/src/apps/settings/src/store/settings.js
+++ b/src/apps/settings/src/store/settings.js
@@ -240,27 +240,29 @@ export function fetchFonts() {
 }
 
 export function installSiteFont(font, variants) {
-  font = font.replace(/\s/g, "+");
-  variants = variants.join();
+  return (dispatch, getState) => {
+    font = font.replace(/\s/g, "+");
+    variants = variants.join();
 
-  return request(`${CONFIG.API_INSTANCE}/web/headtags`, {
-    method: "POST",
-    json: true,
-    body: {
-      type: "link",
-      attributes: {
-        rel: "stylesheet",
-        href: `https://fonts.googleapis.com/css?family=${font}:${variants}`
-      },
-      sort: 1,
-      resourceZUID: "8-b6b5acc6ca-n7hh8b"
-    }
-  })
-    .then(res => res.data)
-    .catch(err => {
-      console.log(err);
-      return err;
-    });
+    return request(`${CONFIG.API_INSTANCE}/web/headtags`, {
+      method: "POST",
+      json: true,
+      body: {
+        type: "link",
+        attributes: {
+          rel: "stylesheet",
+          href: `https://fonts.googleapis.com/css?family=${font}:${variants}`
+        },
+        sort: 1,
+        resourceZUID: getState().instance.ZUID
+      }
+    })
+      .then(res => res.data)
+      .catch(err => {
+        console.log(err);
+        return err;
+      });
+  };
 }
 
 export function fetchFontsInstalled() {

--- a/src/apps/settings/src/store/settings.js
+++ b/src/apps/settings/src/store/settings.js
@@ -83,6 +83,16 @@ export function settings(
         ...state,
         instance: arrInstances
       };
+    case "UPDATE_STYLES_SUCCESS":
+      const styles = state.styles;
+      const styleIndex = styles
+        .map(item => item.ZUID)
+        .indexOf(action.payload.ZUID);
+      styles[styleIndex] = action.payload;
+      return {
+        ...state,
+        styles
+      };
 
     default:
       return state;
@@ -175,14 +185,24 @@ export function fetchStylesVariables() {
   };
 }
 
-export function saveVariables(zuid, data) {
-  return request(`${CONFIG.API_INSTANCE}/web/stylesheets/variables/${zuid}`, {
-    method: "PUT",
-    json: true,
-    body: data
-  })
-    .then(res => res)
-    .catch(err => console.log("err", err));
+export function saveStyleVariable(zuid, data) {
+  return dispatch => {
+    console.log("saving style variable");
+    return request(`${CONFIG.API_INSTANCE}/web/stylesheets/variables/${zuid}`, {
+      method: "PUT",
+      json: true,
+      body: data
+    })
+      .then(res => {
+        if (res) {
+          dispatch({
+            type: "UPDATE_STYLES_SUCCESS",
+            payload: data
+          });
+        }
+      })
+      .catch(err => console.log("err", err));
+  };
 }
 
 export function updateSettings(zuid, data) {

--- a/src/apps/settings/src/store/settings.js
+++ b/src/apps/settings/src/store/settings.js
@@ -187,7 +187,6 @@ export function fetchStylesVariables() {
 
 export function saveStyleVariable(zuid, data) {
   return dispatch => {
-    console.log("saving style variable");
     return request(`${CONFIG.API_INSTANCE}/web/stylesheets/variables/${zuid}`, {
       method: "PUT",
       json: true,


### PR DESCRIPTION
- feat: browse fonts selecting variants enables 'Add' button
- feat: instance settings add dirty state, save only dirty fields, disable save button if not dirty, clear dirty on save
- feat: style settings disable save button if not dirty, clear dirty on save
- refactor: style settings - remove extraneous fetchStyleVariables (since we persist settings updates to store)
- refactor: rename state and functions for clarity
- refactor: browse fonts - remove unused state
- refactor: remove extraneous imports
- refactor: instance settings - remove dead Tooltip code
- fix: settings save notification text
- fix: no search results text, no installed fonts text
- fix: browse fonts variant selection
- fix: installing font uses associated instance ZUID for head tag
- fix: installed fonts and styles settings - allow handling of previously installed fonts with no variants
- fix: style settings - persist settings updates to redux store

fixes #503 
fixes #496 