### PR TITLE
swapped icon for loader to lock and hide delete btn for loader

### DIFF
--- a/src/apps/code-editor/src/app/components/FileActions/FileActions.js
+++ b/src/apps/code-editor/src/app/components/FileActions/FileActions.js
@@ -26,6 +26,7 @@ import { Delete } from "./components/Delete";
 import styles from "./FileActions.less";
 export const FileActions = React.memo(function FileActions(props) {
   const match = useRouteMatch("/code/file/:fileType/:fileZUID");
+
   return (
     <header className={styles.FileActions}>
       <div className={styles.FileMeta}>
@@ -128,6 +129,7 @@ export const FileActions = React.memo(function FileActions(props) {
             dispatch={props.dispatch}
             fileZUID={props.fileZUID}
             status={props.status}
+            fileName={props.fileName}
           />
         </Route>
       </Switch>

--- a/src/apps/code-editor/src/app/components/FileActions/components/Delete/Delete.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/Delete/Delete.js
@@ -22,14 +22,18 @@ export const Delete = React.memo(function Delete(props) {
 
   return (
     <div className={styles.DeleteBtn}>
-      <Button
-        kind="warn"
-        onClick={() => setOpen(true)}
-        className={styles.Button}
-      >
-        <FontAwesomeIcon icon={faExclamationCircle} />
-        Delete
-      </Button>
+      {props.fileName !== "loader" ? (
+        <Button
+          kind="warn"
+          onClick={() => setOpen(true)}
+          className={styles.Button}
+        >
+          <FontAwesomeIcon icon={faExclamationCircle} />
+          Delete
+        </Button>
+      ) : (
+        " "
+      )}
       <Modal
         className={styles.DeleteFileModal}
         type="local"

--- a/src/apps/code-editor/src/store/navCode.js
+++ b/src/apps/code-editor/src/store/navCode.js
@@ -6,7 +6,8 @@ import {
   faListAlt,
   faFileCode,
   faBolt,
-  faDirections
+  faDirections,
+  faLock
 } from "@fortawesome/free-solid-svg-icons";
 import {
   faJs,
@@ -187,7 +188,7 @@ function resolveNavData(file) {
     ...file,
     label: file.sort ? `(${file.sort}) ${file.fileName}` : file.fileName,
     path: `/code/file/${pathPart}/${file.ZUID}`,
-    icon: ICONS[file.type]
+    icon: file.fileName === "loader" ? faLock : ICONS[file.type]
   };
 
   // Remove this prop to ensure we don't accidentially


### PR DESCRIPTION
fixes #62 

Swapped loader icon to lock 
hiding delete button in loader view. 

<img width="1393" alt="code-loader-lock" src="https://user-images.githubusercontent.com/22800749/115445911-53207080-a1cb-11eb-8e5c-33756e5a2394.png">
