### PR TITLE
updating the labels to display parley syntax reference as sublabels

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -37,6 +37,17 @@ import { FieldTypeOneToMany } from "@zesty-io/core/FieldTypeOneToMany";
 import styles from "./Field.less";
 import MediaStyles from "../../../../../../media/src/app/MediaAppModal.less";
 
+const FieldLabel = props => {
+  return (
+    <>
+      <span className={styles.MainLabel}>{props.label}&nbsp;</span>
+      <span className={styles.SubLabel}>
+        {props.datatype}: {props.name}
+      </span>
+    </>
+  );
+};
+
 // NOTE: Componetized so it can be memoized for input/render perf
 const RelatedOption = React.memo(props => {
   return (
@@ -57,14 +68,14 @@ const RelatedOption = React.memo(props => {
 // NOTE: Componetized so it can be memoized for input/render perf
 const LinkOption = React.memo(props => {
   return (
-    <React.Fragment>
+    <>
       <FontAwesomeIcon icon={faExclamationTriangle} />
       &nbsp;
       <AppLink to={`/content/${props.modelZUID}/${props.itemZUID}`}>
         {props.itemZUID}
       </AppLink>
       <strong>&nbsp;is missing a meta title</strong>
-    </React.Fragment>
+    </>
   );
 });
 
@@ -192,15 +203,7 @@ export default connect(state => {
       return (
         <FieldTypeText
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -213,15 +216,7 @@ export default connect(state => {
       return (
         <FieldTypeText
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -236,15 +231,7 @@ export default connect(state => {
       return (
         <FieldTypeUUID
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           placeholder="UUID field values are auto-generated"
@@ -258,15 +245,7 @@ export default connect(state => {
       return (
         <FieldTypeTextarea
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -281,15 +260,7 @@ export default connect(state => {
         <div className={styles.WYSIWYGFieldType}>
           <FieldTypeTinyMCE
             name={name}
-            label={
-              <>
-                {" "}
-                <span className={styles.MainLabel}>{label}</span>{" "}
-                <span className={styles.SubLabel}>
-                  {datatype}: {name}
-                </span>
-              </>
-            }
+            label={<FieldLabel label={label} name={name} datatype={datatype} />}
             description={description}
             tooltip={settings.tooltip}
             required={required}
@@ -320,15 +291,7 @@ export default connect(state => {
         <div className={styles.WYSIWYGFieldType}>
           <FieldTypeEditor
             name={name}
-            label={
-              <>
-                {" "}
-                <span className={styles.MainLabel}>{label}</span>{" "}
-                <span className={styles.SubLabel}>
-                  {datatype}: {name}
-                </span>
-              </>
-            }
+            label={<FieldLabel label={label} name={name} datatype={datatype} />}
             description={description}
             tooltip={settings.tooltip}
             required={required}
@@ -358,15 +321,7 @@ export default connect(state => {
           <FieldTypeImage
             images={images}
             name={name}
-            label={
-              <>
-                {" "}
-                <span className={styles.MainLabel}>{label}</span>{" "}
-                <span className={styles.SubLabel}>
-                  {datatype}: {name}
-                </span>
-              </>
-            }
+            label={<FieldLabel label={label} name={name} datatype={datatype} />}
             description={description}
             tooltip={settings.tooltip}
             required={required}
@@ -411,15 +366,7 @@ export default connect(state => {
         return (
           <FieldTypeBinary
             name={name}
-            label={
-              <>
-                {" "}
-                <span className={styles.MainLabel}>{label}</span>{" "}
-                <span className={styles.SubLabel}>
-                  {datatype}: {name}
-                </span>
-              </>
-            }
+            label={<FieldLabel label={label} name={name} datatype={datatype} />}
             description={description}
             tooltip={settings.tooltip}
             required={required}
@@ -459,15 +406,7 @@ export default connect(state => {
           description={description}
           tooltip={settings.tooltip}
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           required={required}
           value={value}
           onChange={onChange}
@@ -540,15 +479,7 @@ export default connect(state => {
       return (
         <FieldTypeInternalLink
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -624,15 +555,7 @@ export default connect(state => {
         <FieldTypeOneToOne
           className={styles.FieldTypeOneToOne}
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -693,15 +616,7 @@ export default connect(state => {
         <FieldTypeOneToMany
           className={styles.FieldTypeOneToMany}
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -717,15 +632,7 @@ export default connect(state => {
       return (
         <FieldTypeColor
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -738,15 +645,7 @@ export default connect(state => {
       return (
         <FieldTypeNumber
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -759,15 +658,7 @@ export default connect(state => {
       return (
         <FieldTypeCurrency
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           placeholder="0.00"
@@ -797,15 +688,7 @@ export default connect(state => {
       return (
         <FieldTypeDate
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           datatype={datatype}
@@ -819,15 +702,7 @@ export default connect(state => {
       return (
         <FieldTypeSort
           name={name}
-          label={
-            <>
-              {" "}
-              <span className={styles.MainLabel}>{label}</span>{" "}
-              <span className={styles.SubLabel}>
-                {datatype}: {name}
-              </span>
-            </>
-          }
+          label={<FieldLabel label={label} name={name} datatype={datatype} />}
           description={description}
           tooltip={settings.tooltip}
           required={required}

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -192,7 +192,15 @@ export default connect(state => {
       return (
         <FieldTypeText
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -205,7 +213,15 @@ export default connect(state => {
       return (
         <FieldTypeText
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -220,7 +236,15 @@ export default connect(state => {
       return (
         <FieldTypeUUID
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           placeholder="UUID field values are auto-generated"
@@ -234,7 +258,15 @@ export default connect(state => {
       return (
         <FieldTypeTextarea
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -249,7 +281,15 @@ export default connect(state => {
         <div className={styles.WYSIWYGFieldType}>
           <FieldTypeTinyMCE
             name={name}
-            label={label}
+            label={
+              <>
+                {" "}
+                <span className={styles.MainLabel}>{label}</span>{" "}
+                <span className={styles.SubLabel}>
+                  {datatype}: {name}
+                </span>
+              </>
+            }
             description={description}
             tooltip={settings.tooltip}
             required={required}
@@ -280,7 +320,15 @@ export default connect(state => {
         <div className={styles.WYSIWYGFieldType}>
           <FieldTypeEditor
             name={name}
-            label={label}
+            label={
+              <>
+                {" "}
+                <span className={styles.MainLabel}>{label}</span>{" "}
+                <span className={styles.SubLabel}>
+                  {datatype}: {name}
+                </span>
+              </>
+            }
             description={description}
             tooltip={settings.tooltip}
             required={required}
@@ -310,7 +358,15 @@ export default connect(state => {
           <FieldTypeImage
             images={images}
             name={name}
-            label={label}
+            label={
+              <>
+                {" "}
+                <span className={styles.MainLabel}>{label}</span>{" "}
+                <span className={styles.SubLabel}>
+                  {datatype}: {name}
+                </span>
+              </>
+            }
             description={description}
             tooltip={settings.tooltip}
             required={required}
@@ -355,7 +411,15 @@ export default connect(state => {
         return (
           <FieldTypeBinary
             name={name}
-            label={label}
+            label={
+              <>
+                {" "}
+                <span className={styles.MainLabel}>{label}</span>{" "}
+                <span className={styles.SubLabel}>
+                  {datatype}: {name}
+                </span>
+              </>
+            }
             description={description}
             tooltip={settings.tooltip}
             required={required}
@@ -395,7 +459,15 @@ export default connect(state => {
           description={description}
           tooltip={settings.tooltip}
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           required={required}
           value={value}
           onChange={onChange}
@@ -468,7 +540,15 @@ export default connect(state => {
       return (
         <FieldTypeInternalLink
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -544,7 +624,15 @@ export default connect(state => {
         <FieldTypeOneToOne
           className={styles.FieldTypeOneToOne}
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -605,7 +693,15 @@ export default connect(state => {
         <FieldTypeOneToMany
           className={styles.FieldTypeOneToMany}
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -621,7 +717,15 @@ export default connect(state => {
       return (
         <FieldTypeColor
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -634,7 +738,15 @@ export default connect(state => {
       return (
         <FieldTypeNumber
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           required={required}
@@ -647,7 +759,15 @@ export default connect(state => {
       return (
         <FieldTypeCurrency
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           placeholder="0.00"
@@ -677,7 +797,15 @@ export default connect(state => {
       return (
         <FieldTypeDate
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           datatype={datatype}
@@ -691,7 +819,15 @@ export default connect(state => {
       return (
         <FieldTypeSort
           name={name}
-          label={label}
+          label={
+            <>
+              {" "}
+              <span className={styles.MainLabel}>{label}</span>{" "}
+              <span className={styles.SubLabel}>
+                {datatype}: {name}
+              </span>
+            </>
+          }
           description={description}
           tooltip={settings.tooltip}
           required={required}

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.less
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.less
@@ -1,3 +1,5 @@
+@import "~@zesty-io/core/colors.less";
+
 .WYSIWYGFieldType {
   min-height: 250px;
 }
@@ -10,4 +12,10 @@
   .relatedItemLink {
     text-shadow: none;
   }
+}
+.MainLabel {
+  font-weight: bold;
+}
+.SubLabel {
+  color: @zesty-gray;
 }


### PR DESCRIPTION
Fixes #760 

<img width="745" alt="Screen Shot 2021-06-29 at 10 43 36 AM" src="https://user-images.githubusercontent.com/22800749/123843547-de526c80-d8c6-11eb-8154-2d5223734472.png">
<img width="509" alt="Screen Shot 2021-06-29 at 10 43 45 AM" src="https://user-images.githubusercontent.com/22800749/123843555-e3afb700-d8c6-11eb-8419-64309ad85ce2.png">
<img width="457" alt="Screen Shot 2021-06-29 at 10 44 18 AM" src="https://user-images.githubusercontent.com/22800749/123843617-f6c28700-d8c6-11eb-83e2-65462c28f7f9.png">
<img width="524" alt="Screen Shot 2021-06-29 at 10 46 03 AM" src="https://user-images.githubusercontent.com/22800749/123843869-34bfab00-d8c7-11eb-893e-16707b648ae5.png">
