### PR TITLE
added: track session ending state to exit app when 401 response occurs

### DIFF
--- a/src/shell/components/global-actions/components/global-notifications/GlobalNotifications.js
+++ b/src/shell/components/global-actions/components/global-notifications/GlobalNotifications.js
@@ -18,7 +18,7 @@ export default connect(state => {
   };
 })(
   React.memo(function GlobalNotifications(props) {
-    const [open, setOpen] = useState(Boolean(props.notifications.length));
+    const [open, setOpen] = useState(false);
     const [showAll, setShowAll] = useState(false);
 
     const ref = useOnclickOutside(() => {
@@ -26,16 +26,18 @@ export default connect(state => {
     });
 
     useEffect(() => {
-      setOpen(Boolean(props.notifications.length));
+      if (props.notifications.length) {
+        setOpen(true);
 
-      // On every render set timeout to hide notices
-      const token = setTimeout(() => {
-        setOpen(false);
-      }, 5000);
+        // On every render set timeout to hide notices
+        const token = setTimeout(() => {
+          setOpen(false);
+        }, 5000);
 
-      return () => {
-        clearTimeout(token);
-      };
+        return () => {
+          clearTimeout(token);
+        };
+      }
     }, [props.notifications.length]);
 
     return (

--- a/src/shell/store/auth.js
+++ b/src/shell/store/auth.js
@@ -5,7 +5,8 @@ import { notify } from "shell/store/notifications";
 export function auth(
   state = {
     checking: true,
-    valid: false
+    valid: false,
+    sessionEnding: false
   },
   action
 ) {
@@ -24,6 +25,7 @@ export function auth(
       return {
         ...state,
         checking: false,
+        sessionEnding: false,
         valid: action.payload.code === 200,
         token: action.payload.meta.token
       };
@@ -35,6 +37,12 @@ export function auth(
     case "FETCH_LOGIN_ERROR":
       return { ...state, checking: false, valid: action.payload.auth };
 
+    case "SESSION_ENDING":
+      return { ...state, sessionEnding: true };
+
+    case "SESSION_INVALID":
+      return { ...state, valid: false };
+
     case "LOGOUT":
       Cookies.remove(CONFIG.COOKIE_NAME, {
         path: "/",
@@ -45,6 +53,35 @@ export function auth(
     default:
       return state;
   }
+}
+
+export function endSession() {
+  return (dispatch, getState) => {
+    const state = getState();
+
+    dispatch({
+      type: "SESSION_ENDING"
+    });
+
+    // Track session ending to avoid mutliple notifications
+    // when multiple requests return 401
+    if (!state.auth.sessionEnding) {
+      dispatch(
+        notify({
+          kind: "warn",
+          message: "Your session has ended. Opening the login modal."
+        })
+      );
+
+      // Wait 5 seconds so it is not a jarring experience
+      // switching someone to the login screen
+      setTimeout(() => {
+        dispatch({
+          type: "SESSION_INVALID"
+        });
+      }, 5000);
+    }
+  };
 }
 
 export function verify() {

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -245,14 +245,15 @@ export function fetchItem(modelZUID, itemZUID) {
           });
           return res;
         }
-        if (!res || !res.data) {
-          throw new Error("Bad response from API. Missing resource data.");
+
+        // Only insert valid items into state
+        if (res?.data?.meta?.ZUID) {
+          dispatch({
+            type: "FETCH_ITEM_SUCCESS",
+            data: { ...res.data, dirty: false },
+            itemZUID
+          });
         }
-        dispatch({
-          type: "FETCH_ITEM_SUCCESS",
-          data: { ...res.data, dirty: false },
-          itemZUID
-        });
 
         return res;
       }

--- a/src/utility/request.js
+++ b/src/utility/request.js
@@ -1,7 +1,6 @@
 import Cookies from "js-cookie";
 import { store } from "shell/store";
-import { notify } from "shell/store/notifications";
-import { verify } from "shell/store/auth";
+import { endSession } from "shell/store/auth";
 
 export function request(url, opts = {}) {
   if (!url) {
@@ -54,27 +53,8 @@ export function request(url, opts = {}) {
       // if (res.status === 400) {}
 
       if (res.status === 401) {
-        const state = store.getState();
-
-        // When a token is set it means this user had previously logged in
-        // but a request returned a 401, indicating their session has since
-        // ended and we need them to re-login
-        if (state.auth.token) {
-          store.dispatch(
-            notify({
-              kind: "warn",
-              message: "Your session has ended. Opening the login modal."
-            })
-          );
-
-          setTimeout(() => {
-            store.dispatch(verify());
-          }, 5000);
-        } else {
-          // This may create a lot of noise in our error capturing
-          // but I want to understand if we are seeing instances of this code path
-          throw new Error(`401:RequestUnauthenticated: ${res.url}`);
-        }
+        store.dispatch(endSession());
+        throw new Error(`401:Unauthenticated: ${res.url}`);
       }
 
       // Not Found


### PR DESCRIPTION
The fix https://github.com/zesty-io/manager-ui/pull/564 did not account for situations where the state will not have the token on hand.