### PR TITLE
fixing nav heights for code, schema, settings, media

### DIFF
--- a/src/apps/code-editor/src/app/components/FileList/FileList.less
+++ b/src/apps/code-editor/src/app/components/FileList/FileList.less
@@ -1,7 +1,7 @@
 @import "~@zesty-io/core/colors.less";
 
 .FileList {
-  background: #404759;
+  background: @nav-background-color;
   margin: 0;
   padding: 0;
 
@@ -46,20 +46,21 @@
 
   .Title {
     align-items: center;
-    background-color: #5b667d;
+    background-color: @zesty-grey;
     display: flex;
     padding: 12px 12px 4px 12px;
 
     h1 {
-      color: #c3cddf;
+      color: @zesty-light-blue;
       text-transform: uppercase;
       margin-right: auto;
     }
   }
 
   .List {
-    background: #404759;
-    height: calc(100vh - 54px - 57px);
+    background: @nav-background-color;
+    // 100vh - GlobalTopbar - NavActions
+    height: calc(100vh - 54px - 106px);
     margin: 0;
     overflow-x: hidden;
     padding: 0;

--- a/src/apps/media/src/app/components/MediaSidebar.less
+++ b/src/apps/media/src/app/components/MediaSidebar.less
@@ -47,7 +47,7 @@
 }
 
 @global-top-bar-height: 54px;
-@media-sidebar-top-nav-height: 102px;
+@media-sidebar-top-nav-height: 106px;
 @hidden-nav-height: 26px;
 @hidden-nav-full-height: 300px;
 @hidden-nav-expanded-height: @hidden-nav-height + @hidden-nav-full-height;
@@ -59,11 +59,6 @@
     100vh - @global-top-bar-height - @media-sidebar-top-nav-height -
       @hidden-nav-height
   );
-  @media only screen and (min-width: 2000px) {
-    height: calc(
-      100vh - @global-top-bar-height - @media-sidebar-top-nav-height - -15px
-    );
-  }
 }
 .MediaNav {
   //rv-sticky-tree

--- a/src/apps/schema/src/app/components/Nav/SchemaNav.less
+++ b/src/apps/schema/src/app/components/Nav/SchemaNav.less
@@ -26,7 +26,6 @@
     flex-direction: column;
     padding: 8px;
     overflow: hidden;
-    overflow-x: none;
 
     .Search {
       display: flex;
@@ -45,11 +44,8 @@
   }
 
   .ModelList {
-    height: calc(100vh - 54px - 102px);
-
-    @media only screen and (min-width: 2000px) {
-      height: calc(100vh - 54px - 56px);
-    }
+    // 100vh - GlobalTopbar - NavActions
+    height: calc(100vh - 54px - 106px);
 
     margin: 0;
     overflow-y: auto;

--- a/src/apps/settings/src/app/components/Nav/SettingsNav.less
+++ b/src/apps/settings/src/app/components/Nav/SettingsNav.less
@@ -41,7 +41,8 @@
   }
 
   .ModelList {
-    height: calc(100vh - 54px);
+    // 100vh - GlobalTopbar - SettingsNav(padding-top)
+    height: calc(100vh - 54px - 16px);
     margin: 0;
     overflow-y: auto;
 


### PR DESCRIPTION
With the new nav layout of the button and search being stacked this offset the height of nav, making the bottom of the nav content slightly cutoff. This PR resolves the navs from being cutoff at the bottom. 

Media
<img width="572" alt="Screen Shot 2021-07-22 at 3 56 43 PM" src="https://user-images.githubusercontent.com/22800749/126719188-3ccb8bdf-45ed-494a-ac83-eb0f947a85d6.png">

Schema
<img width="563" alt="Screen Shot 2021-07-22 at 3 57 46 PM" src="https://user-images.githubusercontent.com/22800749/126719259-4c35d9a4-9928-4070-9fd7-22f89f758b3a.png">

Code
<img width="556" alt="Screen Shot 2021-07-22 at 3 57 23 PM" src="https://user-images.githubusercontent.com/22800749/126719229-bca825c6-0c6d-4b6f-9b7e-09e805060bf5.png">

Settings
<img width="585" alt="Screen Shot 2021-07-22 at 3 58 15 PM" src="https://user-images.githubusercontent.com/22800749/126719289-2903e1d1-8d40-469b-a52e-49e3dc1a14dd.png">


