### PR TITLE
chore: jsx imports automatic codemod

### DIFF
--- a/src/apps/active-preview/Preview.js
+++ b/src/apps/active-preview/Preview.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Select, Option } from "@zesty-io/core/Select";
 import { WithLoader } from "@zesty-io/core/WithLoader";

--- a/src/apps/active-preview/components/Meta/Meta.js
+++ b/src/apps/active-preview/components/Meta/Meta.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Modal, ModalHeader, ModalContent } from "@zesty-io/core/Modal";
 import { WithLoader } from "@zesty-io/core/WithLoader";

--- a/src/apps/active-preview/index.js
+++ b/src/apps/active-preview/index.js
@@ -1,4 +1,3 @@
-import React from "react";
 import ReactDOM from "react-dom";
 import { Preview } from "./Preview";
 

--- a/src/apps/analytics/src/Analytics.js
+++ b/src/apps/analytics/src/Analytics.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { PureComponent } from "react";
 import { connect } from "react-redux";
 import cx from "classnames";
 import moment from "moment";
@@ -34,7 +34,7 @@ export default connect(function (state) {
     }, {}),
   };
 })(
-  class Analytics extends React.PureComponent {
+  class Analytics extends PureComponent {
     state = {
       recentlyEditedItems: [],
       favoriteModels: [],

--- a/src/apps/analytics/src/components/ContentVelocity/ContentVelocity.js
+++ b/src/apps/analytics/src/components/ContentVelocity/ContentVelocity.js
@@ -1,9 +1,9 @@
-import React from "react";
+import { Component } from "react";
 import { Card, CardHeader, CardContent, CardFooter } from "@zesty-io/core/Card";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChartLine } from "@fortawesome/free-solid-svg-icons";
 
-export class ContentVelocity extends React.Component {
+export class ContentVelocity extends Component {
   render() {
     return (
       <Card>

--- a/src/apps/analytics/src/components/GoogleAuthOverlay/GaAuthenticate.js
+++ b/src/apps/analytics/src/components/GoogleAuthOverlay/GaAuthenticate.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Fragment } from "react";
 
 import { usePermission } from "shell/hooks/use-permissions";
 
@@ -12,7 +12,7 @@ export default function GaAuthenticate(props) {
   const canAuthenticate = usePermission("CODE");
 
   return (
-    <React.Fragment>
+    <Fragment>
       {canAuthenticate && (
         <div className={styles.buttonHolder}>
           <Button kind="save" onClick={props.onClick}>
@@ -21,6 +21,6 @@ export default function GaAuthenticate(props) {
           </Button>
         </div>
       )}
-    </React.Fragment>
+    </Fragment>
   );
 }

--- a/src/apps/analytics/src/components/GoogleAuthOverlay/GoogleAuthOverlay.js
+++ b/src/apps/analytics/src/components/GoogleAuthOverlay/GoogleAuthOverlay.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component, Fragment } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGlobe, faKey, faPlug } from "@fortawesome/free-solid-svg-icons";
 
@@ -7,7 +7,7 @@ import { Button } from "@zesty-io/core/Button";
 import GaAuthenticate from "./GaAuthenticate";
 import styles from "./GoogleAuthOverlay.less";
 
-export class GoogleAuthOverlay extends React.Component {
+export class GoogleAuthOverlay extends Component {
   state = {
     titles: {
       noDomain: "Please Setup a Domain before Authenticating",
@@ -71,24 +71,24 @@ export class GoogleAuthOverlay extends React.Component {
         </div>
 
         {this.props.domainSet ? (
-          <React.Fragment>
+          <Fragment>
             {this.props.gaLegacyAuth ? (
-              <React.Fragment>
+              <Fragment>
                 <h2>{this.state.titles.legacyAuthentication}</h2>
                 <p>{this.state.descriptions.legacyAuthentication}</p>
-              </React.Fragment>
+              </Fragment>
             ) : (
-              <React.Fragment>
+              <Fragment>
                 <h2>{this.state.titles.notAuthenticated}</h2>
                 <p>{this.state.descriptions.notAuthenticated}</p>
-              </React.Fragment>
+              </Fragment>
             )}
 
             {/* Exported this button in order to utilize usePermission hook */}
             <GaAuthenticate onClick={this.createAnalyticsPopup} />
-          </React.Fragment>
+          </Fragment>
         ) : (
-          <React.Fragment>
+          <Fragment>
             <h2>{this.state.titles.noDomain}</h2>
             <p>{this.state.descriptions.noDomain}</p>
             <div className={styles.buttonHolder}>
@@ -102,7 +102,7 @@ export class GoogleAuthOverlay extends React.Component {
                 Click here to Setup Your Domain
               </Button>
             </div>
-          </React.Fragment>
+          </Fragment>
         )}
 
         <p className={styles.generalDescription}>

--- a/src/apps/analytics/src/components/InboundTraffic/InboundTraffic.js
+++ b/src/apps/analytics/src/components/InboundTraffic/InboundTraffic.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { PureComponent } from "react";
 
 import { Doughnut } from "react-chartjs-2";
 import { Card, CardHeader, CardContent, CardFooter } from "@zesty-io/core/Card";
@@ -7,7 +7,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChartPie } from "@fortawesome/free-solid-svg-icons";
 
 import styles from "./InboundTraffic.less";
-export class InboundTraffic extends React.PureComponent {
+export class InboundTraffic extends PureComponent {
   state = {
     data: this.props.data,
   };

--- a/src/apps/analytics/src/components/PageviewTraffic/PageviewTraffic.js
+++ b/src/apps/analytics/src/components/PageviewTraffic/PageviewTraffic.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { PureComponent } from "react";
 
 import { Line } from "react-chartjs-2";
 import { Card, CardHeader, CardContent, CardFooter } from "@zesty-io/core/Card";
@@ -7,7 +7,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChartArea } from "@fortawesome/free-solid-svg-icons";
 
 import styles from "./PageviewTraffic.less";
-export class PageviewTraffic extends React.PureComponent {
+export class PageviewTraffic extends PureComponent {
   state = {
     data: this.props.data,
   };

--- a/src/apps/analytics/src/components/RecentlyEdited/RecentlyEdited.js
+++ b/src/apps/analytics/src/components/RecentlyEdited/RecentlyEdited.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClock } from "@fortawesome/free-solid-svg-icons";
 
@@ -7,7 +7,7 @@ import { AppLink } from "@zesty-io/core/AppLink";
 import { WithLoader } from "@zesty-io/core/WithLoader";
 
 import styles from "./RecentlyEdited.less";
-export class RecentlyEdited extends React.Component {
+export class RecentlyEdited extends Component {
   render() {
     return (
       <Card className={styles.Card}>

--- a/src/apps/analytics/src/components/SocialTraffic/SocialTraffic.js
+++ b/src/apps/analytics/src/components/SocialTraffic/SocialTraffic.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { PureComponent } from "react";
 import { Doughnut } from "react-chartjs-2";
 import { Card, CardHeader, CardContent, CardFooter } from "@zesty-io/core/Card";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -6,7 +6,7 @@ import { faHashtag } from "@fortawesome/free-solid-svg-icons";
 import { request } from "utility/request";
 
 import styles from "./SocialTraffic.less";
-export class SocialTraffic extends React.PureComponent {
+export class SocialTraffic extends PureComponent {
   state = {
     data: this.props.data,
   };

--- a/src/apps/analytics/src/components/TopPerforming/TopPerforming.js
+++ b/src/apps/analytics/src/components/TopPerforming/TopPerforming.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { PureComponent } from "react";
 
 import { Card, CardHeader, CardContent, CardFooter } from "@zesty-io/core/Card";
 import { WithLoader } from "@zesty-io/core/WithLoader";
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowCircleUp } from "@fortawesome/free-solid-svg-icons";
 import { request } from "utility/request";
 
-export class TopPerforming extends React.PureComponent {
+export class TopPerforming extends PureComponent {
   state = {
     headers: [],
     data: [],

--- a/src/apps/audit-trail/src/components/controls/index.js
+++ b/src/apps/audit-trail/src/components/controls/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { memo } from "react";
 import cx from "classnames";
 
 import { Search } from "@zesty-io/core/Search";
@@ -6,7 +6,7 @@ import { Button } from "@zesty-io/core/Button";
 import { ButtonGroup } from "@zesty-io/core/ButtonGroup";
 
 import styles from "./styles.less";
-export default React.memo(function AuditControls(props) {
+export default memo(function AuditControls(props) {
   return (
     <header className={styles.auditControls}>
       <Search

--- a/src/apps/audit-trail/src/components/log/index.js
+++ b/src/apps/audit-trail/src/components/log/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import { connect } from "react-redux";
 import moment from "moment";
 

--- a/src/apps/audit-trail/src/components/pagination/index.js
+++ b/src/apps/audit-trail/src/components/pagination/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import { connect } from "react-redux";
 
 import { Button } from "@zesty-io/core/Button";

--- a/src/apps/audit-trail/src/views/app/index.js
+++ b/src/apps/audit-trail/src/views/app/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import moment from "moment";
 

--- a/src/apps/code-editor/src/app/components/Differ/Differ.js
+++ b/src/apps/code-editor/src/app/components/Differ/Differ.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, useState } from "react";
 import { MonacoDiffEditor } from "react-monaco-editor";
 
 import { resolveMonacoLang } from "../../../store/files";
@@ -13,7 +13,7 @@ import { FileActions } from "../FileActions";
  * But we still want to broadcast store updates `onChange`
  */
 import styles from "./Differ.less";
-export const Differ = React.memo(
+export const Differ = memo(
   function Differ(props) {
     const [loading, setLoading] = useState(false);
     const [versionCodeLeft, setVersionCodeLeft] = useState(

--- a/src/apps/code-editor/src/app/components/Editor/Editor.js
+++ b/src/apps/code-editor/src/app/components/Editor/Editor.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { memo } from "react";
 
 import { FileActions } from "../FileActions";
 import { MemoizedEditor } from "./components/MemoizedEditor/MemoizedEditor";
@@ -9,7 +9,7 @@ import { MemoizedEditor } from "./components/MemoizedEditor/MemoizedEditor";
  * But we still want to broadcast store updates `onChange`
  */
 import styles from "./Editor.less";
-export const Editor = React.memo(function Editor(props) {
+export const Editor = memo(function Editor(props) {
   return (
     <main className={styles.Editor}>
       <FileActions

--- a/src/apps/code-editor/src/app/components/Editor/components/MemoizedEditor/MemoizedEditor.js
+++ b/src/apps/code-editor/src/app/components/Editor/components/MemoizedEditor/MemoizedEditor.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import MonacoEditor from "react-monaco-editor";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import { resolveMonacoLang, updateFileCode } from "../../../../../store/files";
@@ -8,7 +8,7 @@ import { resolveMonacoLang, updateFileCode } from "../../../../../store/files";
  * This is done for performance reasons. Constantly re-rendering slows down the editor typing experience.
  * But we still want to broadcast store updates `onChange`
  */
-export const MemoizedEditor = React.memo(
+export const MemoizedEditor = memo(
   function MemoizedEditor(props) {
     const ref = useRef();
 

--- a/src/apps/code-editor/src/app/components/FileActions/FileActions.js
+++ b/src/apps/code-editor/src/app/components/FileActions/FileActions.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { memo, Fragment } from "react";
 import cx from "classnames";
 import { Switch, Route, useRouteMatch } from "react-router";
 
@@ -24,7 +24,7 @@ import { EditorActions } from "./components/EditorActions";
 import { Delete } from "./components/Delete";
 
 import styles from "./FileActions.less";
-export const FileActions = React.memo(function FileActions(props) {
+export const FileActions = memo(function FileActions(props) {
   const match = useRouteMatch("/code/file/:fileType/:fileZUID");
 
   return (
@@ -47,7 +47,7 @@ export const FileActions = React.memo(function FileActions(props) {
           <Route path={`${match.url}`}>
             <div className={styles.QuickLinks}>
               {props.contentModelZUID && (
-                <React.Fragment>
+                <Fragment>
                   <AppLink
                     className={styles.Link}
                     to={`/content/${props.contentModelZUID}`}
@@ -67,7 +67,7 @@ export const FileActions = React.memo(function FileActions(props) {
                       <FontAwesomeIcon icon={faDatabase} />
                     </Button>
                   </AppLink>
-                </React.Fragment>
+                </Fragment>
               )}
 
               <AppLink

--- a/src/apps/code-editor/src/app/components/FileActions/components/Delete/Delete.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/Delete/Delete.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, useState } from "react";
 import { useHistory } from "react-router";
 
 import { Button } from "@zesty-io/core/Button";
@@ -15,7 +15,7 @@ import {
   faExclamationCircle,
   faSpinner,
 } from "@fortawesome/free-solid-svg-icons";
-export const Delete = React.memo(function Delete(props) {
+export const Delete = memo(function Delete(props) {
   const [open, setOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const history = useHistory();

--- a/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { memo, useState, useEffect } from "react";
 import cx from "classnames";
 import moment from "moment-timezone";
 import { useHistory } from "react-router";
@@ -23,7 +23,7 @@ import {
 } from "../../../../../store/files";
 
 import styles from "./DifferActions.less";
-export const DifferActions = React.memo(function DifferActions(props) {
+export const DifferActions = memo(function DifferActions(props) {
   const [saving, setSaving] = useState(false);
   const [versions, setVersions] = useState([]);
   const [selectedVersion, setSelectedVersion] = useState(

--- a/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/EditorActions.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/EditorActions.js
@@ -1,10 +1,10 @@
-import React from "react";
+import { memo } from "react";
 
 import { Save } from "./Save";
 import { Publish } from "./Publish";
 
 import styles from "./EditorActions.less";
-export const EditorActions = React.memo(function EditorActions(props) {
+export const EditorActions = memo(function EditorActions(props) {
   return (
     <div className={styles.EditorActions}>
       <Save

--- a/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Publish/Publish.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Publish/Publish.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, useState } from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCloudUploadAlt, faSpinner } from "@fortawesome/free-solid-svg-icons";
@@ -9,7 +9,7 @@ import { publishFile, fetchFiles } from "../../../../../../store/files";
 
 import styles from "../EditorActions.less";
 
-export const Publish = React.memo(function Publish(props) {
+export const Publish = memo(function Publish(props) {
   const [publishing, setPublishing] = useState(false);
 
   return (

--- a/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Save/Save.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Save/Save.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { memo, useState, useEffect } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -15,7 +15,7 @@ export default connect((state) => {
     platform: state.platform,
   };
 })(
-  React.memo(function Save(props) {
+  memo(function Save(props) {
     const [saving, setSaving] = useState(false);
 
     const onSave = () => {

--- a/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Sync/Sync.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Sync/Sync.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, useState } from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -16,7 +16,7 @@ import { Modal, ModalContent, ModalFooter } from "@zesty-io/core/Modal";
 import { fetchFile } from "../../../../../../store/files";
 
 import styles from "./Sync.less";
-export const Sync = React.memo(function Sync(props) {
+export const Sync = memo(function Sync(props) {
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
 

--- a/src/apps/code-editor/src/app/components/FileDrawer/FileDrawer.js
+++ b/src/apps/code-editor/src/app/components/FileDrawer/FileDrawer.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { memo, useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
 import moment from "moment";
 
@@ -19,7 +19,7 @@ import { fetchItems } from "shell/store/content";
 import { fetchFields } from "shell/store/fields";
 
 import styles from "./FileDrawer.less";
-export const FileDrawer = React.memo(function FileDrawer(props) {
+export const FileDrawer = memo(function FileDrawer(props) {
   const dispatch = useDispatch();
 
   const [open, setOpen] = useState(false);
@@ -66,7 +66,7 @@ export const FileDrawer = React.memo(function FileDrawer(props) {
 
         if (fields && fields.payload) {
           let tempArray = [];
-          Object.keys(fields.payload).forEach(field =>
+          Object.keys(fields.payload).forEach((field) =>
             tempArray.push(fields.payload[field])
           );
           setFields(tempArray);

--- a/src/apps/code-editor/src/app/components/FileDrawer/components/AuditTrail/AuditTrail.js
+++ b/src/apps/code-editor/src/app/components/FileDrawer/components/AuditTrail/AuditTrail.js
@@ -1,4 +1,3 @@
-import React from "react";
 import moment from "moment";
 import cx from "classnames";
 

--- a/src/apps/code-editor/src/app/components/FileDrawer/components/FileStatus/FileStatus.js
+++ b/src/apps/code-editor/src/app/components/FileDrawer/components/FileStatus/FileStatus.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { useSelector } from "react-redux";
 import moment from "moment";
 import cx from "classnames";
@@ -13,7 +12,7 @@ import { AppLink } from "@zesty-io/core/AppLink";
 import styles from "./FileStatus.less";
 import shared from "../../FileDrawer.less";
 
-const FileType = props => {
+const FileType = (props) => {
   if (
     props.fileType === "templateset" ||
     props.fileType === "pageset" ||
@@ -38,7 +37,7 @@ const FileType = props => {
 };
 
 export default function FileStatus(props) {
-  const instance = useSelector(state => state.instance);
+  const instance = useSelector((state) => state.instance);
 
   return (
     <Card className={cx(styles.FileStatus, shared.DrawerStyles)}>

--- a/src/apps/code-editor/src/app/components/FileDrawer/components/LinkedContent/LinkedContent.js
+++ b/src/apps/code-editor/src/app/components/FileDrawer/components/LinkedContent/LinkedContent.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEdit, faEye, faLink } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";

--- a/src/apps/code-editor/src/app/components/FileDrawer/components/LinkedSchema/LinkedSchema.js
+++ b/src/apps/code-editor/src/app/components/FileDrawer/components/LinkedSchema/LinkedSchema.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faDatabase, faLink } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";

--- a/src/apps/code-editor/src/app/components/FileDrawer/components/PublishAll/PublishAll.js
+++ b/src/apps/code-editor/src/app/components/FileDrawer/components/PublishAll/PublishAll.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { connect } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {

--- a/src/apps/code-editor/src/app/components/FileList/FileList.js
+++ b/src/apps/code-editor/src/app/components/FileList/FileList.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { memo, useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import cx from "classnames";
 
@@ -16,7 +16,7 @@ import { resolvePathPart, publishFile } from "../../../store/files";
 import { collapseNavItem } from "../../../store/navCode";
 
 import styles from "./FileList.less";
-export const FileList = React.memo(function FileList(props) {
+export const FileList = memo(function FileList(props) {
   // const [branch, setBranch] = useState(props.branch);
   const [shownFiles, setShownFiles] = useState(
     props.navCode.tree.sort(byLabel)

--- a/src/apps/code-editor/src/app/components/FileList/components/CreateFile/CreateFile.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/CreateFile/CreateFile.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, Fragment, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -19,7 +19,7 @@ import { notify } from "shell/store/notifications";
 import { createFile } from "../../../../../store/files";
 
 import styles from "./CreateFile.less";
-export const CreateFile = React.memo(function CreateFile(props) {
+export const CreateFile = memo(function CreateFile(props) {
   const history = useHistory();
 
   const [loading, setLoading] = useState(false);
@@ -76,7 +76,7 @@ export const CreateFile = React.memo(function CreateFile(props) {
   };
 
   return (
-    <React.Fragment>
+    <Fragment>
       <Button
         className={styles.CreateFileBtn}
         onClick={() => setOpen(true)}
@@ -196,6 +196,6 @@ export const CreateFile = React.memo(function CreateFile(props) {
           </ModalFooter>
         </Modal>
       )}
-    </React.Fragment>
+    </Fragment>
   );
 });

--- a/src/apps/code-editor/src/app/components/FileList/components/FilterFiles/FilterFiles.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/FilterFiles/FilterFiles.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Search } from "@zesty-io/core/Search";
 
 import styles from "./FilterFiles.less";

--- a/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { Fragment, useState, useEffect } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -100,7 +100,7 @@ export default connect((state, props) => {
   };
 
   return (
-    <React.Fragment>
+    <Fragment>
       <Button
         onClick={() => setOpen(true)}
         kind="primary"
@@ -175,6 +175,6 @@ export default connect((state, props) => {
           </ModalFooter>
         </Modal>
       )}
-    </React.Fragment>
+    </Fragment>
   );
 });

--- a/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/components/Draggable/Draggable.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/components/Draggable/Draggable.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import { useRef } from "react";
 import cx from "classnames";
 
 export function Draggable(props) {

--- a/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/components/Dropzone/Dropzone.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/components/Dropzone/Dropzone.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { Children, cloneElement, useState, useEffect } from "react";
 import cx from "classnames";
 
 export function Dropzone(props) {
@@ -17,13 +17,11 @@ export function Dropzone(props) {
    */
 
   const [sourceIndex, setSourceIndex] = useState(null);
-  const [children, setChildren] = useState(
-    React.Children.toArray(props.children)
-  );
+  const [children, setChildren] = useState(Children.toArray(props.children));
 
   // Update state when props change
   useEffect(
-    () => setChildren(React.Children.toArray(props.children)),
+    () => setChildren(Children.toArray(props.children)),
     [props.children]
   );
 
@@ -37,7 +35,7 @@ export function Dropzone(props) {
   const onDragEnd = (evt) => {
     // Reset
     setSourceIndex(null);
-    setChildren(React.Children.toArray(props.children));
+    setChildren(Children.toArray(props.children));
   };
 
   const onDragEnter = (evt) => {
@@ -73,7 +71,7 @@ export function Dropzone(props) {
       onDrop={onDrop}
     >
       {children.map((child, index) => {
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           index,
           onOver,
           setSourceIndex,

--- a/src/apps/code-editor/src/app/components/FileList/components/PublishAll/PublishAll.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/PublishAll/PublishAll.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, Fragment, useState } from "react";
 import { connect } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -32,7 +32,7 @@ export default connect((state) => {
     files: state.files.filter((file) => file.isLive === false),
   };
 })(
-  React.memo(function PublishAll(props) {
+  memo(function PublishAll(props) {
     const [loading, setLoading] = useState(false);
     const [open, setOpen] = useState(false);
 
@@ -80,7 +80,7 @@ export default connect((state) => {
     };
 
     return (
-      <React.Fragment>
+      <Fragment>
         <Button
           className={styles.PublishAllBtn}
           onClick={() => setOpen(true)}
@@ -135,7 +135,7 @@ export default connect((state) => {
             </ButtonGroup>
           </ModalFooter>
         </Modal>
-      </React.Fragment>
+      </Fragment>
     );
   })
 );

--- a/src/apps/code-editor/src/app/components/FileList/components/SelectBranch/SelectBranch.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/SelectBranch/SelectBranch.js
@@ -1,9 +1,9 @@
-import React from "react";
+import { memo } from "react";
 
 import { Select, Option } from "@zesty-io/core/Select";
 
 import styles from "./SelectBranch.less";
-export const SelectBranch = React.memo(function SelectBranch(props) {
+export const SelectBranch = memo(function SelectBranch(props) {
   return (
     <Select
       name="branch"

--- a/src/apps/code-editor/src/app/components/FileTabs/FileTabs.js
+++ b/src/apps/code-editor/src/app/components/FileTabs/FileTabs.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { memo, useEffect } from "react";
 import cx from "classnames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -12,7 +12,7 @@ import { AppLink } from "@zesty-io/core/AppLink";
 import { fileOpen, resolvePathPart } from "../../../store/files";
 
 import styles from "./FileTabs.less";
-export const FileTabs = React.memo(
+export const FileTabs = memo(
   function FileTabs(props) {
     useEffect(() => {
       props.dispatch(fileOpen(props.openFileZUID, props.status, true));

--- a/src/apps/code-editor/src/app/components/Workspace/Workspace.js
+++ b/src/apps/code-editor/src/app/components/Workspace/Workspace.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { memo } from "react";
 import { Switch, Route } from "react-router";
 
 import { GettingStarted } from "./components/GettingStarted";
@@ -6,7 +6,7 @@ import { FileViewer } from "./components/FileViewer";
 import { NotFound } from "./components/NotFound";
 
 import styles from "./Workspace.less";
-export const Workspace = React.memo(function Workspace(props) {
+export const Workspace = memo(function Workspace(props) {
   return (
     <div className={styles.Workspace}>
       <Switch>

--- a/src/apps/code-editor/src/app/components/Workspace/components/FileViewer/FileViewer.js
+++ b/src/apps/code-editor/src/app/components/Workspace/components/FileViewer/FileViewer.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { memo, useState, useEffect } from "react";
 import { connect } from "react-redux";
 import { Switch, Route } from "react-router";
 import { Redirect } from "react-router-dom";
@@ -39,7 +39,7 @@ export const FileViewer = connect((state, props) => {
     fields,
   };
 })(
-  React.memo(function FileViewer(props) {
+  memo(function FileViewer(props) {
     const { match, location } = props;
     const [loading, setLoading] = useState(false);
 

--- a/src/apps/code-editor/src/app/components/Workspace/components/GettingStarted/GettingStarted.js
+++ b/src/apps/code-editor/src/app/components/Workspace/components/GettingStarted/GettingStarted.js
@@ -1,4 +1,3 @@
-import React from "react";
 import cx from "classnames";
 import moment from "moment";
 

--- a/src/apps/code-editor/src/app/components/Workspace/components/NotFound/NotFound.js
+++ b/src/apps/code-editor/src/app/components/Workspace/components/NotFound/NotFound.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { connect } from "react-redux";
 // import cx from "classnames";
 

--- a/src/apps/code-editor/src/app/views/CodeEditor/CodeEditor.js
+++ b/src/apps/code-editor/src/app/views/CodeEditor/CodeEditor.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { connect } from "react-redux";
 import { useRouteMatch } from "react-router-dom";
 

--- a/src/apps/content-editor/src/app/ContentEditor.js
+++ b/src/apps/content-editor/src/app/ContentEditor.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import { connect } from "react-redux";
 import { Switch, Route } from "react-router-dom";
 

--- a/src/apps/content-editor/src/app/components/DragScroll.js
+++ b/src/apps/content-editor/src/app/components/DragScroll.js
@@ -1,9 +1,9 @@
-import React from "react";
+import { Component } from "react";
 
 /**
  * Adapted from https://github.com/qiaolb/react-dragscroll/blob/master/src/DragScroll.jsx
  */
-export class DragScroll extends React.Component {
+export class DragScroll extends Component {
   constructor(props) {
     super(props);
     this.state = {

--- a/src/apps/content-editor/src/app/components/Editor/Editor.js
+++ b/src/apps/content-editor/src/app/components/Editor/Editor.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
 
 import { Breadcrumbs } from "shell/components/global-tabs/components/Breadcrumbs";
 

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useState } from "react";
+import { memo, useMemo, useCallback, useState } from "react";
 import ReactDOM from "react-dom";
 import { connect } from "react-redux";
 import moment from "moment-timezone";
@@ -49,7 +49,7 @@ const FieldLabel = (props) => {
 };
 
 // NOTE: Componetized so it can be memoized for input/render perf
-const RelatedOption = React.memo((props) => {
+const RelatedOption = memo((props) => {
   return (
     <span>
       <span onClick={(evt) => evt.stopPropagation()}>
@@ -66,7 +66,7 @@ const RelatedOption = React.memo((props) => {
 });
 
 // NOTE: Componetized so it can be memoized for input/render perf
-const LinkOption = React.memo((props) => {
+const LinkOption = memo((props) => {
   return (
     <>
       <FontAwesomeIcon icon={faExclamationTriangle} />

--- a/src/apps/content-editor/src/app/components/LockedItem/LockedItem.js
+++ b/src/apps/content-editor/src/app/components/LockedItem/LockedItem.js
@@ -1,4 +1,3 @@
-import React from "react";
 import moment from "moment-timezone";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/components/Nav/ContentNav.js
+++ b/src/apps/content-editor/src/app/components/Nav/ContentNav.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { Fragment, useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { useLocation, useHistory } from "react-router";
 import { Link } from "react-router-dom";
@@ -71,7 +71,7 @@ export function ContentNav(props) {
   };
 
   return (
-    <React.Fragment>
+    <Fragment>
       <ItemsFilter
         setFilteredItems={setFilteredItems}
         nav={props.nav}
@@ -195,7 +195,7 @@ export function ContentNav(props) {
       </div>
 
       <ReorderNav isOpen={reorderOpen} toggleOpen={toggleModal} />
-    </React.Fragment>
+    </Fragment>
   );
 }
 

--- a/src/apps/content-editor/src/app/components/Nav/ItemsFilter.js
+++ b/src/apps/content-editor/src/app/components/Nav/ItemsFilter.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Search } from "@zesty-io/core/Search";
 import styles from "./ContentNav.less";
 

--- a/src/apps/content-editor/src/app/components/PendingEditsModal/PendingEditsModal.js
+++ b/src/apps/content-editor/src/app/components/PendingEditsModal/PendingEditsModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { memo, useState, useEffect } from "react";
 import { Prompt } from "react-router-dom";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -19,7 +19,7 @@ import {
 } from "@zesty-io/core/Modal";
 
 import styles from "./PendingEditsModal.less";
-export default React.memo(function PendingEditsModal(props) {
+export default memo(function PendingEditsModal(props) {
   // FIXME: non memoized onSave & onDiscard props are causing rerenders
 
   const [loading, setLoading] = useState(props.loading || false);

--- a/src/apps/content-editor/src/app/components/ReorderNav/DragComponents/DragList.js
+++ b/src/apps/content-editor/src/app/components/ReorderNav/DragComponents/DragList.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import DraggableItem from "./DraggableItem";
 
 import styles from "./styles.less";

--- a/src/apps/content-editor/src/app/components/ReorderNav/DragComponents/DraggableItem.js
+++ b/src/apps/content-editor/src/app/components/ReorderNav/DragComponents/DraggableItem.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowsAlt, faCaretRight } from "@fortawesome/free-solid-svg-icons";

--- a/src/apps/content-editor/src/app/components/ReorderNav/ReorderNav.js
+++ b/src/apps/content-editor/src/app/components/ReorderNav/ReorderNav.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/CSVImport/CSVImport.js
+++ b/src/apps/content-editor/src/app/views/CSVImport/CSVImport.js
@@ -1,4 +1,4 @@
-import React, { Component, PureComponent } from "react";
+import { Component, PureComponent } from "react";
 import { connect } from "react-redux";
 import parse from "csv-parse/lib/es5/sync";
 import chunk from "lodash/chunk";

--- a/src/apps/content-editor/src/app/views/CSVImport/Columns/Columns.js
+++ b/src/apps/content-editor/src/app/views/CSVImport/Columns/Columns.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
 import cx from "classnames";
 
 import { Select, Option } from "@zesty-io/core";

--- a/src/apps/content-editor/src/app/views/CSVImport/CsvSettings/CsvSettings.js
+++ b/src/apps/content-editor/src/app/views/CSVImport/CsvSettings/CsvSettings.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import { Select, Option, Input } from "@zesty-io/core";
 
 import styles from "./CsvSettings.less";

--- a/src/apps/content-editor/src/app/views/Dashboard/Dashboard.js
+++ b/src/apps/content-editor/src/app/views/Dashboard/Dashboard.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { createSelector } from "@reduxjs/toolkit";
 import moment from "moment-timezone";
@@ -66,7 +66,7 @@ const selectModelsByZuid = createSelector(
     }, {})
 );
 
-export default React.memo(function Dashboard() {
+export default memo(function Dashboard() {
   const user = useSelector((state) => state.user);
   const instance = useSelector((state) => state.instance);
   const headTags = useSelector((state) => state.headTags);

--- a/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.js
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/AccountInfo/AccountInfo.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {

--- a/src/apps/content-editor/src/app/views/Dashboard/components/ChartDashboard/ChartDashboard.js
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/ChartDashboard/ChartDashboard.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Bar } from "react-chartjs-2";
 import moment from "moment";
 

--- a/src/apps/content-editor/src/app/views/Dashboard/components/InstanceActivity/InstanceActivity.js
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/InstanceActivity/InstanceActivity.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import moment from "moment";
 import cx from "classnames";
 

--- a/src/apps/content-editor/src/app/views/Dashboard/components/QuickJumps/QuickJumps.js
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/QuickJumps/QuickJumps.js
@@ -1,4 +1,3 @@
-import React from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/Dashboard/components/UserLatest/UserLatest.js
+++ b/src/apps/content-editor/src/app/views/Dashboard/components/UserLatest/UserLatest.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useDispatch } from "react-redux";
 import moment from "moment";
 import uniqBy from "lodash/uniqBy";

--- a/src/apps/content-editor/src/app/views/ItemCreate/Header/Header.js
+++ b/src/apps/content-editor/src/app/views/ItemCreate/Header/Header.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.js
+++ b/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import useIsMounted from "ismounted";
 import { useHistory, useParams } from "react-router-dom";

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Actions.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Actions.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "react";
 
 import { usePermission } from "shell/hooks/use-permissions";
 import { useDomain } from "shell/hooks/use-domain";

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/Modal/Modal.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/Modal/Modal.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faWindowClose } from "@fortawesome/free-solid-svg-icons";
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/QuickView/QuickView.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/QuickView/QuickView.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { memo, Fragment } from "react";
 import { useFilePath } from "shell/hooks/useFilePath";
 import moment from "moment-timezone";
 import cx from "classnames";
@@ -20,7 +20,7 @@ import { useDomain } from "shell/hooks/use-domain";
 
 import SharedWidgetStyles from "../SharedWidget.less";
 import styles from "./QuickView.less";
-export const QuickView = React.memo(function QuickView(props) {
+export const QuickView = memo(function QuickView(props) {
   const isPublished = props.publishing && props.publishing.isPublished;
   const isScheduled = props.scheduling && props.scheduling.isScheduled;
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/Unpublish/Unpublish.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/Unpublish/Unpublish.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, Fragment, useState } from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner, faUnlink } from "@fortawesome/free-solid-svg-icons";
@@ -11,7 +11,7 @@ import {
 
 import { unpublish } from "shell/store/content";
 
-export const Unpublish = React.memo(function Unpublish(props) {
+export const Unpublish = memo(function Unpublish(props) {
   const isPublished = props.publishing && props.publishing.isPublished;
 
   const [loading, setLoading] = useState(false);
@@ -31,10 +31,10 @@ export const Unpublish = React.memo(function Unpublish(props) {
     <CollapsibleCard
       className={"Unpublish"}
       header={
-        <React.Fragment>
+        <Fragment>
           <FontAwesomeIcon icon={faUnlink} />
           &nbsp;Unpublish
-        </React.Fragment>
+        </Fragment>
       }
     >
       <CardContent>

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
@@ -1,4 +1,4 @@
-import React, { useState, Fragment } from "react";
+import { memo, useState, Fragment } from "react";
 import cx from "classnames";
 import { useHistory } from "react-router-dom";
 
@@ -19,7 +19,7 @@ import { ConfirmDialog } from "@zesty-io/core/ConfirmDialog";
 
 import { deleteItem } from "shell/store/content";
 
-export const WidgetDeleteItem = React.memo(function WidgetDeleteItem(props) {
+export const WidgetDeleteItem = memo(function WidgetDeleteItem(props) {
   const history = useHistory();
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDraftHistory/WidgetDraftHistory.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDraftHistory/WidgetDraftHistory.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { connect } from "react-redux";
 import moment from "moment-timezone";
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetListed/WidgetListed.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetListed/WidgetListed.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { memo } from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCode } from "@fortawesome/free-solid-svg-icons";
@@ -9,7 +9,7 @@ import { FieldTypeBinary } from "@zesty-io/core/FieldTypeBinary";
 import { Infotip } from "@zesty-io/core/Infotip";
 
 import styles from "./WidgetListed.less";
-export const WidgetListed = React.memo(function WidgetListed(props) {
+export const WidgetListed = memo(function WidgetListed(props) {
   return (
     <Card className={styles.WidgetListed}>
       <CardHeader>

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPublishHistory/WidgetPublishHistory.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPublishHistory/WidgetPublishHistory.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { memo, useState, useEffect } from "react";
 import { connect } from "react-redux";
 import moment from "moment-timezone";
 
@@ -16,7 +16,7 @@ export default connect((state) => {
     instanceZUID: state.instance.ZUID,
   };
 })(
-  React.memo(function WidgetPublishHistory(props) {
+  memo(function WidgetPublishHistory(props) {
     const [loading, setLoading] = useState(false);
 
     useEffect(() => {

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPurgeItem/WidgetPurgeItem.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPurgeItem/WidgetPurgeItem.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, useState } from "react";
 import { Card, CardHeader, CardContent, CardFooter } from "@zesty-io/core/Card";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -9,7 +9,7 @@ import { notify } from "shell/store/notifications";
 import { request } from "utility/request";
 import SharedWidgetStyles from "../SharedWidget.less";
 
-export const WidgetPurgeItem = React.memo(function WidgetPurgeItem(props) {
+export const WidgetPurgeItem = memo(function WidgetPurgeItem(props) {
   const [loading, setLoading] = useState(false);
 
   return (

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetQuickShare/WidgetQuickShare.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetQuickShare/WidgetQuickShare.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { memo } from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faShareAlt } from "@fortawesome/free-solid-svg-icons";
@@ -12,7 +12,7 @@ import {
   faRedditSquare,
   faTwitterSquare,
 } from "@fortawesome/free-brands-svg-icons";
-export const WidgetQuickShare = React.memo(function WidgetQuickShare(props) {
+export const WidgetQuickShare = memo(function WidgetQuickShare(props) {
   const handleOpen = (evt, url) => {
     window.open(
       url,

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WorkflowRequest/WorkflowRequest.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WorkflowRequest/WorkflowRequest.js
@@ -1,4 +1,4 @@
-import React, { memo, useState } from "react";
+import { memo, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faSave,

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Editor } from "../../../components/Editor";
 import { Header } from "../components/Header";
 import { ItemVersioning } from "../components/Header/ItemVersioning";

--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Switch,
   Route,

--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemHead/ItemHead.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemHead/ItemHead.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Head } from "shell/components/Head";
 import { Header } from "../components/Header";
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/DataSettings.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/DataSettings.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import cx from "classnames";
 
 import { MetaTitle } from "./settings/MetaTitle";
@@ -7,7 +7,7 @@ import { MetaKeywords } from "./settings/MetaKeywords";
 import { MetaLinkText } from "./settings/MetaLinkText";
 
 import styles from "./ItemSettings.less";
-export class DataSettings extends React.Component {
+export class DataSettings extends Component {
   onChange = (value, name) => {
     if (!name) {
       throw new Error("Input is missing name attribute");

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/ItemSettings.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/ItemSettings.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import { memo, Fragment, useCallback } from "react";
 
 import { MetaTitle } from "./settings/MetaTitle";
 import MetaDescription from "./settings/MetaDescription";
@@ -12,7 +12,7 @@ import { useDomain } from "shell/hooks/use-domain";
 
 import styles from "./ItemSettings.less";
 
-export const ItemSettings = React.memo(
+export const ItemSettings = memo(
   function ItemSettings(props) {
     const domain = useDomain();
     let { data, meta, web } = props.item;
@@ -40,7 +40,7 @@ export const ItemSettings = React.memo(
       <section className={styles.Meta}>
         <main className={styles.Settings}>
           {web.pathPart !== "zesty_home" && (
-            <React.Fragment>
+            <Fragment>
               <ItemParent
                 itemZUID={meta.ZUID}
                 modelZUID={props.modelZUID}
@@ -56,7 +56,7 @@ export const ItemSettings = React.memo(
                 path_part={web.pathPart}
                 path_to={web.path}
               />
-            </React.Fragment>
+            </Fragment>
           )}
           <MetaLinkText meta_link_text={web.metaLinkText} onChange={onChange} />
           <MetaTitle meta_title={web.metaTitle} onChange={onChange} />

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/CanonicalTag.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/CanonicalTag.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, useState } from "react";
 
 import { Select, Option } from "@zesty-io/core/Select";
 import { Input } from "@zesty-io/core/Input";
@@ -25,7 +25,7 @@ const CANONICAL_OPTS = [
 ];
 
 import styles from "./CanonicalTag.less";
-export const CanonicalTag = React.memo(function CanonicalTag(props) {
+export const CanonicalTag = memo(function CanonicalTag(props) {
   const [whitelist, setWhitelist] = useState(props.whitelist);
   const [custom, setCustom] = useState(props.custom);
   const [mode, setMode] = useState(

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { memo, Fragment, useState, useEffect } from "react";
 import { connect } from "react-redux";
 import debounce from "lodash/debounce";
 
@@ -15,7 +15,7 @@ export const ItemParent = connect((state) => {
     nav: state.navContent.raw,
   };
 })(
-  React.memo(
+  memo(
     function ItemParent(props) {
       const [loading, setLoading] = useState(false);
       const [parent, setParent] = useState({
@@ -143,10 +143,10 @@ export const ItemParent = connect((state) => {
               <Option
                 value="0"
                 component={
-                  <React.Fragment>
+                  <Fragment>
                     <FontAwesomeIcon icon={faHome} />
                     &nbsp;/
-                  </React.Fragment>
+                  </Fragment>
                 }
               />
               {parents.map((item) => (

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemRoute.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemRoute.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from "react";
+import { memo, Fragment, useCallback, useState, useEffect } from "react";
 import { connect, useDispatch } from "react-redux";
 import debounce from "lodash/debounce";
 import { searchItems } from "shell/store/content";
@@ -18,7 +18,7 @@ export const ItemRoute = connect((state) => {
     content: state.content,
   };
 })(
-  React.memo(function ItemRoute(props) {
+  memo(function ItemRoute(props) {
     const dispatch = useDispatch();
     const [pathPart, setPathPart] = useState(props.path_part);
     const [loading, setLoading] = useState(false);
@@ -122,7 +122,7 @@ export const ItemRoute = connect((state) => {
               &nbsp;Homepage
             </h1>
           ) : (
-            <React.Fragment>
+            <Fragment>
               <Input
                 type={"text"}
                 name="pathPart"
@@ -148,7 +148,7 @@ export const ItemRoute = connect((state) => {
                   <FontAwesomeIcon icon={faTimes} />
                 </InputIcon>
               )}
-            </React.Fragment>
+            </Fragment>
           )}
         </div>
       </article>

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/MetaDescription.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/MetaDescription.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/MetaKeywords.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/MetaKeywords.js
@@ -1,10 +1,10 @@
-import React from "react";
+import { memo } from "react";
 
 import { FieldTypeTextarea } from "@zesty-io/core/FieldTypeTextarea";
 import { Infotip } from "@zesty-io/core/Infotip";
 
 import styles from "./MetaKeywords.less";
-export const MetaKeywords = React.memo(function MetaKeywords({
+export const MetaKeywords = memo(function MetaKeywords({
   meta_keywords,
   onChange,
 }) {

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/MetaLinkText.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/MetaLinkText.js
@@ -1,10 +1,10 @@
-import React from "react";
+import { memo } from "react";
 
 import { FieldTypeText } from "@zesty-io/core/FieldTypeText";
 import { Infotip } from "@zesty-io/core/Infotip";
 
 import styles from "./MetaLinkText.less";
-export const MetaLinkText = React.memo(function MetaLinkText({
+export const MetaLinkText = memo(function MetaLinkText({
   meta_link_text,
   onChange,
 }) {

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/MetaTitle.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/MetaTitle.js
@@ -1,13 +1,10 @@
-import React from "react";
+import { memo } from "react";
 
 import { FieldTypeText } from "@zesty-io/core/FieldTypeText";
 import { Infotip } from "@zesty-io/core/Infotip";
 
 import styles from "./MetaTitle.less";
-export const MetaTitle = React.memo(function MetaTitle({
-  meta_title,
-  onChange,
-}) {
+export const MetaTitle = memo(function MetaTitle({ meta_title, onChange }) {
   return (
     <article className={styles.MetaTitle} data-cy="metaTitle">
       <FieldTypeText

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/SitemapPriority.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/SitemapPriority.js
@@ -1,11 +1,11 @@
-import React from "react";
+import { memo } from "react";
 
 import { Select, Option } from "@zesty-io/core/Select";
 import { FieldLabel } from "@zesty-io/core/FieldLabel";
 import { Infotip } from "@zesty-io/core/Infotip";
 
 import styles from "./SitemapPriority.less";
-export const SitemapPriority = React.memo(function SitemapPriority(props) {
+export const SitemapPriority = memo(function SitemapPriority(props) {
   return (
     <article className={styles.SitemapPriority} data-cy="sitemapPriority">
       <FieldLabel

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/Meta.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/Meta.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Header } from "../components/Header";
 import { ItemVersioning } from "../components/Header/ItemVersioning";
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { PureComponent } from "react";
 import cx from "classnames";
 
 import { PreviewUrl } from "./PreviewUrl";
@@ -8,7 +8,7 @@ import { LanguageSelector } from "./LanguageSelector";
 import ItemNavigation from "./ItemNavigation";
 
 import styles from "./Header.less";
-export class Header extends React.PureComponent {
+export class Header extends PureComponent {
   render() {
     return (
       <header className={styles.Header}>

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.js
@@ -1,4 +1,3 @@
-import React from "react";
 import cx from "classnames";
 
 import { AppLink } from "@zesty-io/core/AppLink";

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ScheduleFlyout/ScheduleFlyout.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ScheduleFlyout/ScheduleFlyout.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import moment from "moment-timezone";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/VersionSelector/VersionSelector.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/VersionSelector/VersionSelector.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import { memo, useState, useEffect, useCallback } from "react";
 import { connect } from "react-redux";
 import moment from "moment-timezone";
 import cx from "classnames";
@@ -21,7 +21,7 @@ export default connect((state, props) => {
     latestVersionNum,
   };
 })(
-  React.memo(function VersionSelector(props) {
+  memo(function VersionSelector(props) {
     const [loading, setLoading] = useState(true);
     const [selectedVersionNum, setSelectedVersionNum] = useState(
       props.latestVersionNum

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/LanguageSelector/LanguageSelector.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/LanguageSelector/LanguageSelector.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { Fragment, useState, useEffect } from "react";
 import cx from "classnames";
 import { connect } from "react-redux";
 import { useHistory, useLocation } from "react-router-dom";
@@ -43,7 +43,7 @@ export const LanguageSelector = connect((state, props) => {
   };
 
   return (
-    <React.Fragment>
+    <Fragment>
       {props.languages.length > 1 ? (
         <Select
           name="LanguageSelector"
@@ -56,6 +56,6 @@ export const LanguageSelector = connect((state, props) => {
           ))}
         </Select>
       ) : null}
-    </React.Fragment>
+    </Fragment>
   );
 });

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/LiveUrl/LiveUrl.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/LiveUrl/LiveUrl.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faHome, faLink, faUnlink } from "@fortawesome/free-solid-svg-icons";
 import { Url } from "@zesty-io/core/Url";

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/PreviewUrl/PreviewUrl.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/PreviewUrl/PreviewUrl.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEye } from "@fortawesome/free-solid-svg-icons";
 import { Url } from "@zesty-io/core/Url";

--- a/src/apps/content-editor/src/app/views/ItemList/ItemList.js
+++ b/src/apps/content-editor/src/app/views/ItemList/ItemList.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, PureComponent } from "react";
+import { useRef, useState, useEffect, PureComponent } from "react";
 import { connect } from "react-redux";
 import { VariableSizeList as List } from "react-window";
 import { useHistory } from "react-router-dom";

--- a/src/apps/content-editor/src/app/views/ItemList/SetActions/SetActions.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetActions/SetActions.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import { Link } from "react-router-dom";
 import cx from "classnames";
 

--- a/src/apps/content-editor/src/app/views/ItemList/SetColumns/SetColumns.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetColumns/SetColumns.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/ColorCell/ColorCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/ColorCell/ColorCell.js
@@ -1,8 +1,8 @@
-import React from "react";
+import { memo } from "react";
 import cx from "classnames";
 
 import styles from "./ColorCell.less";
-export const ColorCell = React.memo(function ColorCell(props) {
+export const ColorCell = memo(function ColorCell(props) {
   return (
     <span
       style={{

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/DateCell/DateCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/DateCell/DateCell.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { memo } from "react";
 import cx from "classnames";
 import moment from "moment-timezone";
 
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCalendar } from "@fortawesome/free-solid-svg-icons";
 
 import styles from "./DateCell.less";
-export const DateCell = React.memo(function DateCell(props) {
+export const DateCell = memo(function DateCell(props) {
   if (props.value) {
     return (
       <span className={cx(props.className, styles.DateCell)}>

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/DropdownCell/DropdownCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/DropdownCell/DropdownCell.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { memo } from "react";
 
 import cx from "classnames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -6,7 +6,7 @@ import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { AppLink } from "@zesty-io/core/AppLink";
 
 import styles from "./DropdownCell.less";
-export const DropdownCell = React.memo(function DropdownCell(props) {
+export const DropdownCell = memo(function DropdownCell(props) {
   if (props.field.settings && props.field.settings.options) {
     return (
       <span className={cx(props.className, styles.DropdownCell)}>

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/FileCell/FileCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/FileCell/FileCell.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import cx from "classnames";
 
 import { request } from "utility/request";

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/ImageCell/ImageCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/ImageCell/ImageCell.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/InternalLinkCell/InternalLinkCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/InternalLinkCell/InternalLinkCell.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/LinkCell/LinkCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/LinkCell/LinkCell.js
@@ -1,4 +1,3 @@
-import React from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/OneToManyCell/OneToManyCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/OneToManyCell/OneToManyCell.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/OneToOneCell/OneToOneCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/OneToOneCell/OneToOneCell.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import { PureComponent } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/PublishStatusCell/PublishStatusCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/PublishStatusCell/PublishStatusCell.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { memo } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -8,7 +8,7 @@ import { Url } from "@zesty-io/core/Url";
 import { AppLink } from "@zesty-io/core/AppLink";
 
 import styles from "./PublishStatusCell.less";
-export const PublishStatusCell = React.memo(function PublishStatusCell(props) {
+export const PublishStatusCell = memo(function PublishStatusCell(props) {
   if (props.itemZUID.slice(0, 3) === "new") {
     return (
       <AppLink

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/SetRow.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/SetRow.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { useHistory } from "react-router-dom";
 import cx from "classnames";
 import { connect } from "react-redux";

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/SortCell/SortCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/SortCell/SortCell.js
@@ -1,10 +1,10 @@
-import React from "react";
+import { memo } from "react";
 import cx from "classnames";
 
 import { FieldTypeSort } from "@zesty-io/core/FieldTypeSort";
 
 import styles from "./SortCell.less";
-export const SortCell = React.memo(function SortCell(props) {
+export const SortCell = memo(function SortCell(props) {
   return (
     <span className={cx(props.className, styles.SortCell)}>
       <FieldTypeSort

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/TextCell/TextCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/TextCell/TextCell.js
@@ -1,9 +1,9 @@
-import React from "react";
+import { memo } from "react";
 import cx from "classnames";
 
 import styles from "./TextCell.less";
 
-export const TextCell = React.memo(function TextCell(props) {
+export const TextCell = memo(function TextCell(props) {
   return (
     <span className={cx(props.className, styles.TextCell)}>
       {props.value && props.value.substr(0, 160)}

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/ToggleCell/ToggleCell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/ToggleCell/ToggleCell.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { memo } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -7,7 +7,7 @@ import { ToggleButton } from "@zesty-io/core/ToggleButton";
 import { AppLink } from "@zesty-io/core/AppLink";
 
 import styles from "./ToggleCell.less";
-export const ToggleCell = React.memo(function ToggleCell(props) {
+export const ToggleCell = memo(function ToggleCell(props) {
   if (props.field.settings && props.field.settings.options) {
     let options = Object.values(props.field.settings.options);
 

--- a/src/apps/content-editor/src/app/views/ItemList/SetRow/WYSIWYGcell/WYSIWYGcell.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetRow/WYSIWYGcell/WYSIWYGcell.js
@@ -1,8 +1,8 @@
-import React from "react";
+import { memo } from "react";
 import cx from "classnames";
 
 import styles from "./WYSIWYGcell.less";
-export const WYSIWYGcell = React.memo(function WYSIWYGcell(props) {
+export const WYSIWYGcell = memo(function WYSIWYGcell(props) {
   const rawData = props.value;
   let elementFromData = document.createElement("div");
   elementFromData.innerHTML = rawData;

--- a/src/apps/content-editor/src/app/views/LinkCreate/LinkCreate.js
+++ b/src/apps/content-editor/src/app/views/LinkCreate/LinkCreate.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router";
 
@@ -132,20 +132,20 @@ export function LinkCreate() {
               className={styles.Icon}
               value="internal"
               component={
-                <React.Fragment>
+                <Fragment>
                   <FontAwesomeIcon icon={faLink} />
                   &nbsp;Internal Link
-                </React.Fragment>
+                </Fragment>
               }
             />
             <Option
               className={styles.Icon}
               value="external"
               component={
-                <React.Fragment>
+                <Fragment>
                   <FontAwesomeIcon icon={faExternalLinkSquareAlt} />
                   &nbsp;External Link
-                </React.Fragment>
+                </Fragment>
               }
             />
           </Select>

--- a/src/apps/content-editor/src/app/views/LinkEdit/LinkDeleteConfirmation.js
+++ b/src/apps/content-editor/src/app/views/LinkEdit/LinkDeleteConfirmation.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { useDispatch } from "react-redux";
 
 import { notify } from "shell/store/notifications";

--- a/src/apps/content-editor/src/app/views/LinkEdit/LinkEdit.js
+++ b/src/apps/content-editor/src/app/views/LinkEdit/LinkEdit.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/src/apps/content-editor/src/app/views/NotFound/NotFound.js
+++ b/src/apps/content-editor/src/app/views/NotFound/NotFound.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 // import cx from "classnames";
 
 import { Url } from "@zesty-io/core/Url";

--- a/src/apps/leads/src/app/components/LeadExporter/DownloadCSVButton/DownloadCSVButton.js
+++ b/src/apps/leads/src/app/components/LeadExporter/DownloadCSVButton/DownloadCSVButton.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import csvDownload from "json-to-csv-export";
 import * as moment from "moment";
 import { connect } from "react-redux";
@@ -16,7 +16,7 @@ export default connect((state) => {
     leads: state.leads,
   };
 })(
-  class DownloadCSVButton extends React.Component {
+  class DownloadCSVButton extends Component {
     constructor(props) {
       super(props);
       this.props = props;

--- a/src/apps/leads/src/app/components/LeadExporter/FormGroupSelector/FormGroupSelector.js
+++ b/src/apps/leads/src/app/components/LeadExporter/FormGroupSelector/FormGroupSelector.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import { connect } from "react-redux";
 
 import { FieldTypeDropDown } from "@zesty-io/core/FieldTypeDropDown";
@@ -12,7 +12,7 @@ export default connect((state) => {
     leads: state.leads,
   };
 })(
-  class DownloadCSVButton extends React.Component {
+  class DownloadCSVButton extends Component {
     constructor(props) {
       super(props);
 

--- a/src/apps/leads/src/app/components/LeadExporter/LeadExporter.js
+++ b/src/apps/leads/src/app/components/LeadExporter/LeadExporter.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { useDispatch } from "react-redux";
 import cx from "classnames";
 

--- a/src/apps/leads/src/app/components/LeadExporter/TableDateFilter/TableDateFilter.js
+++ b/src/apps/leads/src/app/components/LeadExporter/TableDateFilter/TableDateFilter.js
@@ -1,5 +1,5 @@
 import * as moment from "moment";
-import React from "react";
+import { Component } from "react";
 import { connect } from "react-redux";
 
 import { FieldTypeDate } from "@zesty-io/core/FieldTypeDate";
@@ -27,7 +27,7 @@ export default connect((state) => {
     filter: state.filter,
   };
 })(
-  class TableDateFilter extends React.Component {
+  class TableDateFilter extends Component {
     state = {
       endDate: this.props.endDate,
       startDate: this.props.startDate,

--- a/src/apps/leads/src/app/components/LeadsTable/LeadsTable.js
+++ b/src/apps/leads/src/app/components/LeadsTable/LeadsTable.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import { connect } from "react-redux";
 import { createBrowserHistory } from "history";
 
@@ -27,7 +27,7 @@ export default connect((state) => {
     leads,
   };
 })(
-  class LeadsTable extends React.Component {
+  class LeadsTable extends Component {
     history = createBrowserHistory();
 
     constructor(props) {

--- a/src/apps/leads/src/app/views/GetStarted/GetStarted.js
+++ b/src/apps/leads/src/app/views/GetStarted/GetStarted.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { connect } from "react-redux";
 import { Route } from "react-router-dom";
 

--- a/src/apps/leads/src/app/views/Leads/Leads.js
+++ b/src/apps/leads/src/app/views/Leads/Leads.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { connect } from "react-redux";
 import { Route } from "react-router-dom";
 

--- a/src/apps/media/src/app/MediaApp.js
+++ b/src/apps/media/src/app/MediaApp.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import cx from "classnames";
 import usePrevious from "react-use/lib/usePrevious";
 import { useHistory, useParams } from "react-router-dom";

--- a/src/apps/media/src/app/components/MediaCreateGroupModal.js
+++ b/src/apps/media/src/app/components/MediaCreateGroupModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";

--- a/src/apps/media/src/app/components/MediaDeleteFileModal.js
+++ b/src/apps/media/src/app/components/MediaDeleteFileModal.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { useDispatch } from "react-redux";
 import {
   Modal,

--- a/src/apps/media/src/app/components/MediaDeleteGroupModal.js
+++ b/src/apps/media/src/app/components/MediaDeleteGroupModal.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { useDispatch } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {

--- a/src/apps/media/src/app/components/MediaDetailsModal.js
+++ b/src/apps/media/src/app/components/MediaDetailsModal.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from "react";
+import { memo, useRef, useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import cx from "classnames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -23,7 +23,7 @@ import { editFile } from "shell/store/media";
 import shared from "./MediaShared.less";
 import styles from "./MediaDetailsModal.less";
 
-export const MediaDetailsModal = React.memo(function MediaDetailsModal(props) {
+export const MediaDetailsModal = memo(function MediaDetailsModal(props) {
   const dispatch = useDispatch();
   const platform = useSelector((state) => state.platform);
   const userRole = useSelector((state) => state.userRole);

--- a/src/apps/media/src/app/components/MediaEditGroupModal.js
+++ b/src/apps/media/src/app/components/MediaEditGroupModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSave } from "@fortawesome/free-solid-svg-icons";

--- a/src/apps/media/src/app/components/MediaHeader.js
+++ b/src/apps/media/src/app/components/MediaHeader.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, useState } from "react";
 import { useSelector } from "react-redux";
 import cx from "classnames";
 
@@ -11,7 +11,7 @@ import { MediaEditGroupModal } from "./MediaEditGroupModal";
 
 import styles from "./MediaHeader.less";
 
-export const MediaHeader = React.memo(function MediaHeader(props) {
+export const MediaHeader = memo(function MediaHeader(props) {
   const userRole = useSelector((state) => state.userRole);
   const [createGroupModal, setCreateGroupModal] = useState(false);
   const [editGroupModal, setEditGroupModal] = useState(false);

--- a/src/apps/media/src/app/components/MediaImage.js
+++ b/src/apps/media/src/app/components/MediaImage.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { forwardRef } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faFile,
@@ -16,7 +16,7 @@ import {
 import { fileExtension } from "../FileUtils";
 import styles from "./MediaImage.less";
 
-export const MediaImage = React.forwardRef(function MediaImage(props, ref) {
+export const MediaImage = forwardRef(function MediaImage(props, ref) {
   if (props.file.url.indexOf("blob:") !== -1) {
     return <img ref={ref} src={encodeURI(props.file.url)} />;
   }

--- a/src/apps/media/src/app/components/MediaNav.js
+++ b/src/apps/media/src/app/components/MediaNav.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { StickyTree } from "react-virtualized-sticky-tree";
 import Measure from "react-measure";
 

--- a/src/apps/media/src/app/components/MediaSelected.js
+++ b/src/apps/media/src/app/components/MediaSelected.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCheck,

--- a/src/apps/media/src/app/components/MediaSidebar.js
+++ b/src/apps/media/src/app/components/MediaSidebar.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useRef } from "react";
+import { memo, useCallback, useState, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -23,7 +23,7 @@ import shared from "./MediaShared.less";
 import styles from "./MediaSidebar.less";
 import { MediaNav } from "./MediaNav";
 
-export const MediaSidebar = React.memo(function MediaSidebar(props) {
+export const MediaSidebar = memo(function MediaSidebar(props) {
   const dispatch = useDispatch();
 
   const groups = useSelector((state) => state.media.groups);

--- a/src/apps/media/src/app/components/MediaWorkspace.js
+++ b/src/apps/media/src/app/components/MediaWorkspace.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from "react";
+import { memo, useCallback, useRef } from "react";
 import cx from "classnames";
 import { createSelector } from "reselect";
 import { useDispatch, useSelector } from "react-redux";
@@ -22,7 +22,7 @@ const selectGroupFiles = createSelector(
     files.filter((file) => file.group_id === currentGroup.id).reverse()
 );
 
-export const MediaWorkspace = React.memo(function MediaWorkspace(props) {
+export const MediaWorkspace = memo(function MediaWorkspace(props) {
   const ref = useRef();
   const hiddenInputRef = useRef();
   const search = useSelector((state) => state.media.search);

--- a/src/apps/media/src/app/components/MediaWorkspaceItem.js
+++ b/src/apps/media/src/app/components/MediaWorkspaceItem.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import { memo, useCallback, useState } from "react";
 import cx from "classnames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheck, faCog } from "@fortawesome/free-solid-svg-icons";
@@ -11,9 +11,7 @@ import styles from "./MediaWorkspaceItem.less";
 import shared from "./MediaShared.less";
 import { isImage } from "../FileUtils";
 
-export const MediaWorkspaceItem = React.memo(function MediaWorkspaceItem(
-  props
-) {
+export const MediaWorkspaceItem = memo(function MediaWorkspaceItem(props) {
   const [lazyLoading, setLazyLoading] = useState(false);
   function handleIntersection(event) {
     if (event.isIntersecting) {

--- a/src/apps/media/src/app/components/NavDraggable/NavDraggable/NavDraggable.js
+++ b/src/apps/media/src/app/components/NavDraggable/NavDraggable/NavDraggable.js
@@ -1,11 +1,11 @@
-import React, { useCallback, useState } from "react";
+import { memo, useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
 import cx from "classnames";
 import { NodeDraggableMemo } from "../NodeDraggable";
 import styles from "./NavDraggable.less";
 import { editFile, editGroup, highlightGroup } from "shell/store/media";
 
-export const NavDraggable = React.memo(function NavDraggable(props) {
+export const NavDraggable = memo(function NavDraggable(props) {
   const dispatch = useDispatch();
   const [prevID, setPrevID] = useState();
 

--- a/src/apps/media/src/app/components/NavDraggable/NodeDraggable/NodeDraggable.js
+++ b/src/apps/media/src/app/components/NavDraggable/NodeDraggable/NodeDraggable.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from "react";
+import { memo, useCallback, useRef } from "react";
 import { Link } from "react-router-dom";
 import cx from "classnames";
 import { useDrag, useDrop } from "react-dnd";
@@ -26,7 +26,7 @@ function find(id, items) {
   return false;
 }
 
-export const NodeDraggableMemo = React.memo(function NodeDraggable(props) {
+export const NodeDraggableMemo = memo(function NodeDraggable(props) {
   const depth = props.depth + 1 || 1;
   const collapseNode = useCallback(
     () => props.collapseNode(props.id),

--- a/src/apps/media/src/app/components/NavDraggable/ParentDraggable/ParentDraggable.js
+++ b/src/apps/media/src/app/components/NavDraggable/ParentDraggable/ParentDraggable.js
@@ -1,10 +1,10 @@
-import React, { useRef } from "react";
+import { memo, useRef } from "react";
 import { useDrag, useDrop } from "react-dnd";
 import omit from "lodash/omit";
 import { NodeDraggable } from "../NodeDraggable";
 import styles from "./ParentDraggable.less";
 
-export const ParentDraggable = React.memo(function ParentDraggable(props) {
+export const ParentDraggable = memo(function ParentDraggable(props) {
   // track recursion depth and pass it as a prop to the node component
   const depth = props.depth + 1 || 1;
   const ref = useRef(null);

--- a/src/apps/media/src/index.js
+++ b/src/apps/media/src/index.js
@@ -1,4 +1,3 @@
-import React from "react";
 import MediaApp from "./app/MediaApp";
 
 export default function DamApp(props) {

--- a/src/apps/publish/src/app/PublishApp.js
+++ b/src/apps/publish/src/app/PublishApp.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import cx from "classnames";
 import { fetchVersions } from "shell/store/contentVersions";

--- a/src/apps/publish/src/app/components/Completed/Completed.js
+++ b/src/apps/publish/src/app/components/Completed/Completed.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 import { useDispatch } from "react-redux";
 import { resetPlan } from "shell/store/publishPlan";
 import { Button } from "@zesty-io/core/Button";

--- a/src/apps/publish/src/app/components/Header/Header.js
+++ b/src/apps/publish/src/app/components/Header/Header.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 import { useDispatch } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCloudUploadAlt, faSpinner } from "@fortawesome/free-solid-svg-icons";

--- a/src/apps/publish/src/app/components/PlanStep/PlanStep.js
+++ b/src/apps/publish/src/app/components/PlanStep/PlanStep.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import cx from "classnames";
 import moment from "moment-timezone";

--- a/src/apps/publish/src/app/components/PlanTable/PlanTable.js
+++ b/src/apps/publish/src/app/components/PlanTable/PlanTable.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { useSelector } from "react-redux";
 import { PlanStep } from "../PlanStep";
 import styles from "./PlanTable.less";

--- a/src/apps/publish/src/app/components/Start/Start.js
+++ b/src/apps/publish/src/app/components/Start/Start.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import styles from "./Start.less";
 export function Start(props) {
   return (

--- a/src/apps/schema/src/app/components/Nav/SchemaNav.js
+++ b/src/apps/schema/src/app/components/Nav/SchemaNav.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import cx from "classnames";
 

--- a/src/apps/schema/src/app/components/Wizard/Wizard.js
+++ b/src/apps/schema/src/app/components/Wizard/Wizard.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState, useEffect } from "react";
+import { Fragment, useState, useEffect } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/schema/src/app/components/Wizard/components/WizardStep/WizardStep.js
+++ b/src/apps/schema/src/app/components/Wizard/components/WizardStep/WizardStep.js
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "./WizardStep.less";
 
 export function WizardStep(props) {

--- a/src/apps/schema/src/app/main.js
+++ b/src/apps/schema/src/app/main.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { connect } from "react-redux";
 import { Switch, Route, useRouteMatch } from "react-router-dom";
 

--- a/src/apps/schema/src/app/views/GettingStarted/GettingStarted.js
+++ b/src/apps/schema/src/app/views/GettingStarted/GettingStarted.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { connect } from "react-redux";
 import { notify } from "shell/store/notifications";
 

--- a/src/apps/schema/src/app/views/GettingStarted/components/FieldName/FieldName.js
+++ b/src/apps/schema/src/app/views/GettingStarted/components/FieldName/FieldName.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { FieldTypeText } from "@zesty-io/core/FieldTypeText";
 
 import styles from "./FieldName.less";

--- a/src/apps/schema/src/app/views/GettingStarted/components/FieldSuccess/FieldSuccess.js
+++ b/src/apps/schema/src/app/views/GettingStarted/components/FieldSuccess/FieldSuccess.js
@@ -1,4 +1,3 @@
-import React from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/schema/src/app/views/GettingStarted/components/FieldType/FieldType.js
+++ b/src/apps/schema/src/app/views/GettingStarted/components/FieldType/FieldType.js
@@ -1,4 +1,3 @@
-import React from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/schema/src/app/views/GettingStarted/components/ModelName/ModelName.js
+++ b/src/apps/schema/src/app/views/GettingStarted/components/ModelName/ModelName.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { FieldTypeText } from "@zesty-io/core/FieldTypeText";
 
 import styles from "./ModelName.less";

--- a/src/apps/schema/src/app/views/GettingStarted/components/ModelType/ModelType.js
+++ b/src/apps/schema/src/app/views/GettingStarted/components/ModelType/ModelType.js
@@ -1,4 +1,3 @@
-import React from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/schema/src/app/views/SchemaCreate/SchemaCreate.js
+++ b/src/apps/schema/src/app/views/SchemaCreate/SchemaCreate.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useReducer } from "react";
+import { Fragment, useState, useEffect, useReducer } from "react";
 import { connect } from "react-redux";
 import { useHistory } from "react-router-dom";
 import cx from "classnames";
@@ -29,29 +29,29 @@ const SCHEMA_TYPES = [
   {
     value: "templateset",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faFile} />
         &nbsp;Single Page Model
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "pageset",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faListAlt} />
         &nbsp;Multi Page Model
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "dataset",
 
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faDatabase} />
         &nbsp;Headless Data Model
-      </React.Fragment>
+      </Fragment>
     ),
   },
 ];

--- a/src/apps/schema/src/app/views/SchemaEdit/Draggable/Draggable.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/Draggable/Draggable.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import { Children, cloneElement, useRef } from "react";
 
 // import styles from "./Draggable.less";
 export function Draggable(props) {
@@ -14,8 +14,8 @@ export function Draggable(props) {
         props.onOver(props.index);
       }}
     >
-      {React.Children.map(props.children, (child) =>
-        React.cloneElement(child, {
+      {Children.map(props.children, (child) =>
+        cloneElement(child, {
           onDragStart: (evt) => {
             props.drag(props.index);
 

--- a/src/apps/schema/src/app/views/SchemaEdit/Dropzone/Dropzone.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/Dropzone/Dropzone.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { Children, cloneElement, useState, useEffect } from "react";
 import cx from "classnames";
 
 import styles from "./Dropzone.less";
@@ -19,13 +19,11 @@ export function Dropzone(props) {
    * to describe what happens when the children are sorted.
    */
 
-  const [children, setChildren] = useState(
-    React.Children.toArray(props.children)
-  );
+  const [children, setChildren] = useState(Children.toArray(props.children));
 
   // Update state when props change
   useEffect(
-    () => setChildren(React.Children.toArray(props.children)),
+    () => setChildren(Children.toArray(props.children)),
     [props.children]
   );
 
@@ -39,7 +37,7 @@ export function Dropzone(props) {
   const onDragEnd = (evt) => {
     // Reset
     setSourceIndex(null);
-    setChildren(React.Children.toArray(props.children));
+    setChildren(Children.toArray(props.children));
   };
 
   const onDragEnter = (evt) => {
@@ -75,7 +73,7 @@ export function Dropzone(props) {
       onDrop={onDrop}
     >
       {children.map((child, index) => {
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           index,
           onOver,
           drag: setSourceIndex,

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldAdd/FieldAdd.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldAdd/FieldAdd.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { Fragment, useState } from "react";
 import { useHistory } from "react-router-dom";
 import cx from "classnames";
 
@@ -114,7 +114,7 @@ export function FieldAdd(props) {
         {/* <div className={styles.description}>{fieldType.description}</div> */}
 
         {field.datatype == 0 && (
-          <React.Fragment>
+          <Fragment>
             {props.firstField && (
               <div className={styles.AlignHeader}>
                 <FontAwesomeIcon icon={faHandPointUp} />
@@ -135,7 +135,7 @@ export function FieldAdd(props) {
                 &nbsp;Learn more about fields and their types.
               </Url>
             </p>
-          </React.Fragment>
+          </Fragment>
         )}
 
         {field.datatype != 0 && (

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldEdit/FieldEdit.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldEdit/FieldEdit.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useHistory } from "react-router-dom";
 import cx from "classnames";
 import { connect } from "react-redux";

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/DropdownOptions/DropdownOptions.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/DropdownOptions/DropdownOptions.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrash, faPlus } from "@fortawesome/free-solid-svg-icons";

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/FieldSettings.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/FieldSettings.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Fragment } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -153,78 +153,78 @@ export const FIELD_TYPES = [
   {
     value: "text",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faParagraph} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: (
-      <React.Fragment>
+      <Fragment>
         <p>
           Text fields are limited to 150 characters and are useful for short
           content.
         </p>
         <em>e.g. Titles</em>
-      </React.Fragment>
+      </Fragment>
     ),
     title: "Text",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faParagraph} />
         &nbsp;Text
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "textarea",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faParagraph} />
-      </React.Fragment>
+      </Fragment>
     ),
     description:
       "Textarea fields are useful for unstructured large chunks of text. They provide more character length than a text field but exclude the styling control of a WYSIWYG field. Textarea content is stored raw without going through any processing.",
     title: "Textarea",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faParagraph} />
         &nbsp;TextArea
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "wysiwyg_basic",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faParagraph} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: (
-      <React.Fragment>
+      <Fragment>
         <p>
           <abbr title="What You See Is What You Get">WYSIWYG</abbr> fields allow
           an editor styling and structuring of their content. This field type is
           also able to be viewed as a Markdown, Inline or HTML editor, giving
           authors control over their experience.
         </p>
-      </React.Fragment>
+      </Fragment>
     ),
     title: "WYSIWYG",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faParagraph} />
         &nbsp;WYSIWYG
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "markdown",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faParagraph} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: (
-      <React.Fragment>
+      <Fragment>
         <p>
           Markdown fields provide an editor that allows using{" "}
           <Url
@@ -238,238 +238,238 @@ export const FIELD_TYPES = [
           able to be viewed as a WYSIWYG, Inline or HTML editor. Giving authors
           control over their experience.
         </p>
-      </React.Fragment>
+      </Fragment>
     ),
     title: "Markdown",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faParagraph} />
         &nbsp;Markdown
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "article_writer",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faParagraph} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: (
-      <React.Fragment>
+      <Fragment>
         <p>
           Article Writer fields provide an inline editor that allows a subset of
           styling and structuring elements. This field type is also able to be
           viewed as a Markdown, Inline or HTML editor. Giving authors control
           over their experience.
         </p>
-      </React.Fragment>
+      </Fragment>
     ),
     title: "Article Writer",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faParagraph} />
         &nbsp;Article Writer
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "images",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faImages} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: (
-      <React.Fragment>
+      <Fragment>
         <p>
           Media fields allow the selection of media from this instances
           available media assets. This field can have a limit on how many assets
           can be selected as well as can be locked to a specific group from the
           media app.
         </p>
-      </React.Fragment>
+      </Fragment>
     ),
     title: "Media",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faImages} />
         &nbsp;Media
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "date",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faCalendar} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: (
-      <React.Fragment>
+      <Fragment>
         <p>
           Date fields allow authors to select a date that will be guaranteed to
           be in a structured format.
         </p>
-      </React.Fragment>
+      </Fragment>
     ),
     title: "Date",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faCalendar} />
         &nbsp;Date
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "datetime",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faCalendarAlt} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: (
-      <React.Fragment>
+      <Fragment>
         <p>
           Date &amp; Time fields allow authors to select a date and time that
           will be guaranteed to be in a structured format.
         </p>
-      </React.Fragment>
+      </Fragment>
     ),
     title: "Date & Time",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faCalendarAlt} />
         &nbsp;Date &amp; Time
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "dropdown",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faList} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: (
-      <React.Fragment>
+      <Fragment>
         <p>
           Dropdown fields offer the ability to provide a pre-defined set of
           options for authors to select from.
         </p>
-      </React.Fragment>
+      </Fragment>
     ),
     title: "Dropdown",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faList} />
         &nbsp;Dropdown
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "one_to_one",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faArrowsAltH} />
-      </React.Fragment>
+      </Fragment>
     ),
     description:
       "One to one relationships allow content editors to connect another models content to this one by selecting the other item based upon one of it's fields. This provides the ability to resolve this relationship within a template or the SDK and gain access to the related item data.",
     title: "Related: One to One",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faArrowsAltH} />
         &nbsp;Related: One to One
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "one_to_many",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faSitemap} />
-      </React.Fragment>
+      </Fragment>
     ),
     description:
       "Many to one relationships allows content editors to connect many items from another model to this one by selecting the other items based upon one of their fields. This provides the ability to resolve the relationships within a template or the SDK and gain access to the related items data.",
     title: "Related: Many to One",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faSitemap} />
         &nbsp;Related: Many to one
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "link",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faExternalLinkAlt} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: (
-      <React.Fragment>
+      <Fragment>
         <p>
           External URL fields provide content authors an input allowing for
           external domain urls.
         </p>
-      </React.Fragment>
+      </Fragment>
     ),
     title: "External URL",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faExternalLinkAlt} />
         &nbsp;External URL
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "internal_link",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faLink} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: (
-      <React.Fragment>
+      <Fragment>
         <p>
           Internal Link fields allow for the selection of an internal instance
           item from any schema. This can be useful for providing authors the
           ability to relate an item across an instance.
         </p>
-      </React.Fragment>
+      </Fragment>
     ),
     title: "Internal Link",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faLink} />
         &nbsp;Internal Link
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "yes_no",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faToggleOn} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: "",
     title: "Toggle",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faToggleOn} />
         &nbsp;Toggle
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "number",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <i>+0</i>
-      </React.Fragment>
+      </Fragment>
     ),
     description: "",
     title: "Number",
@@ -478,65 +478,65 @@ export const FIELD_TYPES = [
   {
     value: "color",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faPalette} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: "",
     title: "Color",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faPalette} />
         &nbsp;Color
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "sort",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faSortNumericUp} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: "",
     title: "Sort",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faSortNumericUp} />
         &nbsp;Sort
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "currency",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faMoneyBillAlt} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: "",
     title: "Currency",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faMoneyBillAlt} />
         &nbsp;Currency
-      </React.Fragment>
+      </Fragment>
     ),
   },
   {
     value: "uuid",
     icon: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faIdCard} />
-      </React.Fragment>
+      </Fragment>
     ),
     description: "",
     title: "UUID",
     component: (
-      <React.Fragment>
+      <Fragment>
         <FontAwesomeIcon icon={faIdCard} />
         &nbsp;UUID
-      </React.Fragment>
+      </Fragment>
     ),
   },
 ];

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/ImageOptions/ImageOptions.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/ImageOptions/ImageOptions.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { connect } from "react-redux";
 
 import { FieldTypeNumber } from "@zesty-io/core/FieldTypeNumber";

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/RelatedOptions/RelatedOptions.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/RelatedOptions/RelatedOptions.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { connect } from "react-redux";
 
 import { FieldTypeDropDown } from "@zesty-io/core/FieldTypeDropDown";

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/ToggleOptions/ToggleOptions.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/ToggleOptions/ToggleOptions.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { FieldTypeText } from "@zesty-io/core/FieldTypeText";
 

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaEdit.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaEdit.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { connect } from "react-redux";
 import cx from "classnames";
 

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/AuditTrail/AuditTrail.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/AuditTrail/AuditTrail.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { Card, CardHeader, CardContent, CardFooter } from "@zesty-io/core/Card";

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Delete/Delete.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Delete/Delete.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { Fragment, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -33,10 +33,10 @@ export default function Delete(props) {
 
 function Header() {
   return (
-    <React.Fragment>
+    <Fragment>
       <FontAwesomeIcon icon={faTrash} />
       &nbsp;Delete Model
-    </React.Fragment>
+    </Fragment>
   );
 }
 
@@ -45,7 +45,7 @@ function Footer(props) {
   const history = useHistory();
 
   return (
-    <React.Fragment>
+    <Fragment>
       <CardFooter>
         <Button kind="warn" onClick={() => setIsOpen(true)}>
           <FontAwesomeIcon icon={faTrash} />
@@ -92,6 +92,6 @@ function Footer(props) {
           Cancel
         </Button>
       </ConfirmDialog>
-    </React.Fragment>
+    </Fragment>
   );
 }

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Info/Info.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Info/Info.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { connect } from "react-redux";
 import { useFilePath } from "shell/hooks/useFilePath";
 

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/SchemaMeta.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/SchemaMeta.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { Info } from "./Info";
 import { Settings } from "./Settings";
 import { Delete } from "./Delete";

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Settings/Parent/Parent.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Settings/Parent/Parent.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { connect } from "react-redux";
 
 import { FieldTypeDropDown } from "@zesty-io/core/FieldTypeDropDown";

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Settings/Settings.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Settings/Settings.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { Fragment, useState } from "react";
 import { useHistory } from "react-router-dom";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -103,10 +103,10 @@ export default function Settings(props) {
 
 function Header(props) {
   return (
-    <React.Fragment>
+    <Fragment>
       <FontAwesomeIcon icon={faCog} />
       &nbsp;Model Settings
-    </React.Fragment>
+    </Fragment>
   );
 }
 

--- a/src/apps/schema/src/index.js
+++ b/src/apps/schema/src/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { connect } from "react-redux";
 
 import { WithLoader } from "@zesty-io/core/WithLoader";

--- a/src/apps/seo/src/app/index.js
+++ b/src/apps/seo/src/app/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import { Switch, Route, Link } from "react-router-dom";
 import { connect } from "react-redux";
 

--- a/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectActions.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectActions.js
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "./RedirectActions.less";
 
 import { RedirectFilter } from "./RedirectFilter";

--- a/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectFilter/RedirectFilter.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectFilter/RedirectFilter.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { Search } from "@zesty-io/core/Search";
 

--- a/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectsImport/RedirectsImport.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectsImport/RedirectsImport.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUpload } from "@fortawesome/free-solid-svg-icons";
 import { Button } from "@zesty-io/core/Button";

--- a/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/ImportTableRowDisabled/ImportTableRowDisabled.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/ImportTableRowDisabled/ImportTableRowDisabled.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { ToggleButton } from "@zesty-io/core/ToggleButton";
 
 import styles from "./ImportTableRowDisabled.less";

--- a/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTable.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTable.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -12,7 +12,7 @@ import ImportTableRowDisabled from "./ImportTableRowDisabled";
 import { createRedirect } from "../../../store/redirects";
 import { cancelImports } from "../../../store/imports";
 
-export default class RedirectImportTable extends React.Component {
+export default class RedirectImportTable extends Component {
   constructor(props) {
     super(props);
 

--- a/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTableRow/RedirectImportTableRow.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTableRow/RedirectImportTableRow.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import styles from "./RedirectImportTableRow.less";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -13,7 +13,7 @@ import { createRedirect } from "../../../../store/redirects";
 import { importTarget } from "../../../../store/imports";
 import { importQuery } from "../../../../store/imports";
 
-export default class RedirectImportTableRow extends React.Component {
+export default class RedirectImportTableRow extends Component {
   constructor(props) {
     super(props);
 

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsManager.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsManager.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { WithLoader } from "@zesty-io/core/WithLoader";
 

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import styles from "./RedirectTable.less";
 import cx from "classnames";
 
@@ -8,7 +8,7 @@ import { RedirectCreator } from "./RedirectCreator";
 import RedirectsTableHeader from "./RedirectsTableHeader";
 import RedirectsTableRow from "./RedirectsTableRow";
 
-export default class RedirectTable extends React.Component {
+export default class RedirectTable extends Component {
   constructor(props) {
     super(props);
 

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.js
@@ -1,4 +1,3 @@
-import React from "react";
 import cx from "classnames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableRow/RedirectsTableRow.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableRow/RedirectsTableRow.js
@@ -1,4 +1,3 @@
-import React from "react";
 import cx from "classnames";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/settings/src/app/App.js
+++ b/src/apps/settings/src/app/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { Switch, Route, Redirect } from "react-router-dom";
 import { connect } from "react-redux";
 

--- a/src/apps/settings/src/app/components/Nav/SettingsNav.js
+++ b/src/apps/settings/src/app/components/Nav/SettingsNav.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { connect } from "react-redux";
 import { useLocation } from "react-router";
 import { faCog, faFont } from "@fortawesome/free-solid-svg-icons";

--- a/src/apps/settings/src/app/views/Fonts/Browse.js
+++ b/src/apps/settings/src/app/views/Fonts/Browse.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { connect } from "react-redux";
 import debounce from "lodash/debounce";
 

--- a/src/apps/settings/src/app/views/Fonts/Installed.js
+++ b/src/apps/settings/src/app/views/Fonts/Installed.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/settings/src/app/views/Instance/Instance.js
+++ b/src/apps/settings/src/app/views/Instance/Instance.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/apps/settings/src/app/views/Robots/Robots.js
+++ b/src/apps/settings/src/app/views/Robots/Robots.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import cx from "classnames";
 import { connect } from "react-redux";
 import { useDomain } from "shell/hooks/use-domain";

--- a/src/apps/settings/src/app/views/Styles/Styles.js
+++ b/src/apps/settings/src/app/views/Styles/Styles.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/shell/components/AppError/AppError.js
+++ b/src/shell/components/AppError/AppError.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -1,4 +1,12 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import {
+  forwardRef,
+  createRef,
+  Fragment,
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+} from "react";
 import { connect, useDispatch } from "react-redux";
 import moment from "moment-timezone";
 import debounce from "lodash/debounce";
@@ -27,7 +35,7 @@ import { searchItems } from "shell/store/content";
 import { notify } from "shell/store/notifications";
 
 import styles from "./styles.less";
-export default React.forwardRef((props, providedRef) => {
+export default forwardRef((props, providedRef) => {
   const dispatch = useDispatch();
 
   const [term, setTerm] = useState(props.value);
@@ -52,7 +60,7 @@ export default React.forwardRef((props, providedRef) => {
               if (props.filterResults) {
                 results = props.filterResults(results);
               }
-              setRefs(results.map(() => React.createRef()));
+              setRefs(results.map(() => createRef()));
               setSearchResults(results);
             } else {
               dispatch(
@@ -346,15 +354,15 @@ const ListOption = (props) => {
       <p className={styles.ItemName}>
         <span className={styles.subheadline}>
           {props.opt?.web?.metaTitle ? (
-            <React.Fragment>
+            <Fragment>
               {modelIcon}
               {props.opt.web.metaTitle}
-            </React.Fragment>
+            </Fragment>
           ) : (
-            <React.Fragment>
+            <Fragment>
               <FontAwesomeIcon icon={faExclamationTriangle} /> Item missing meta
               title
-            </React.Fragment>
+            </Fragment>
           )}
         </span>
 

--- a/src/shell/components/GlobalHelpMenu/GlobalHelpMenu.js
+++ b/src/shell/components/GlobalHelpMenu/GlobalHelpMenu.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import cx from "classnames";
 import { connect } from "react-redux";
 

--- a/src/shell/components/GlobalTopbar/GlobalTopbar.js
+++ b/src/shell/components/GlobalTopbar/GlobalTopbar.js
@@ -1,4 +1,3 @@
-import React from "react";
 import GlobalSearch from "shell/components/global-search";
 import GlobalAccount from "shell/components/global-account";
 import GlobalInstance from "shell/components/global-instance";

--- a/src/shell/components/Head/Head.js
+++ b/src/shell/components/Head/Head.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { connect } from "react-redux";
 import cx from "classnames";
 

--- a/src/shell/components/Head/HeadTag/HeadTag.js
+++ b/src/shell/components/Head/HeadTag/HeadTag.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { notify } from "shell/store/notifications";
 

--- a/src/shell/components/Head/Preview/Preview.js
+++ b/src/shell/components/Head/Preview/Preview.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import styles from "./Preview.less";
 export const Preview = (props) => (
   <aside className={styles.TagPreviewWrap}>

--- a/src/shell/components/NotFound/NotFound.js
+++ b/src/shell/components/NotFound/NotFound.js
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "./NotFound.less";
 
 export default function NotFound(props) {

--- a/src/shell/components/favicon/favicon.js
+++ b/src/shell/components/favicon/favicon.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/shell/components/global-account/GlobalAccount.js
+++ b/src/shell/components/global-account/GlobalAccount.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { connect } from "react-redux";
 import cx from "classnames";
 

--- a/src/shell/components/global-actions/components/ActivePreview/ActivePreview.js
+++ b/src/shell/components/global-actions/components/ActivePreview/ActivePreview.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { connect } from "react-redux";
 

--- a/src/shell/components/global-actions/index.js
+++ b/src/shell/components/global-actions/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, useState } from "react";
 import useOnclickOutside from "react-cool-onclickoutside";
 import cx from "classnames";
 
@@ -8,7 +8,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faBook,
   faHashtag,
-  faQuestion
+  faQuestion,
 } from "@fortawesome/free-solid-svg-icons";
 
 import { Url } from "@zesty-io/core/Url";
@@ -17,7 +17,7 @@ import GlobalHelpMenu from "shell/components/GlobalHelpMenu";
 import { ActivePreview } from "./components/ActivePreview";
 
 import styles from "./styles.less";
-export default React.memo(function GlobalActions(props) {
+export default memo(function GlobalActions(props) {
   const dispatch = useDispatch();
   const openNav = useSelector((state) => state.ui.openNav);
   const [openMenu, setOpenMenu] = useState(false);

--- a/src/shell/components/global-instance/GlobalInstance.js
+++ b/src/shell/components/global-instance/GlobalInstance.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import cx from "classnames";
 import { useSelector } from "react-redux";
 import { usePermission } from "shell/hooks/use-permissions";

--- a/src/shell/components/global-menu/index.js
+++ b/src/shell/components/global-menu/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { memo } from "react";
 import { connect } from "react-redux";
 import { useLocation } from "react-router-dom";
 import { Link } from "react-router-dom";
@@ -23,7 +23,7 @@ export default connect((state) => {
     products: state.products,
   };
 })(
-  React.memo(function GlobalMenu(props) {
+  memo(function GlobalMenu(props) {
     const location = useLocation();
     const slug = location.pathname.split("/")[1];
     const icons = {

--- a/src/shell/components/global-notifications/GlobalNotifications.js
+++ b/src/shell/components/global-notifications/GlobalNotifications.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { memo, useState, useEffect } from "react";
 import { connect } from "react-redux";
 import moment from "moment-timezone";
 import cx from "classnames";
@@ -21,7 +21,7 @@ export default connect((state) => {
     notifications: state.notifications,
   };
 })(
-  React.memo(function GlobalNotifications(props) {
+  memo(function GlobalNotifications(props) {
     const [initialRender, setInitialRender] = useState(true);
     const [drawerOpen, setDrawerOpen] = useState(false);
     const [showToast, setShowToast] = useState(false);

--- a/src/shell/components/global-search/index.js
+++ b/src/shell/components/global-search/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useRef } from "react";
+import { useEffect, useCallback, useRef } from "react";
 import { connect } from "react-redux";
 import { useHistory } from "react-router-dom";
 

--- a/src/shell/components/global-sidebar/GlobalSidebar.js
+++ b/src/shell/components/global-sidebar/GlobalSidebar.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { connect } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {

--- a/src/shell/components/global-tabs/GlobalTabs.js
+++ b/src/shell/components/global-tabs/GlobalTabs.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 import cx from "classnames";
@@ -18,7 +18,7 @@ const MAX_TAB_WIDTH = 200;
 const TAB_PADDING = 16;
 const TAB_BORDER = 1;
 
-export default React.memo(function GlobalTabs() {
+export default memo(function GlobalTabs() {
   const history = useHistory();
   const dispatch = useDispatch();
   const tabs = useSelector((state) => state.ui.tabs);

--- a/src/shell/components/global-tabs/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/shell/components/global-tabs/components/Breadcrumbs/Breadcrumbs.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { memo, useMemo } from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -44,7 +44,7 @@ export default connect((state) => {
     models: state.models,
   };
 })(
-  React.memo(function Breadcrumbs(props) {
+  memo(function Breadcrumbs(props) {
     const trail = useMemo(() => {
       const normalizedNav = props.navContent.raw.reduce((acc, item) => {
         acc[item.ZUID] = item;

--- a/src/shell/components/load-instance/index.js
+++ b/src/shell/components/load-instance/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { connect } from "react-redux";
 
 import { WithLoader } from "@zesty-io/core/WithLoader";
@@ -27,10 +27,10 @@ export default connect((state) => {
     user: state.user,
     products: state.products,
     languages: state.languages,
-    files: state.files
+    files: state.files,
   };
 })(
-  React.memo(function LoadInstance(props) {
+  memo(function LoadInstance(props) {
     const [error, setError] = useState("");
     useEffect(() => {
       props

--- a/src/shell/components/login/Login.js
+++ b/src/shell/components/login/Login.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { memo, useState } from "react";
 import { connect } from "react-redux";
 import cx from "classnames";
 
@@ -26,7 +26,7 @@ export default connect((state) => {
     user: state.user,
   };
 })(
-  React.memo(function Login(props) {
+  memo(function Login(props) {
     const [loading, setLoading] = useState(false);
     const [twoFactor, setTwoFactor] = useState(false);
     const [error, setError] = useState("");

--- a/src/shell/components/missing/index.js
+++ b/src/shell/components/missing/index.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { connect } from "react-redux";
 
 import { Url } from "@zesty-io/core/Url";

--- a/src/shell/components/private-route/index.js
+++ b/src/shell/components/private-route/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { memo, useEffect } from "react";
 import { connect } from "react-redux";
 
 import { WithLoader } from "@zesty-io/core/WithLoader";
@@ -13,7 +13,7 @@ export default connect((state) => {
     auth: state.auth,
   };
 })(
-  React.memo(function PrivateRoute(props) {
+  memo(function PrivateRoute(props) {
     useEffect(() => {
       const checkSession = () => {
         props.dispatch(verify()).catch(() => {

--- a/src/shell/components/welcome/index.js
+++ b/src/shell/components/welcome/index.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { connect } from "react-redux";
 
 export default connect()(function Welcome() {

--- a/src/shell/index.js
+++ b/src/shell/index.js
@@ -2,9 +2,7 @@
 // must be setup before starting the store
 window.CONFIG = __CONFIG__;
 
-// import "./wdyr";
-
-import React, { StrictMode } from "react";
+import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { Router } from "react-router-dom";

--- a/src/shell/views/Shell/Shell.js
+++ b/src/shell/views/Shell/Shell.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { memo, useState, useEffect } from "react";
 import { Switch, Route, Redirect } from "react-router-dom";
 import { connect } from "react-redux";
 import { Sentry } from "utility/sentry";
@@ -30,7 +30,7 @@ export default connect((state) => {
     products: state.products,
   };
 })(
-  React.memo(function Shell(props) {
+  memo(function Shell(props) {
     const dispatch = useDispatch();
     const openNav = useSelector((state) => state.ui.openNav);
 

--- a/src/shell/wdyr.js
+++ b/src/shell/wdyr.js
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 
 if (process.env.NODE_ENV === "development") {
   const whyDidYouRender = require("@welldone-software/why-did-you-render");

--- a/src/shell/webpack.config.js
+++ b/src/shell/webpack.config.js
@@ -208,7 +208,10 @@ module.exports = async (env) => {
             options: {
               cacheCompression: false,
               cacheDirectory: true,
-              presets: ["@babel/preset-env", "@babel/preset-react"],
+              presets: [
+                "@babel/preset-env",
+                ["@babel/preset-react", { runtime: "automatic" }],
+              ],
               plugins: ["@babel/plugin-transform-runtime"],
             },
           },


### PR DESCRIPTION
Implements new preferred style for babel jsx import. 
Upgrade instructions here: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
comes with a codemod script that updates all the old import statements and prefers destructed imports on React.