### PR TITLE
fix: Multi-Lang related Fields filter by content lang

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/Editor.js
+++ b/src/apps/content-editor/src/app/components/Editor/Editor.js
@@ -135,6 +135,7 @@ export default class Editor extends PureComponent {
                     onChange={this.onChange}
                     onSave={onSave}
                     value={item && item.data && item.data[field.name]}
+                    langID={item.meta.langID}
                   />
                 </div>
               );

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -468,15 +468,12 @@ export default connect(state => {
       }
 
       const onOneToOneOpen = useCallback(() => {
-        if (!props.allLanguages.length) {
-          return Promise.resolve();
-        }
         return dispatch(
           fetchItems(relatedModelZUID, {
             lang: props.allLanguages.find(lang => lang.ID === langID).code
           })
         );
-      }, [props.allLanguages.length]);
+      }, [props.allLanguages.length, relatedModelZUID, langID]);
 
       let oneToOneOptions = useMemo(() => {
         return resolveRelatedOptions(
@@ -568,9 +565,6 @@ export default connect(state => {
 
       // Delay loading options until user opens dropdown
       const onOneToManyOpen = useCallback(() => {
-        if (!props.allLanguages.length) {
-          return Promise.resolve();
-        }
         return Promise.all([
           dispatch(fetchFields(relatedModelZUID)),
           dispatch(

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -110,6 +110,9 @@ function resolveRelatedOptions(
     .sort(sortTitle);
 }
 
+const getSelectedLang = (langs, langID) =>
+  langs.find(lang => lang.ID === langID).code;
+
 export default connect(state => {
   return {
     allItems: state.content,
@@ -470,7 +473,7 @@ export default connect(state => {
       const onOneToOneOpen = useCallback(() => {
         return dispatch(
           fetchItems(relatedModelZUID, {
-            lang: props.allLanguages.find(lang => lang.ID === langID).code
+            lang: getSelectedLang(props.allLanguages, langID)
           })
         );
       }, [props.allLanguages.length, relatedModelZUID, langID]);
@@ -485,8 +488,8 @@ export default connect(state => {
           value
         );
       }, [
-        props.allFields,
-        props.allItems,
+        Object.keys(props.allFields).length,
+        Object.keys(props.allItems).length,
         relatedModelZUID,
         relatedFieldZUID,
         langID,
@@ -555,8 +558,8 @@ export default connect(state => {
           value
         );
       }, [
-        props.allFields,
-        props.allItems,
+        Object.keys(props.allFields).length,
+        Object.keys(props.allItems).length,
         relatedModelZUID,
         relatedFieldZUID,
         langID,
@@ -569,7 +572,7 @@ export default connect(state => {
           dispatch(fetchFields(relatedModelZUID)),
           dispatch(
             fetchItems(relatedModelZUID, {
-              lang: props.allLanguages.find(lang => lang.ID === langID).code
+              lang: getSelectedLang(props.allLanguages, langID)
             })
           )
         ]);

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/LanguageSelector/LanguageSelector.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/LanguageSelector/LanguageSelector.js
@@ -50,7 +50,6 @@ export const LanguageSelector = connect((state, props) => {
           className={cx(styles.LanguageSelector, props.className)}
           value={props.selectedLang}
           onSelect={handleSelect}
-          loading={false}
         >
           {props.languages.map(lang => (
             <Option key={lang.code} text={lang.code} value={lang.code} />

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/LanguageSelector/LanguageSelector.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/LanguageSelector/LanguageSelector.js
@@ -5,7 +5,6 @@ import { useHistory, useLocation } from "react-router-dom";
 
 import { Select, Option } from "@zesty-io/core/Select";
 
-import { fetchLangauges } from "shell/store/languages";
 import { selectLang } from "shell/store/user";
 
 import styles from "./LanguageSelector.less";
@@ -30,14 +29,6 @@ export const LanguageSelector = connect((state, props) => {
 })(props => {
   const location = useLocation();
   const history = useHistory();
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    if (!props.languages.length && !loading) {
-      setLoading(true);
-      props.dispatch(fetchLangauges("enabled")).then(() => setLoading(false));
-    }
-  });
 
   const handleSelect = val => {
     props.dispatch(selectLang(val));
@@ -59,7 +50,7 @@ export const LanguageSelector = connect((state, props) => {
           className={cx(styles.LanguageSelector, props.className)}
           value={props.selectedLang}
           onSelect={handleSelect}
-          loading={loading}
+          loading={false}
         >
           {props.languages.map(lang => (
             <Option key={lang.code} text={lang.code} value={lang.code} />

--- a/src/shell/components/load-instance/index.js
+++ b/src/shell/components/load-instance/index.js
@@ -64,7 +64,7 @@ export default connect(state => {
               props.instance.ID &&
               props.instance.domains &&
               props.user.ID &&
-              props.languages
+              props.languages.length
             }
             message="Loading Instance"
             width="100vw"

--- a/src/shell/components/load-instance/index.js
+++ b/src/shell/components/load-instance/index.js
@@ -10,6 +10,7 @@ import { fetchUsers } from "shell/store/users";
 import { fetchProducts } from "shell/store/products";
 import { detectPlatform } from "shell/store/platform";
 import { fetchInstances } from "shell/store/instances";
+import { fetchLangauges } from "shell/store/languages";
 
 import styles from "./LoadInstance.less";
 
@@ -17,7 +18,8 @@ export default connect(state => {
   return {
     instance: state.instance,
     user: state.user,
-    products: state.products
+    products: state.products,
+    languages: state.languages
   };
 })(
   React.memo(function LoadInstance(props) {
@@ -46,6 +48,7 @@ export default connect(state => {
       props.dispatch(fetchUsers());
       props.dispatch(detectPlatform());
       props.dispatch(fetchInstances());
+      props.dispatch(fetchLangauges("enabled"));
     }, []);
 
     return (
@@ -60,7 +63,8 @@ export default connect(state => {
               props.products &&
               props.instance.ID &&
               props.instance.domains &&
-              props.user.ID
+              props.user.ID &&
+              props.languages
             }
             message="Loading Instance"
             width="100vw"


### PR DESCRIPTION
Multi-Lang content with related fields will now use the Content Lang to filter the related fields. 
If non-English content has English related fields, we will continue to show the selected English fields and user can remove them. Redux Middleware for related fields continues to loads items in English.

Hoist fetch languages to LoadInstance so that languages are guaranteed available for us to filter fields by language.

fixes #637 
fixes #610 