### PR TITLE
build: replace redux logger with redux devtools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "react-virtualized-sticky-tree": "^2.1.30",
         "react-window": "1.8.5",
         "redux": "4.0.5",
+        "redux-devtools-extension": "^2.13.9",
         "redux-sentry-middleware": "^0.2.2",
         "redux-thunk": "2.3.0",
         "regenerator-runtime": "0.13.5",
@@ -16085,6 +16086,14 @@
       "dependencies": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
+      }
+    },
+    "node_modules/redux-devtools-extension": {
+      "version": "2.13.9",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
+      "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
+      "peerDependencies": {
+        "redux": "^3.1.0 || ^4.0.0"
       }
     },
     "node_modules/redux-logger": {
@@ -33418,6 +33427,12 @@
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
       }
+    },
+    "redux-devtools-extension": {
+      "version": "2.13.9",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
+      "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
+      "requires": {}
     },
     "redux-logger": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-virtualized-sticky-tree": "^2.1.30",
     "react-window": "1.8.5",
     "redux": "4.0.5",
+    "redux-devtools-extension": "^2.13.9",
     "redux-sentry-middleware": "^0.2.2",
     "redux-thunk": "2.3.0",
     "regenerator-runtime": "0.13.5",

--- a/src/shell/store/index.js
+++ b/src/shell/store/index.js
@@ -1,14 +1,11 @@
 import { applyMiddleware, combineReducers, createStore } from "redux";
-import { createLogger } from "redux-logger";
-
 import thunkMiddleware from "redux-thunk";
 import createSentryMiddleware from "redux-sentry-middleware";
+import { composeWithDevTools } from "redux-devtools-extension";
 import { fetchResource, resolveFieldOptions } from "./middleware/api";
 import { localStorage } from "./middleware/local-storage";
 import { session } from "./middleware/session";
-
 import { Sentry } from "utility/sentry";
-
 import { auth } from "./auth";
 import { products } from "./products";
 import { user } from "./user";
@@ -24,8 +21,6 @@ import { logs } from "./logs";
 import { notifications } from "./notifications";
 import { platform } from "./platform";
 import { headTags } from "./headTags";
-
-// RTK
 import media from "./media";
 import { users } from "./users";
 import ui from "./ui";
@@ -38,20 +33,6 @@ const middlewares = [
   resolveFieldOptions,
   thunkMiddleware
 ];
-
-/**
- * Do not log actions in production
- * Improves performance and keeps bug tracking clean
- */
-if (!["production", "stage"].includes(__CONFIG__?.ENV)) {
-  middlewares.push(
-    createLogger({
-      collapsed: true,
-      duration: true,
-      diff: false
-    })
-  );
-}
 
 /**
  * Setup bug tracking
@@ -118,7 +99,7 @@ function configureStore(initialState = {}) {
   const store = createStore(
     createReducer(),
     initialState,
-    applyMiddleware(...middlewares)
+    composeWithDevTools(applyMiddleware(...middlewares))
   );
 
   // Keep a reference of injected reducers


### PR DESCRIPTION
[Redux Devtools Extension](https://github.com/zalmoxisus/redux-devtools-extension) allows a better experience for debugging redux state (including state diff) than the redux logger. Redux logger also has potential issues with Sentry.

This PR enables redux devtools extension for all environments and removes the redux logger for dev.

Adds 344b to min+gzip size.
https://bundlephobia.com/result?p=redux-devtools-extension@2.13.9