### PR TITLE
Adding flex to Dashboard View links to prevent cheveron from breaking a new line…

### DIFF
--- a/src/apps/content-editor/src/app/views/Dashboard/components/UserLatest/UserLatest.less
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/UserLatest/UserLatest.less
@@ -31,6 +31,8 @@
     }
   }
   .AppLink {
+    display: flex;
+
     svg {
       margin-left: 8px;
 


### PR DESCRIPTION
Open navbar at 1280px was breaking Dashboard View links. 

<img width="1280" alt="Screen Shot 2021-06-11 at 2 31 53 PM" src="https://user-images.githubusercontent.com/22800749/121750887-133a8300-cac2-11eb-9b47-5209c1c0b440.png">
… on small viewports smallest 1280px