### PR TITLE
background color consistency  

### DIFF
--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -342,7 +342,7 @@ const ListOption = props => {
     >
       {/* main line */}
       <p className={styles.ItemName}>
-        <span className={styles.title}>
+        <span className={styles.subheadline}>
           {props.opt?.web?.metaTitle ? (
             <React.Fragment>
               {modelIcon}

--- a/src/shell/components/ContentSearch/styles.less
+++ b/src/shell/components/ContentSearch/styles.less
@@ -35,8 +35,8 @@
   li {
     cursor: pointer;
     color: @zesty-dark-blue;
-    background: @zesty-field-blue;
-    border-bottom: 1px solid darken(@zesty-field-blue, 8%);
+    background-color: @appBkgColor;
+    border-bottom: 1px solid darken(@appBkgColor, 8%);
     padding: 16px 12px;
 
     .Lang {
@@ -62,7 +62,8 @@
       @media only screen and (min-width: 2000px) {
         flex-direction: row;
       }
-      background-color: lighten(@zesty-light-blue, 10%);
+
+      background-color: @white;
       display: flex;
       .SortBy {
         flex: 2;

--- a/src/shell/components/GlobalHelpMenu/styles.less
+++ b/src/shell/components/GlobalHelpMenu/styles.less
@@ -12,7 +12,7 @@
   left: 60px;
   padding: 24px;
   z-index: 100;
-  background: #c7d4ea;
+  background-color: @appBkgColor;
   box-shadow: 1px 1px 19px #171b26;
   border-radius: 0 4px 4px 0;
 
@@ -29,7 +29,7 @@
     height: 0;
     border-top: 10px solid transparent;
     border-bottom: 10px solid transparent;
-    border-right: 10px solid @zesty-light-blue;
+    border-right: 10px solid @appBkgColor;
     left: -10px;
     bottom: 0;
   }

--- a/src/shell/components/global-account/GlobalAccount.less
+++ b/src/shell/components/global-account/GlobalAccount.less
@@ -25,7 +25,7 @@
     top: 54px;
     right: 20px;
     padding: 24px;
-    background: @zesty-field-blue;
+    background-color: @appBkgColor;
     box-shadow: 1px 1px 8px #171b26;
     border-radius: 0 0 0 4px;
     text-align: left;

--- a/src/shell/components/global-instance/GlobalInstance.less
+++ b/src/shell/components/global-instance/GlobalInstance.less
@@ -59,7 +59,7 @@
       height: 0;
       display: inline-block;
       border: 8px solid transparent;
-      border-bottom-color: #c3cddf;
+      border-bottom-color: @appBkgColor;
     }
 
     img {

--- a/src/shell/components/global-instance/GlobalInstance.less
+++ b/src/shell/components/global-instance/GlobalInstance.less
@@ -39,7 +39,7 @@
     top: 54px;
     right: 0;
     padding: 24px;
-    background: @zesty-field-blue;
+    background-color: @appBkgColor;
     box-shadow: 1px 1px 10px #171b26;
     border-radius: 0 0 0 4px;
     text-align: left;


### PR DESCRIPTION
@shrunyan  As we discussed, there should be consistency among background colors for fly outs, drop-downs, and search. Attached are screenshots of all the places I swapped background-color to use design-systems global background color @appBkgColor.  I also swapped content-search text title to use subheadline as the font felt very large and wasn't consistent with other sections of the app. Let me know what you think thanks.

<img width="808" alt="Screen Shot 2021-04-28 at 12 08 26 PM" src="https://user-images.githubusercontent.com/22800749/116459659-f8b29000-a81a-11eb-88f7-2ec96a1dbfe3.png">
<img width="257" alt="Screen Shot 2021-04-28 at 12 08 38 PM" src="https://user-images.githubusercontent.com/22800749/116459677-fc461700-a81a-11eb-90aa-b9d323138bef.png">
<img width="1071" alt="Screen Shot 2021-04-28 at 11 58 20 AM" src="https://user-images.githubusercontent.com/22800749/116459698-01a36180-a81b-11eb-9d90-aceac0ac0951.png">
<img width="1868" alt="Screen Shot 2021-04-28 at 11 58 48 AM" src="https://user-images.githubusercontent.com/22800749/116459719-06681580-a81b-11eb-8634-e75d4652b009.png">
<img width="1968" alt="Screen Shot 2021-04-28 at 12 02 59 PM" src="https://user-images.githubusercontent.com/22800749/116459765-1122aa80-a81b-11eb-979c-949a9ce26d08.png">
<img width="1948" alt="Screen Shot 2021-04-28 at 12 04 47 PM" src="https://user-images.githubusercontent.com/22800749/116459785-167ff500-a81b-11eb-8153-12584d0ca2e1.png">
