### PR TITLE
increased z-index so that drop downs do not overlap content header

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@sentry/react": "6.2.1",
     "@sentry/tracing": "6.2.1",
     "@tinymce/tinymce-react": "3.5.0",
-    "@zesty-io/core": "1.0.7",
+    "@zesty-io/core": "1.0.8",
     "chart.js": "2.9.3",
     "classnames": "2.2.6",
     "clipboard": "2.0.6",

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.less
@@ -3,7 +3,7 @@
 
 .Header {
   padding: 16px 32px;
-  z-index: 10;
+  z-index: 120;
   position: sticky;
   top: 0;
   background-color: #f2f7fc;


### PR DESCRIPTION
Increased z-index for header content but then that was conflicting with modals so I then increase design system modal aligner z-index. I tested other pages and did not see any other conflicts. I did notice tooltips had an index of 10 however tooltips will render only on hover so I don't think there should be conflicts. @shrunyan let me know if there are any other use cases that I may have missed thanks. 

PR in design systems https://github.com/zesty-io/design-system/pull/109

https://www.loom.com/share/00514a1b49074cf09ba549fb816a88b3
