### PR TITLE
Feature/#864 head tag fix

### DIFF
--- a/src/shell/components/Head/Head.js
+++ b/src/shell/components/Head/Head.js
@@ -60,8 +60,9 @@ export default connect((state, props) => {
           </Button>
 
           <Notice>
-            Head tags are not versioned or published. Saved changes to head tags
-            take effect immediately on your live instance.
+            Head tags are not versioned. Once saved they will take effect when
+            the page(s) are next cached. Caching occurs on publish or every 24
+            hours.
           </Notice>
         </h1>
 

--- a/src/shell/components/Head/Preview/Preview.js
+++ b/src/shell/components/Head/Preview/Preview.js
@@ -13,12 +13,12 @@ export const Preview = (props) => (
   <link rel="canonical" href="${props.domain}${props.item.web.path}" />
 
   <meta name="description" content="${props.item.web.metaDescription}" />
+  <meta name="keywords" content="${props.item.web.metaKeywords}" />
   <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary">
   <meta property="og:title" content="${props.item.web.metaTitle}" />
   <meta name="twitter:title" content="${props.item.web.metaTitle}">
-  <meta property="name:keywords" content="${props.item.web.metaKeywords}" />
   <meta property="og:description" content="${props.item.web.metaDescription}" />
   <meta property="twitter:description" content="${props.item.web.metaDescription}" />
   <meta property="og:url" content="${props.domain}${props.item.web.path}" />


### PR DESCRIPTION
Adding keywords Meta fixes #864 

og:image width and og:image height to preview seo meta window  

<img width="1425" alt="previewMetapng" src="https://user-images.githubusercontent.com/22800749/130876035-38586e3c-6f69-4d7f-8878-aeb252f08670.png">

https://zesty.org/services/web-engine/meta-tags/open-graph-twitter-card-meta-tags