### PR TITLE
adding optional chaining Sentry bug

### DIFF
--- a/src/apps/content-editor/src/app/components/Nav/ContentNav.js
+++ b/src/apps/content-editor/src/app/components/Nav/ContentNav.js
@@ -69,7 +69,7 @@ export function ContentNav(props) {
             .filter(modelZUID => {
               // exclude these special models from the create item list
               return !["widgets", "clippings", "globals"].includes(
-                props.models[modelZUID]?.name.toLowerCase()
+                props?.models[modelZUID]?.name.toLowerCase()
               );
             })
             .sort((a, b) => {


### PR DESCRIPTION
Sentry bug `undefined is not an object (evaluating 'a.name.toLowerCase')`
I think this edit will fix 
MANAGER-UI-JM
MANAGER-UI-JP
MANAGER-UI-JN