### PR TITLE
fix: fixed Ctrl+S on content item after textfield is changed

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -80,11 +80,23 @@ export default function ItemEdit() {
 
   // handle keyboard shortcut save
   useEffect(() => {
+    const handleSaveKeyboardShortcut = event => {
+      if (
+        ((platform.isMac && event.metaKey) ||
+          (!platform.isMac && event.ctrlKey)) &&
+        event.key == "s"
+      ) {
+        event.preventDefault();
+        if (item && item.dirty) {
+          save();
+        }
+      }
+    };
     window.addEventListener("keydown", handleSaveKeyboardShortcut);
     return () => {
       window.removeEventListener("keydown", handleSaveKeyboardShortcut);
     };
-  }, []);
+  }, [item]);
 
   useEffect(() => {
     // on mount and modelZUID/itemZUID update,
@@ -96,19 +108,6 @@ export default function ItemEdit() {
       releaseLock(itemZUID);
     };
   }, [modelZUID, itemZUID]);
-
-  function handleSaveKeyboardShortcut(event) {
-    if (
-      ((platform.isMac && event.metaKey) ||
-        (!platform.isMac && event.ctrlKey)) &&
-      event.key == "s"
-    ) {
-      event.preventDefault();
-      if (item && item.dirty) {
-        save();
-      }
-    }
-  }
 
   async function lockItem() {
     setCheckingLock(true);


### PR DESCRIPTION
changing a text field and then doing Ctrl+S did not save the content item.
This fix makes sure the keybind handler is not using stale version of item when it checks if item is dirty by pulling the function statement into the useEffect and declaring all it's dependencies: `item`
fixes #791 