### PR TITLE
Publish Plan: keep results after searching and selecting

### DIFF
--- a/src/apps/publish/src/app/components/Header/Header.js
+++ b/src/apps/publish/src/app/components/Header/Header.js
@@ -36,6 +36,7 @@ export function Header({ plan }) {
         <ContentSearch
           placeholder="Search for items to include in your publish plan"
           onSelect={onSelect}
+          keepResultsOnSelect={true}
         />
       ) : null}
       {showPublishAll ? (

--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -35,7 +35,7 @@ export default React.forwardRef((props, providedRef) => {
   const [refs, setRefs] = useState([]);
   const [searchResults, setSearchResults] = useState([]);
   const [selectedIndex, setSelectedIndex] = useState(-1);
-  const [hasSelected, setHasSelected] = useState(true);
+  const [showResults, setShowResults] = useState(false);
 
   // Allow for consumer to externally update term
   useEffect(() => {
@@ -72,7 +72,7 @@ export default React.forwardRef((props, providedRef) => {
   function handleKeyUp(evt) {
     // NOTE: Must happen before switch
     // If user starts typing into input reset hasSelected
-    setHasSelected(false);
+    setShowResults(true);
 
     switch (evt.key) {
       case "ArrowUp":
@@ -108,15 +108,17 @@ export default React.forwardRef((props, providedRef) => {
   }
 
   function handleFocus(evt) {
-    setHasSelected(false);
+    setShowResults(true);
   }
 
   function handleSelect(option) {
     props.onSelect(option);
 
-    // Clear term to close options list
-    setTerm("");
-    setHasSelected(true);
+    // optionally, clear term and close results list
+    if (!props.keepResultsOnSelect) {
+      setTerm("");
+      setShowResults(false);
+    }
   }
 
   // clear search results if user clicks outside of results list
@@ -124,7 +126,7 @@ export default React.forwardRef((props, providedRef) => {
   useEffect(() => {
     function handleClickOutside(evt) {
       if (searchRef.current && !searchRef.current.contains(evt.target)) {
-        setHasSelected(true);
+        setShowResults(false);
       }
     }
 
@@ -145,7 +147,7 @@ export default React.forwardRef((props, providedRef) => {
         ref={providedRef}
         value={term}
       />
-      {term && !hasSelected && (
+      {term && showResults && (
         <List
           term={term}
           loading={loading}

--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -71,7 +71,7 @@ export default React.forwardRef((props, providedRef) => {
 
   function handleKeyUp(evt) {
     // NOTE: Must happen before switch
-    // If user starts typing into input reset hasSelected
+    // If user starts typing into input reset showResults
     setShowResults(true);
 
     switch (evt.key) {


### PR DESCRIPTION
adds new optional prop to `ContentSearch` to `keepResultsOnSelect`
and updates Publish Plan to use the new option