### PR TITLE
fix for 400 error going from ItemList to new item

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/PublishStatusCell/PublishStatusCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/PublishStatusCell/PublishStatusCell.js
@@ -19,10 +19,12 @@ export const PublishStatusCell = React.memo(function PublishStatusCell(props) {
       </AppLink>
     );
   }
-  const url = `/content/${props.modelZUID}/${props.itemZUID}`;
   if (props.type === "dataset") {
     return (
-      <AppLink className={cx(styles.PublishStatusCell)} to={`${props.url}`}>
+      <AppLink
+        className={cx(styles.PublishStatusCell)}
+        to={`/content/${props.modelZUID}/${props.itemZUID}`}
+      >
         {props.item &&
         props.item.scheduling &&
         props.item.scheduling.isScheduled ? (

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/PublishStatusCell/PublishStatusCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/PublishStatusCell/PublishStatusCell.js
@@ -9,6 +9,17 @@ import { AppLink } from "@zesty-io/core/AppLink";
 
 import styles from "./PublishStatusCell.less";
 export const PublishStatusCell = React.memo(function PublishStatusCell(props) {
+  if (props.itemZUID.slice(0, 3) === "new") {
+    return (
+      <AppLink
+        className={styles.PublishStatusCell}
+        to={`/content/${props.modelZUID}/new`}
+      >
+        <FontAwesomeIcon icon={faCircle} className={styles.Unpublished} />
+      </AppLink>
+    );
+  }
+  const url = `/content/${props.modelZUID}/${props.itemZUID}`;
   if (props.type === "dataset") {
     return (
       <AppLink className={cx(styles.PublishStatusCell)} to={`${props.url}`}>

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/SetRow.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/SetRow.js
@@ -40,7 +40,8 @@ export default connect()(function SetRow(props) {
       <PublishStatusCell
         type={props.model && props.model.type ? props.model.type : null}
         item={item}
-        url={`/content/${props.modelZUID}/${props.itemZUID}`}
+        modelZUID={props.modelZUID}
+        itemZUID={props.itemZUID}
       />
       <div className={styles.Cells} onClick={selectRow}>
         {props.fields.map(field => {


### PR DESCRIPTION
starting at ItemList view for a Headless Content Model, click create new item, enter some data. Click back to ItemList.
The publish status icon should now link to `content/MODEL_ZUID/new` instead of `content/MODEL_ZUID/new:MODEL_ZUID`.
Fixes issue 2421338753 on Sentry