### PR TITLE
Refactor ContentSearch

### DIFF
--- a/src/apps/seo/src/app/app.less
+++ b/src/apps/seo/src/app/app.less
@@ -35,6 +35,6 @@
     height: calc(100vh - 54px);
     overflow: scroll;
     padding: 0;
-    background: @zesty-field-blue;
+    background: @appBkgColor;
   }
 }

--- a/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectActions.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectActions.less
@@ -9,6 +9,7 @@
   min-height: 3.4rem;
   top: 0;
   z-index: 2;
+  background-color: @appBkgColor;
 
   .title {
     flex: 1;

--- a/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectActions.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectActions.less
@@ -8,7 +8,6 @@
   position: sticky;
   min-height: 3.4rem;
   top: 0;
-  background: @zesty-field-blue;
   z-index: 2;
 
   .title {

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
@@ -11,88 +11,63 @@ import { createRedirect } from "../../../../store/redirects";
 
 import styles from "./RedirectCreator.less";
 import ContentSearch from "shell/components/ContentSearch";
-export default class RedirectCreator extends Component {
-  constructor(props) {
-    super(props);
 
-    this.state = {
-      path: "",
-      targetType: "path",
-      target: "",
-      code: 1
-    };
-  }
-  handleFrom(evt) {
-    console.log("TODO// validate from url", evt);
-    this.setState({
-      path: evt.currentTarget.value
-    });
-  }
-  handleCode(value) {
-    this.setState({
-      code: value
-    });
-  }
-  handleTarget(value) {
-    this.setState({
-      target: value
-    });
-  }
-  handleCreateRedirect() {
-    this.props.dispatch(
+export function RedirectCreator(props) {
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [code, setCode] = useState(1); // Toggle defaults to 301
+
+  const handleCreateRedirect = () => {
+    props.dispatch(
       createRedirect({
-        path: this.state.path,
-        targetType: this.state.targetType,
-        target: this.state.target,
-        code: this.state.code === 1 ? 301 : 302
+        path: from,
+        targetType: "path",
+        target: to,
+        code: code === 1 ? 301 : 302 // API expects a 301/302 value
       })
     );
-  }
-  render() {
-    return (
-      <div className={styles.RedirectCreator}>
-        <span className={styles.RedirectCreatorCell} style={{ flex: "1" }}>
-          <Input
-            className={styles.from}
-            name="redirectFrom"
-            type="text"
-            placeholder="Enter the old url you want to create a redirect with."
-            onChange={this.handleFrom.bind(this)}
-          />
-        </span>
-        <span className={styles.RedirectCreatorCell}>
-          <ToggleButton
-            className={styles.code}
-            name="redirectType"
-            value={this.state.code}
-            offValue="302"
-            onValue="301"
-            onChange={this.handleCode.bind(this)}
-          />
-        </span>
-        <span className={styles.RedirectCreatorCell} style={{ flex: "1" }}>
-          <ContentSearch
-            className={styles.SearchBar}
-            onSelect={(item, setSearchTerm) => {
-              setSearchTerm(item.web.path);
-              this.handleTarget(item.web.path);
-            }}
-            filterResults={results =>
-              results.filter(result => result.web.path !== null)
-            }
-          />
-        </span>
-        <span className={styles.RedirectCreatorCell}>
-          <Button
-            className="save"
-            kind="save"
-            onClick={this.handleCreateRedirect.bind(this)}
-          >
-            <FontAwesomeIcon icon={faPlus} />
-            Create Redirect
-          </Button>
-        </span>
-      </div>
-    );
-  }
+  };
+
+  return (
+    <div className={styles.RedirectCreator}>
+      <span className={styles.RedirectCreatorCell} style={{ flex: "1" }}>
+        <Input
+          className={styles.from}
+          name="redirectFrom"
+          type="text"
+          placeholder="URL path to redirect from"
+          onChange={evt => setFrom(evt.target.value)}
+        />
+      </span>
+      <span className={styles.RedirectCreatorCell}>
+        <ToggleButton
+          className={styles.code}
+          name="redirectType"
+          value={code}
+          offValue="302"
+          onValue="301"
+          onChange={val => setCode(Number(val))}
+        />
+      </span>
+      <span className={styles.RedirectCreatorCell} style={{ flex: "1" }}>
+        <ContentSearch
+          className={styles.SearchBar}
+          placeholder="Search for item"
+          onSelect={item => {
+            setTo(item.web.path);
+          }}
+          filterResults={results =>
+            results.filter(result => result.web.path !== null)
+          }
+          value={to}
+        />
+      </span>
+      <span className={styles.RedirectCreatorCell}>
+        <Button className="save" kind="save" onClick={handleCreateRedirect}>
+          <FontAwesomeIcon icon={faPlus} />
+          Create Redirect
+        </Button>
+      </span>
+    </div>
+  );
 }

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.less
@@ -4,7 +4,7 @@
 .RedirectCreator {
   align-items: center;
   display: flex;
-  background-color: @zesty-tab-blue;
+  background: lighten(@zesty-light-blue, 10%);
   border-radius: 4px 4px 0 0;
   margin: 0;
 
@@ -21,14 +21,11 @@
       flex: 1;
     }
     .from {
-      border: 1px solid darken(@zesty-grey, 5%);
       flex: 1;
     }
     .code {
-      border: 1px solid darken(@zesty-grey, 5%);
     }
     .to {
-      border: 1px solid darken(@zesty-grey, 5%);
       flex: 1;
     }
   }

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.less
@@ -8,6 +8,10 @@
   border-radius: 4px 4px 0 0;
   margin: 0;
 
+  .RedirectCreatorCell:nth-child("odd") {
+    flex: 1;
+  }
+
   .RedirectCreatorCell {
     display: flex;
     padding: 1rem;

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/index.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/index.js
@@ -1,2 +1,1 @@
-import RedirectCreator from "./RedirectCreator";
-export default RedirectCreator;
+export { RedirectCreator } from "./RedirectCreator";

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
@@ -3,7 +3,7 @@ import styles from "./RedirectTable.less";
 
 import { removeRedirect } from "../../../store/redirects";
 
-import RedirectCreator from "./RedirectCreator";
+import { RedirectCreator } from "./RedirectCreator";
 import RedirectsTableHeader from "./RedirectsTableHeader";
 import RedirectsTableRow from "./RedirectsTableRow";
 

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
@@ -109,8 +109,12 @@ export default class RedirectTable extends React.Component {
 
     if (direction === "desc") {
       return Object.keys(redirects).sort((a, b) => {
-        const prev = redirects[a][mapping[by]].toLowerCase().trim();
-        const next = redirects[b][mapping[by]].toLowerCase().trim();
+        const prev = String(redirects[a][mapping[by]])
+          ?.toLowerCase()
+          .trim();
+        const next = String(redirects[b][mapping[by]])
+          ?.toLowerCase()
+          .trim();
 
         if (prev > next) {
           return -1;
@@ -122,8 +126,12 @@ export default class RedirectTable extends React.Component {
       });
     } else if (direction === "asc") {
       return Object.keys(redirects).sort((a, b) => {
-        const prev = redirects[a][mapping[by]].toLowerCase().trim();
-        const next = redirects[b][mapping[by]].toLowerCase().trim();
+        const prev = String(redirects[a][mapping[by]])
+          ?.toLowerCase()
+          .trim();
+        const next = String(redirects[b][mapping[by]])
+          ?.toLowerCase()
+          .trim();
 
         if (prev < next) {
           return -1;

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.less
@@ -8,7 +8,7 @@
     border: 1px solid @zesty-light-blue;
     border-radius: 4px;
     .noResults {
-      margin: 2rem 0;
+      margin: 16px;
       font-size: 2rem;
       font-weight: 900;
     }

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.less
@@ -1,8 +1,12 @@
+@import "~@zesty-io/core/colors.less";
+
 .RedirectsTable {
   width: 100%;
   .TableBody {
     display: flex;
     flex-direction: column;
+    border: 1px solid @zesty-light-blue;
+    border-radius: 4px;
     .noResults {
       margin: 2rem 0;
       font-size: 2rem;

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.js
@@ -18,6 +18,7 @@ export default function RedirectsTableHeader(props) {
       >
         <span
           className={cx(
+            styles.subheadline,
             styles.column,
             props.sortBy === "from" ? styles.sorted : ""
           )}
@@ -39,6 +40,7 @@ export default function RedirectsTableHeader(props) {
       >
         <span
           className={cx(
+            styles.subheadline,
             styles.column,
             props.sortBy === "type" ? styles.sorted : ""
           )}
@@ -61,6 +63,7 @@ export default function RedirectsTableHeader(props) {
       >
         <span
           className={cx(
+            styles.subheadline,
             styles.column,
             props.sortBy === "to" ? styles.sorted : ""
           )}

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.less
@@ -3,11 +3,9 @@
   display: flex;
   position: sticky;
   top: 3rem;
-  background: @zesty-field-blue;
-  border-bottom: 1px solid #b8c8e2;
   z-index: 1;
   align-items: baseline;
-  padding-bottom: 0.5rem;
+  padding-bottom: 16px;
 
   .RedirectsTableHeaderCell {
     cursor: pointer;

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.less
@@ -8,6 +8,7 @@
   z-index: 1;
   align-items: baseline;
   padding-bottom: 16px;
+  background-color: @appBkgColor;
 
   .RedirectsTableHeaderCell {
     cursor: pointer;

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.less
@@ -1,4 +1,6 @@
 @import "~@zesty-io/core/colors.less";
+@import "~@zesty-io/core/typography.less";
+
 .RedirectsTableHeader {
   display: flex;
   position: sticky;
@@ -12,15 +14,12 @@
     font-weight: 900;
     padding: 0 1rem;
 
-    .icon {
-      padding-left: 3px;
-    }
-
     .column {
       border-bottom: 3px solid @zesty-field-blue;
       padding-bottom: 0.1rem;
-      line-height: 24px;
-      font-size: 16px;
+      svg {
+        padding-left: 8px;
+      }
     }
     &:hover,
     &:active,

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableRow/RedirectsTableRow.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableRow/RedirectsTableRow.less
@@ -1,13 +1,11 @@
 @import "~@zesty-io/core/colors.less";
 .RedirectsTableRow {
   align-items: center;
-  background-color: @zesty-white;
-  border-bottom: 1px @zesty-field-blue solid;
+  background-color: @white;
   display: flex;
 
   &:nth-of-type(odd) {
-    // background-color: lighten(@zesty-field-blue, 3%);
-    background-color: #dae2f1;
+    background: lighten(@zesty-light-blue, 15%);
   }
 
   &:hover,
@@ -16,16 +14,17 @@
   &:nth-of-type(odd):hover,
   &:nth-of-type(odd):focus,
   &:nth-of-type(odd):active {
-    background-color: lighten(@zesty-field-blue, 2%);
+    background-color: lighten(@zesty-field-blue, 10%);
   }
 
   .RedirectsTableRowCell {
-    padding: 0.6rem 1rem;
+    padding: 16px;
     .internalLink {
       font-size: 1em;
     }
     .removeBtn {
-      line-height: initial;
+      // line-height: initial;
+      align-items: center;
     }
   }
   .code {

--- a/src/shell/app.config.js
+++ b/src/shell/app.config.js
@@ -38,7 +38,10 @@ module.exports = {
     COOKIE_NAME: "APP_SID",
     COOKIE_DOMAIN: ".zesty.io",
 
-    GOOGLE_WEB_FONTS_KEY: "AIzaSyD075qEo9IXa4BPsSZ_YJGWlTw34T51kuk"
+    GOOGLE_WEB_FONTS_KEY: "AIzaSyD075qEo9IXa4BPsSZ_YJGWlTw34T51kuk",
+
+    TIME_DISPLAY_FORMAT: "MMMM Do YYYY, [at] h:mm a",
+    TIME_UTC_FORMAT: "YYYY-MM-DD HH:mm:ss"
   },
   stage: {
     VERSION: pkg.version,
@@ -74,7 +77,10 @@ module.exports = {
     COOKIE_NAME: "STAGE_APP_SID",
     COOKIE_DOMAIN: ".zesty.io",
 
-    GOOGLE_WEB_FONTS_KEY: "AIzaSyD075qEo9IXa4BPsSZ_YJGWlTw34T51kuk"
+    GOOGLE_WEB_FONTS_KEY: "AIzaSyD075qEo9IXa4BPsSZ_YJGWlTw34T51kuk",
+
+    TIME_DISPLAY_FORMAT: "MMMM Do YYYY, [at] h:mm a",
+    TIME_UTC_FORMAT: "YYYY-MM-DD HH:mm:ss"
   },
   development: {
     VERSION: pkg.version,
@@ -110,7 +116,10 @@ module.exports = {
     URL_ACCOUNTS: "https://accounts.dev.zesty.io:9001",
 
     COOKIE_NAME: "DEV_APP_SID",
-    COOKIE_DOMAIN: ".zesty.io"
+    COOKIE_DOMAIN: ".zesty.io",
+
+    TIME_DISPLAY_FORMAT: "MMMM Do YYYY, [at] h:mm a",
+    TIME_UTC_FORMAT: "YYYY-MM-DD HH:mm:ss"
   },
   local: {
     VERSION: pkg.version,
@@ -148,6 +157,9 @@ module.exports = {
     URL_ACCOUNTS: "https://accounts.zesty.localdev:9001",
 
     COOKIE_NAME: "DEV_APP_SID",
-    COOKIE_DOMAIN: ".zesty.localdev"
+    COOKIE_DOMAIN: ".zesty.localdev",
+
+    TIME_DISPLAY_FORMAT: "MMMM Do YYYY, [at] h:mm a",
+    TIME_UTC_FORMAT: "YYYY-MM-DD HH:mm:ss"
   }
 };

--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -238,27 +238,29 @@ const List = connect(state => {
       // onSelect event at this parent UL, by taking advantage of event bubbling
     >
       <li className={styles.Actions}>
-        <ButtonGroup className={styles.SortBy}>
-          <span>Sort By</span>
-          <Button onClick={() => setSortType("default")}>
-            <FontAwesomeIcon icon={faSort} /> Default
-          </Button>
-          <Button onClick={() => setSortType("alpha")}>
-            <FontAwesomeIcon icon={faSortAlphaDown} /> Title
-          </Button>
-          <Button onClick={() => setSortType("edited")}>
-            <FontAwesomeIcon icon={faCalendar} /> Edited
-          </Button>
-          <Button onClick={() => setSortType("created")}>
-            <FontAwesomeIcon icon={faCalendar} /> Created
-          </Button>
-          <Button onClick={() => setSortType("user")}>
-            <FontAwesomeIcon icon={faUser} /> User
-          </Button>
-        </ButtonGroup>
+        <div className={styles.SortBy}>
+          <p className={styles.Title}>Sort By</p>
+          <ButtonGroup>
+            <Button onClick={() => setSortType("default")}>
+              <FontAwesomeIcon icon={faSort} /> Default
+            </Button>
+            <Button onClick={() => setSortType("alpha")}>
+              <FontAwesomeIcon icon={faSortAlphaDown} /> Title
+            </Button>
+            <Button onClick={() => setSortType("edited")}>
+              <FontAwesomeIcon icon={faCalendar} /> Edited
+            </Button>
+            <Button onClick={() => setSortType("created")}>
+              <FontAwesomeIcon icon={faCalendar} /> Created
+            </Button>
+            <Button onClick={() => setSortType("user")}>
+              <FontAwesomeIcon icon={faUser} /> User
+            </Button>
+          </ButtonGroup>
+        </div>
 
         <div className={styles.FilterBy}>
-          <span>Filter By</span>
+          <p>Filter By</p>
           <Input onChange={evt => setFilterTerm(evt.target.value)} />
         </div>
       </li>

--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -260,7 +260,7 @@ const List = connect(state => {
         </div>
 
         <div className={styles.FilterBy}>
-          <p>Filter By</p>
+          <p className={styles.Title}>Filter By</p>
           <Input onChange={evt => setFilterTerm(evt.target.value)} />
         </div>
       </li>

--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -9,7 +9,6 @@ import {
   faExclamationTriangle,
   faSort,
   faSortAlphaDown,
-  faSortNumericUp,
   faUser
 } from "@fortawesome/free-solid-svg-icons";
 

--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -58,7 +58,7 @@ export default React.forwardRef((props, providedRef) => {
           }
         })
         .finally(() => setLoading(false));
-    }, 500),
+    }, 650),
     []
   );
 
@@ -163,7 +163,12 @@ const List = connect(state => {
 
   const sortBy = {
     default: (a, b) => {
-      console.log("sort:default");
+      if (a.meta.sort < b.meta.sort) {
+        return -1;
+      }
+      if (a.meta.sort > b.meta.sort) {
+        return 1;
+      }
       return 0;
     },
     alpha: (a, b) => {
@@ -205,7 +210,6 @@ const List = connect(state => {
   };
 
   const filter = opt => {
-    console.log("filter", filterTerm, opt);
     if (filterTerm) {
       const lang = props.languages.find(
         lang => lang.ID === props.opt?.meta?.langID
@@ -230,8 +234,8 @@ const List = connect(state => {
       // NOTE we could get better performance if we handle the
       // onSelect event at this parent UL, by taking advantage of event bubbling
     >
-      <li>
-        <ButtonGroup>
+      <li className={styles.Actions}>
+        <ButtonGroup className={styles.SortBy}>
           <span>Sort By</span>
           <Button onClick={() => setSortType("default")}>
             <FontAwesomeIcon icon={faSort} /> Default
@@ -250,9 +254,9 @@ const List = connect(state => {
           </Button>
         </ButtonGroup>
 
-        <div>
+        <div className={styles.FilterBy}>
           <span>Filter By</span>
-          <Input onChange={val => setFilterTerm(val)} />
+          <Input onChange={evt => setFilterTerm(evt.target.value)} />
         </div>
       </li>
 
@@ -263,7 +267,9 @@ const List = connect(state => {
       )}
 
       {!props.loading && !props.options.length && (
-        <li>No results found for search term: {props.term}</li>
+        <li className={styles.headline}>
+          No results found for search term: <strong>{props.term}</strong>
+        </li>
       )}
 
       {props.options
@@ -309,7 +315,6 @@ const ListOption = props => {
           {props.opt?.web?.metaTitle ? (
             <React.Fragment>
               {/* <span>TODO show model icon</span>  */}
-              {/* TODO show item language */}
               {props.opt.web.metaTitle}
             </React.Fragment>
           ) : (
@@ -334,7 +339,7 @@ const ListOption = props => {
       } on ${moment(props.opt?.web?.createdAt).format(
         CONFIG.TIME_DISPLAY_FORMAT
       )}`}</p>
-      <p>{`Version ${props.opt?.meta?.version} last edited ${moment(
+      <p>{`Version ${props.opt?.meta?.version} was edited ${moment(
         props.opt?.meta?.updatedAt
       ).from()}`}</p>
     </li>

--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -6,7 +6,10 @@ import cx from "classnames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCalendar,
+  faDatabase,
   faExclamationTriangle,
+  faFile,
+  faListAlt,
   faSort,
   faSortAlphaDown,
   faUser
@@ -154,7 +157,8 @@ export default React.forwardRef((props, providedRef) => {
 const List = connect(state => {
   return {
     languages: state.languages,
-    users: state.users
+    users: state.users,
+    models: state.models
   };
 })(props => {
   const [sortType, setSortType] = useState("default");
@@ -284,6 +288,7 @@ const List = connect(state => {
             index={i}
             users={props.users}
             languages={props.languages}
+            models={props.models}
           />
         ))}
     </ul>
@@ -299,6 +304,26 @@ const ListOption = props => {
     lang => lang.ID === props.opt?.meta?.langID
   );
 
+  let modelIcon;
+  const model = props.models[props.opt.meta.contentModelZUID];
+  if (model && model.type) {
+    if (model.type === "dataset") {
+      modelIcon = (
+        <FontAwesomeIcon className={styles.ModelIcon} icon={faDatabase} />
+      );
+    }
+    if (model.type === "templateset") {
+      modelIcon = (
+        <FontAwesomeIcon className={styles.ModelIcon} icon={faFile} />
+      );
+    }
+    if (model.type === "pageset") {
+      modelIcon = (
+        <FontAwesomeIcon className={styles.ModelIcon} icon={faListAlt} />
+      );
+    }
+  }
+
   return (
     <li
       onClick={() => props.onSelect(props.opt)}
@@ -310,10 +335,10 @@ const ListOption = props => {
     >
       {/* main line */}
       <p className={styles.ItemName}>
-        <span className={styles.subheadline}>
+        <span className={styles.title}>
           {props.opt?.web?.metaTitle ? (
             <React.Fragment>
-              {/* <span>TODO show model icon</span>  */}
+              {modelIcon}
               {props.opt.web.metaTitle}
             </React.Fragment>
           ) : (
@@ -324,23 +349,25 @@ const ListOption = props => {
           )}
         </span>
 
-        <span>{lang?.code || ""}</span>
+        <span className={styles.Lang}>{lang?.code || ""}</span>
       </p>
 
       {/* path */}
-      {props.opt?.web?.path && <p>{props.opt.web.path}</p>}
+      {props.opt?.web?.path && (
+        <p className={styles.bodyText}>{props.opt.web.path}</p>
+      )}
 
       {/* meta */}
-      <p>{`Created by ${
+      <p className={styles.caption}>{`Created by ${
         createdBy
           ? createdBy.firstName + " " + createdBy.lastName
           : "Unknown User"
       } on ${moment(props.opt?.web?.createdAt).format(
         CONFIG.TIME_DISPLAY_FORMAT
       )}`}</p>
-      <p>{`Version ${props.opt?.meta?.version} was edited ${moment(
-        props.opt?.meta?.updatedAt
-      ).from()}`}</p>
+      <p className={styles.caption}>{`Version ${
+        props.opt?.meta?.version
+      } was edited ${moment(props.opt?.meta?.updatedAt).from()}`}</p>
     </li>
   );
 };

--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -223,7 +223,9 @@ const ListOption = props => {
 
       {/* meta */}
       <p>{`Created by ${
-        createdBy ? createdBy.firstName + " " + createdBy.lastName : "Unknown"
+        createdBy
+          ? createdBy.firstName + " " + createdBy.lastName
+          : "Unknown User"
       } on ${moment(props.opt?.web?.createdAt).format(
         CONFIG.TIME_DISPLAY_FORMAT
       )}`}</p>

--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -2,11 +2,6 @@ import React, { useState, useRef, useEffect, useCallback } from "react";
 import { connect, useDispatch } from "react-redux";
 import debounce from "lodash.debounce";
 import cx from "classnames";
-
-import { searchItems } from "shell/store/content";
-import { Search } from "@zesty-io/core/Search";
-import styles from "./styles.less";
-
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faChevronRight,
@@ -14,135 +9,104 @@ import {
   faExclamationTriangle
 } from "@fortawesome/free-solid-svg-icons";
 
-export default React.forwardRef(function ContentSearch(props, ref) {
+import { Search } from "@zesty-io/core/Search";
+import { Loader } from "@zesty-io/core/Loader";
+
+import { searchItems } from "shell/store/content";
+
+import styles from "./styles.less";
+export default React.forwardRef((props, providedRef) => {
   const dispatch = useDispatch();
 
+  const [term, setTerm] = useState(props.value);
   const [loading, setLoading] = useState(false);
-  const [skipSearch, setSkipSearch] = useState(false);
-
+  const [refs, setRefs] = useState([]);
   const [searchResults, setSearchResults] = useState([]);
-  const [searchTerm, setSearchTerm] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [hasSelected, setHasSelected] = useState(true);
 
+  // Allow for consumer to externally update term
   useEffect(() => {
-    if (searchTerm !== "" && !skipSearch) {
-      setLoading(true);
-      debouncedSearch(searchTerm);
-    } else {
-      // search term "" will cancel any inflight searches
-      setSearchResults([]);
-      debouncedSearch.cancel();
-    }
-  }, [searchTerm, skipSearch]);
-
-  const refs = searchResults.map(() => React.createRef());
+    setTerm(props.value);
+  }, [props.value]);
 
   const debouncedSearch = useCallback(
     debounce(term => {
       dispatch(searchItems(term))
         .then(res => {
-          let results = res.data;
-          if (props.filterResults) {
-            results = props.filterResults(results);
+          if (res.status === 200) {
+            let results = res.data;
+            if (props.filterResults) {
+              results = props.filterResults(results);
+            }
+            setRefs(results.map(() => React.createRef()));
+            setSearchResults(results);
+          } else {
+            props.dispatch(
+              notice({
+                kind: "warn",
+                message: `Error searching for term: ${term}`
+              })
+            );
           }
-          setSearchResults(results);
         })
         .finally(() => setLoading(false));
     }, 500),
     []
   );
 
-  function handleChange(term) {
-    setSearchTerm(term);
-    // reset skip after user input
-    setSkipSearch(false);
-  }
+  function handleKeyUp(evt) {
+    // NOTE: Must happen before switch
+    // If user starts typing into input reset hasSelected
+    setHasSelected(false);
 
-  function clearSearch() {
-    setSearchTerm("");
-  }
+    switch (evt.key) {
+      case "ArrowUp":
+      case "ArrowDown":
+        // Navigate up/down search results
+        const index =
+          evt.key === "ArrowUp" ? selectedIndex - 1 : selectedIndex + 1;
 
-  function handleKeydown(evt) {
-    if (searchResults.length === 0) {
-      return;
-    }
-    if (evt.key === "ArrowDown") {
-      let newIndex;
-      if (selectedIndex === searchResults.length - 1) {
-        newIndex = 0;
-      } else {
-        newIndex = selectedIndex + 1;
-      }
-      setSelectedIndex(newIndex);
-      refs[newIndex].current.scrollIntoView({
-        block: "center",
-        inline: "nearest"
-      });
-    } else if (evt.key === "ArrowUp") {
-      let newIndex;
-      if (selectedIndex <= 0) {
-        newIndex = searchResults.length - 1;
-      } else {
-        newIndex = selectedIndex - 1;
-      }
-      setSelectedIndex(newIndex);
-      refs[newIndex].current.scrollIntoView({
-        block: "center",
-        inline: "nearest"
-      });
-    } else if (evt.key === "Enter") {
-      if (props.clearSearchOnSelect) {
-        clearSearch();
-      }
-      const item = searchResults[selectedIndex];
-      // skip search on user select
-      setSkipSearch(true);
-      props.onSelect(item, setSearchTerm);
-    }
-  }
+        // Only allow index within the range of indexes
+        if (index >= 0 && index < refs.length) {
+          const optionRef = refs[index];
 
-  return (
-    <div className={cx(styles.GlobalSearch, props.className)}>
-      <Search
-        ref={ref}
-        className={styles.Search}
-        value={searchTerm}
-        onKeyDown={handleKeydown}
-        onChange={handleChange}
-        placeholder={props.placeholder}
-      />
-      {searchResults && (
-        <SearchResults
-          loading={loading}
-          results={searchResults}
-          clearSearch={clearSearch}
-          clearSearchOnClickOutside={props.clearSearchOnClickOutside}
-          clearSearchOnSelect={props.clearSearchOnSelect}
-          searchTerm={searchTerm}
-          setSearchTerm={setSearchTerm}
-          setSkipSearch={setSkipSearch}
-          selectedIndex={selectedIndex}
-          refs={refs}
-          onSelect={props.onSelect}
-        />
-      )}
-    </div>
-  );
-});
+          if (optionRef?.current) {
+            optionRef.current.scrollIntoView({
+              block: "center",
+              inline: "nearest"
+            });
+          }
 
-const SearchResults = connect(state => {
-  return {
-    languages: state.languages
-  };
-})(props => {
-  const wrapperRef = useRef(null);
-  // clear search results if user clicks outside of results
-  useEffect(() => {
-    function handleClickOutside(event) {
-      if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
-        if (props.clearSearchOnClickOutside) {
-          props.clearSearch();
+          setSelectedIndex(index);
         }
+        break;
+
+      case "Enter":
+        handleSelect(searchResults[selectedIndex]);
+        break;
+
+      default:
+        setLoading(true);
+        debouncedSearch(evt.target.value);
+        break;
+    }
+  }
+
+  function handleSelect(option) {
+    props.onSelect(option);
+
+    // Clear term to close options list
+    setTerm("");
+    setHasSelected(true);
+  }
+
+  // clear search results if user clicks outside of results list
+  const searchRef = useRef(null);
+  useEffect(() => {
+    function handleClickOutside(evt) {
+      if (searchRef.current && !searchRef.current.contains(evt.target)) {
+        setHasSelected(true);
       }
     }
 
@@ -150,77 +114,90 @@ const SearchResults = connect(state => {
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [wrapperRef]);
+  }, [searchRef]);
 
   return (
+    <div className={cx(styles.GlobalSearch, props.className)} ref={searchRef}>
+      <Search
+        className={styles.Search}
+        placeholder={props.placeholder}
+        onKeyUp={handleKeyUp}
+        onChange={val => setTerm(val)}
+        ref={providedRef}
+        value={term}
+      />
+      {term && !hasSelected && (
+        <List
+          term={term}
+          loading={loading}
+          options={searchResults}
+          onSelect={handleSelect}
+          refs={refs}
+          selectedIndex={selectedIndex}
+        />
+      )}
+    </div>
+  );
+});
+
+const List = props => {
+  return (
     <ul
-      ref={wrapperRef}
       className={cx(styles.SearchResults)}
-      onClick={() => {
-        if (props.clearSearchOnSelect) {
-          props.clearSearch();
-        }
-      }}
+      // NOTE we could get better performance if we handle the
+      // onSelect event at this parent UL, by taking advantage of event bubbling
     >
-      {props.loading && props.searchTerm && (
-        <li className={styles.Start}>Searching for "{props.searchTerm}"</li>
-      )}
-
-      {/* {!props.searchTerm && (
-        <li className={styles.Start}>Search by content title, URL or ZUID</li>
-      )} */}
-
-      {!props.loading && props.searchTerm && !props.results.length && (
-        <li className={styles.NoResults}>
-          No matches for the term: {props.searchTerm}
+      {props.loading && (
+        <li>
+          <Loader label="Searching" />
         </li>
       )}
 
-      {props.results.map((result, index) => (
-        <li
-          key={result.meta.ZUID}
-          ref={props.refs[index]}
-          className={props.selectedIndex === index ? styles.SelectedRow : null}
-        >
-          <div
-            className={styles.ListItem}
-            onClick={() => {
-              // skip search on user select
-              props.setSkipSearch(true);
-              props.onSelect(result, props.setSearchTerm);
-            }}
-          >
-            <FontAwesomeIcon icon={faEdit} />
-            <div>
-              <div className={styles.SearchResultTitle}>
-                [
-                {props.languages.length
-                  ? props.languages[result.meta.langID - 1].code
-                  : "en-US"}
-                ]&nbsp;
-                {!result.web.pathPart ? (
-                  result.web.metaTitle || result.web.metaLinkText
-                ) : result.web.metaTitle ? (
-                  result.web.metaTitle
-                ) : (
-                  <span>
-                    <FontAwesomeIcon icon={faExclamationTriangle} /> Missing
-                    Meta Title
-                  </span>
-                )}
-              </div>
-              <div className={styles.SearchResultPath}>
-                {result.web.path}
-                {result.web.pathpart}
-              </div>
-            </div>
-            <FontAwesomeIcon
-              className={styles.faChevronRight}
-              icon={faChevronRight}
-            />
-          </div>
-        </li>
+      {!props.loading && !props.options.length && (
+        <li>No results found for search term: {props.term}</li>
+      )}
+
+      {props.options.map((opt, i) => (
+        <ListOption
+          key={i}
+          opt={opt}
+          onSelect={props.onSelect}
+          optRef={props.refs[i]}
+          selectedIndex={props.selectedIndex}
+          index={i}
+        />
       ))}
     </ul>
   );
-});
+};
+
+const ListOption = props => {
+  return (
+    <li
+      onClick={() => props.onSelect(props.opt)}
+      ref={props.optRef}
+      className={cx(
+        styles.bodyText,
+        props.selectedIndex === props.index ? styles.SelectedRow : null
+      )}
+    >
+      <p>
+        <span className={styles.subheadline}>
+          {props.opt?.web?.metaTitle ? (
+            <React.Fragment>
+              {/* <span>TODO show model icon</span>  */}
+              {/* TODO show item language */}
+              {props.opt.web.metaTitle}
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              <FontAwesomeIcon icon={faExclamationTriangle} /> Item missing meta
+              title
+            </React.Fragment>
+          )}
+        </span>
+      </p>
+      {props.opt?.web?.path && <p>{props.opt.web.path}</p>}
+    </li>
+  );
+};

--- a/src/shell/components/ContentSearch/styles.less
+++ b/src/shell/components/ContentSearch/styles.less
@@ -31,6 +31,12 @@
     font-weight: bold;
   }
 
+  .ItemName {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
   li {
     cursor: pointer;
     color: @zesty-dark-blue;

--- a/src/shell/components/ContentSearch/styles.less
+++ b/src/shell/components/ContentSearch/styles.less
@@ -31,7 +31,18 @@
     justify-content: space-between;
     align-items: baseline;
   }
+  .SortBy {
+    margin-bottom: 16px;
+    & > * {
+      margin-right: 8px;
+    }
+  }
 
+  .FilterBy {
+    input {
+      margin-top: 8px;
+    }
+  }
   li {
     cursor: pointer;
     color: @zesty-dark-blue;

--- a/src/shell/components/ContentSearch/styles.less
+++ b/src/shell/components/ContentSearch/styles.less
@@ -59,6 +59,18 @@
     &.Actions:hover,
     &.Actions:focus {
       background-color: lighten(@zesty-light-blue, 10%);
+      display: flex;
+      .SortBy {
+        flex: 2;
+      }
+      .FilterBy {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        input {
+          width: auto;
+        }
+      }
     }
 
     .ModelIcon {

--- a/src/shell/components/ContentSearch/styles.less
+++ b/src/shell/components/ContentSearch/styles.less
@@ -49,6 +49,10 @@
     &.Actions:focus {
       background-color: lighten(@zesty-light-blue, 10%);
     }
+
+    .ModelIcon {
+      margin-right: 8px;
+    }
   }
 
   li:last-child {

--- a/src/shell/components/ContentSearch/styles.less
+++ b/src/shell/components/ContentSearch/styles.less
@@ -1,4 +1,5 @@
 @import "~@zesty-io/core/colors.less";
+@import "~@zesty-io/core/typography.less";
 
 .GlobalSearch {
   position: relative;

--- a/src/shell/components/ContentSearch/styles.less
+++ b/src/shell/components/ContentSearch/styles.less
@@ -55,12 +55,3 @@
     border-bottom: none;
   }
 }
-
-// .SearchResultTitle {
-//   font-size: 20px;
-//   margin-bottom: 4px;
-// }
-// .SearchResultPath {
-//   color: @zesty-gray;
-//   font-size: 12px;
-// }

--- a/src/shell/components/ContentSearch/styles.less
+++ b/src/shell/components/ContentSearch/styles.less
@@ -31,18 +31,7 @@
     justify-content: space-between;
     align-items: baseline;
   }
-  .SortBy {
-    margin-bottom: 16px;
-    & > * {
-      margin-right: 8px;
-    }
-  }
 
-  .FilterBy {
-    input {
-      margin-top: 8px;
-    }
-  }
   li {
     cursor: pointer;
     color: @zesty-dark-blue;
@@ -71,10 +60,17 @@
           width: auto;
         }
       }
+      .SortBy,
+      .FilterBy {
+        .Title {
+          margin-bottom: 4px;
+        }
+      }
     }
 
     .ModelIcon {
       margin-right: 8px;
+      color: @zesty-grey;
     }
   }
 

--- a/src/shell/components/ContentSearch/styles.less
+++ b/src/shell/components/ContentSearch/styles.less
@@ -47,10 +47,18 @@
     &.Actions,
     &.Actions:hover,
     &.Actions:focus {
+      flex-direction: column;
+      @media only screen and (min-width: 2000px) {
+        flex-direction: row;
+      }
       background-color: lighten(@zesty-light-blue, 10%);
       display: flex;
       .SortBy {
         flex: 2;
+        margin-bottom: 16px;
+        button {
+          margin-right: 8px;
+        }
       }
       .FilterBy {
         flex: 1;

--- a/src/shell/components/ContentSearch/styles.less
+++ b/src/shell/components/ContentSearch/styles.less
@@ -17,7 +17,7 @@
 .SearchResults {
   position: absolute;
   z-index: 110;
-  max-height: 590px;
+  max-height: 700px;
   min-width: 850px;
   list-style: none;
   overflow: auto;
@@ -25,11 +25,6 @@
   border-radius: 0 4px 4px 4px;
   left: 0px;
   top: 38px;
-
-  .Start,
-  .NoResults {
-    font-weight: bold;
-  }
 
   .ItemName {
     display: flex;
@@ -47,20 +42,12 @@
     &.SelectedRow,
     &:hover {
       background-color: @white;
-      svg {
-        color: @zesty-blue;
-      }
-      .faChevronRight {
-        display: block;
-      }
     }
-    .ListItem {
-      display: flex;
-      align-items: baseline;
-      svg {
-        margin-right: 8px;
-        font-size: 16px;
-      }
+
+    &.Actions,
+    &.Actions:hover,
+    &.Actions:focus {
+      background-color: lighten(@zesty-light-blue, 10%);
     }
   }
 
@@ -68,16 +55,12 @@
     border-bottom: none;
   }
 }
-.SearchResultTitle {
-  font-size: 20px;
-  margin-bottom: 4px;
-}
-.SearchResultPath {
-  color: @zesty-gray;
-  font-size: 12px;
-}
 
-.faChevronRight {
-  margin-left: auto;
-  display: none;
-}
+// .SearchResultTitle {
+//   font-size: 20px;
+//   margin-bottom: 4px;
+// }
+// .SearchResultPath {
+//   color: @zesty-gray;
+//   font-size: 12px;
+// }

--- a/src/shell/views/Shell/Shell.less
+++ b/src/shell/views/Shell/Shell.less
@@ -13,7 +13,7 @@
 }
 
 .Shell {
-  background-color: #f2f7fc;
+  background-color: @appBkgColor;
   color: @zesty-grey;
 
   // typography
@@ -42,7 +42,7 @@
 
     .SubApp {
       height: calc(100vh - 54px);
-      background-color: #f2f7fc;
+      background-color: @appBkgColor;
 
       // shadow effect
       border-radius: 10px 0 0 0;


### PR DESCRIPTION
Fixes https://github.com/zesty-io/manager-ui/issues/640

Large refactor to `ContentSearch` component. Smooths out existing functionality of;
- loading display
- no results message
- Arrow up/down through options
- Code structure
- [x] show item language
- [x] show item content model icon
- [x] show item last edited date
- [x] show last edited by user name
  - [ ] Can the app load user lookup include previous instance members? i.e. We want to be able to show historical information even after a user has left an instance.
- [ ] when redirecting internal to instance show instance live domain, if present
- [ ] Search for a path that does not include the initial preceding forward slash will not return results. Even if that path exists.