### PR TITLE
move getUserConfirmation to history creation utility

### DIFF
--- a/src/shell/index.js
+++ b/src/shell/index.js
@@ -118,16 +118,7 @@ MonacoSetup(store);
 const App = Sentry.withProfiler(() => (
   <Provider store={store}>
     <Sentry.ErrorBoundary fallback={() => <AppError />}>
-      <Router
-        history={history}
-        getUserConfirmation={(message, callback) => {
-          if (message === "confirm") {
-            window.openNavigationModal(callback);
-          } else {
-            callback(true);
-          }
-        }}
-      >
+      <Router history={history}>
         <PrivateRoute>
           <LoadInstance>
             <Shell />

--- a/src/utility/history.js
+++ b/src/utility/history.js
@@ -1,3 +1,11 @@
 import { createBrowserHistory } from "history";
-const history = createBrowserHistory();
+const history = createBrowserHistory({
+  getUserConfirmation(message, callback) {
+    if (message === "confirm") {
+      window.openNavigationModal(callback);
+    } else {
+      callback(true);
+    }
+  }
+});
 export default history;


### PR DESCRIPTION
fixes #722
This allows us to use custom `<Router>` component with a `history` object with a custom `getUserConfirmation()` which allows our Pending Edit modal to work again while maintaining custom `history`