### PR TITLE
ItemEdit throw error on 404

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -179,10 +179,11 @@ export default connect((state, props) => {
           if (res.status === 404) {
             this.props.dispatch(
               notify({
-                message: `Not Found: ${res.error}`,
+                message: res.message,
                 kind: "error"
               })
             );
+            throw new Error(res.message);
           }
           this.props.dispatch(
             selectLang(


### PR DESCRIPTION
this solves the issue of a failed request going down the `.then()` chain and triggering runtime errors