### PR TITLE
Fix/618 force global item edit

### DIFF
--- a/src/apps/content-editor/src/app/components/Nav/ContentNav.js
+++ b/src/apps/content-editor/src/app/components/Nav/ContentNav.js
@@ -67,9 +67,9 @@ export function ContentNav(props) {
           <Option value="link" text="Internal/External Link" />
           {Object.keys(props.models)
             .filter(modelZUID => {
-              return (
-                props.models[modelZUID].label !==
-                ("Dashboard Widgets" || "Widgets")
+              // exclude these special models from the create item list
+              return !["widgets", "clippings", "globals"].includes(
+                props.models[modelZUID]?.name.toLowerCase()
               );
             })
             .sort((a, b) => {

--- a/src/apps/content-editor/src/app/views/ItemList/ItemList.js
+++ b/src/apps/content-editor/src/app/views/ItemList/ItemList.js
@@ -106,19 +106,20 @@ export default connect((state, props) => {
     };
   }, []);
 
-  // redirect to single entry
+  // globals is a special dataset which should have a single entry
+  // it contains instance wide parsley referenceable values
   useEffect(() => {
-    if (
-      props.model &&
-      (props.model.name === "clippings" || props.model.type === "templateset")
-    ) {
-      // First item is always the column row
+    if (["clippings", "globals"].includes(props?.model?.name.toLowerCase())) {
+      // only force redirect if there is a single globals content item
       if (items.length === 2) {
-        // redirect to the single entry in content clippings
-        history.push(`/content/${props.modelZUID}/${items[1].meta.ZUID}`);
+        // the first record is the list column headers so we use the second which
+        // should be the first content item
+        history.push(
+          `/content/${items[1]?.meta?.contentModelZUID}/${items[1]?.meta?.ZUID}`
+        );
       }
     }
-  }, [props.modelZUID]);
+  }, [props.modelZUID, items.length]);
 
   // on initial and
   // on modelZUID change


### PR DESCRIPTION
Resolves #618 

Will only force redirect to a clippings/globals content item entry if there is a single content item entry. This allows for self service to correct these models when more than one content item entry exists incorrectly.

Removes the clippings/globals from the create new item list. This does not prevent manual navigation to the `/new/` endpoint for that model. As we want that accessible for support to respond to issues with missing globals.