### PR TITLE
increased missing image favicon and add redirect link to head tags

### DIFF
--- a/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.js
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.js
@@ -41,7 +41,7 @@ export function AccountInfo(props) {
           ) : (
             <AppLink
               className={styles.UploadImg}
-              title="Upload Image"
+              title="Add Image"
               to="/settings/head"
             >
               <FontAwesomeIcon icon={faUpload} />
@@ -76,9 +76,9 @@ export function AccountInfo(props) {
               &nbsp; Instance Admin
             </Url>
             {!faviconURL ? (
-              <AppLink to="/settings/head" title="Upload Image">
+              <AppLink to="/settings/head" title="Add Image">
                 <FontAwesomeIcon icon={faUpload} />
-                &nbsp; Upload Image
+                &nbsp; Add Image
               </AppLink>
             ) : (
               ""

--- a/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.js
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.js
@@ -11,6 +11,7 @@ import {
 import { Card, CardHeader, CardContent } from "@zesty-io/core/Card";
 import { Url } from "@zesty-io/core/Url";
 import styles from "./AccountInfo.less";
+import { AppLink } from "@zesty-io/core/AppLink";
 
 export function AccountInfo(props) {
   const [faviconURL, setFaviconURL] = useState("");
@@ -38,7 +39,9 @@ export function AccountInfo(props) {
           {faviconURL ? (
             <img src={faviconURL} height="64px" width="64px" />
           ) : (
-            <FontAwesomeIcon icon={faFileImage} />
+            <AppLink className={styles.UploadImg} to="/settings/head">
+              <FontAwesomeIcon icon={faFileImage} />
+            </AppLink>
           )}
 
           <div className={styles.Links}>

--- a/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.js
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.js
@@ -5,8 +5,8 @@ import {
   faHome,
   faEye,
   faUser,
-  faFileImage,
-  faGlobeAmericas
+  faGlobeAmericas,
+  faUpload
 } from "@fortawesome/free-solid-svg-icons";
 import { Card, CardHeader, CardContent } from "@zesty-io/core/Card";
 import { Url } from "@zesty-io/core/Url";
@@ -39,8 +39,12 @@ export function AccountInfo(props) {
           {faviconURL ? (
             <img src={faviconURL} height="64px" width="64px" />
           ) : (
-            <AppLink className={styles.UploadImg} to="/settings/head">
-              <FontAwesomeIcon icon={faFileImage} />
+            <AppLink
+              className={styles.UploadImg}
+              title="Upload Image"
+              to="/settings/head"
+            >
+              <FontAwesomeIcon icon={faUpload} />
             </AppLink>
           )}
 
@@ -71,6 +75,14 @@ export function AccountInfo(props) {
               <FontAwesomeIcon icon={faUser} />
               &nbsp; Instance Admin
             </Url>
+            {!faviconURL ? (
+              <AppLink to="/settings/head" title="Upload Image">
+                <FontAwesomeIcon icon={faUpload} />
+                &nbsp; Upload Image
+              </AppLink>
+            ) : (
+              ""
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.js
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.js
@@ -41,7 +41,7 @@ export function AccountInfo(props) {
           ) : (
             <AppLink
               className={styles.UploadImg}
-              title="Add Image"
+              title="Add an image"
               to="/settings/head"
             >
               <FontAwesomeIcon icon={faUpload} />
@@ -76,9 +76,9 @@ export function AccountInfo(props) {
               &nbsp; Instance Admin
             </Url>
             {!faviconURL ? (
-              <AppLink to="/settings/head" title="Add Image">
+              <AppLink to="/settings/head" title="Add an image">
                 <FontAwesomeIcon icon={faUpload} />
-                &nbsp; Add Image
+                &nbsp; Add an image
               </AppLink>
             ) : (
               ""

--- a/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.less
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.less
@@ -16,6 +16,22 @@
 
     text-align: left;
   }
+  .UploadImg {
+    position: relative;
+    font-size: 63px;
+    transition: all 0.3s ease;
+    &:hover {
+      &::after {
+        content: "Upload Image in Head Tags ";
+        position: absolute;
+        bottom: -12px;
+        left: 0;
+        z-index: 2;
+        font-size: 10px;
+        width: max-content;
+      }
+    }
+  }
   .Links {
     display: flex;
     flex-direction: column;

--- a/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.less
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.less
@@ -13,24 +13,12 @@
     display: grid;
     grid-template-columns: max-content max-content;
     gap: 16px;
-
+    align-items: center;
     text-align: left;
   }
   .UploadImg {
     position: relative;
-    font-size: 57px;
-    transition: all 0.3s ease;
-    &:hover {
-      &::after {
-        content: "Upload Image in Head Tags ";
-        position: absolute;
-        bottom: -12px;
-        left: 0;
-        z-index: 2;
-        font-size: 10px;
-        width: max-content;
-      }
-    }
+    font-size: 32px;
   }
   .Links {
     display: flex;

--- a/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.less
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.less
@@ -18,7 +18,7 @@
   }
   .UploadImg {
     position: relative;
-    font-size: 63px;
+    font-size: 57px;
     transition: all 0.3s ease;
     &:hover {
       &::after {


### PR DESCRIPTION
Increased favicon size and added on hover directions, redirect to Head Tags
fixes #555 
On SVG hover text will populate 

<img width="316" alt="Screen Shot 2021-03-11 at 10 43 54 AM" src="https://user-images.githubusercontent.com/22800749/110838110-effbff80-8256-11eb-9949-dea3724ac07f.png">
