### PR TITLE
updating design systems styles and colors buttons

### DIFF
--- a/cypress/integration/code/actions_spec.js
+++ b/cypress/integration/code/actions_spec.js
@@ -9,7 +9,7 @@ describe("Code Editor", () => {
     cy.get(".Select").eq(1).click();
     cy.get(".Select li").eq(1).click();
     cy.get('input[type="text"]').type("mySnippet");
-    cy.get('button[kind="save"]').eq(1).click();
+    cy.get('button[type="save"]').eq(1).click();
   });
 
   it("Navigate to file", () => {
@@ -31,7 +31,7 @@ describe("Code Editor", () => {
       .trigger("mousemove", { which: 1, force: true })
       .trigger("mouseup", { force: true });
 
-    cy.get('button[kind="save"]').contains("Save Order").click({ force: true });
+    cy.get('button[type="save"]').contains("Save Order").click({ force: true });
 
     cy.contains("File sort order has been saved", { timeout: 5000 }).should(
       "exist"

--- a/cypress/integration/schema/field_spec.js
+++ b/cypress/integration/schema/field_spec.js
@@ -16,7 +16,7 @@ describe("Fields", () => {
 
     cy.get('.FieldAdd input[name="label"]').type(fieldLabel);
     cy.get('.FieldAdd input[name="name"]').type(fieldName);
-    cy.get('.FieldAdd footer button[kind="save"]').click();
+    cy.get('.FieldAdd footer button[type="save"]').click();
 
     // Find the newly created field
     cy.contains(".Fields article header h1", fieldLabel, {
@@ -42,7 +42,7 @@ describe("Fields", () => {
           .clear()
           .type(newFieldLabel);
 
-        cy.get('.Fields article footer button[kind="save"]').last().click();
+        cy.get('.Fields article footer button[type="save"]').last().click();
 
         cy.get('.Fields article input[name="label"]')
           .last()
@@ -65,7 +65,7 @@ describe("Fields", () => {
 
     cy.get('.FieldAdd input[name="label"]').type(fieldLabel);
     cy.get('.FieldAdd input[name="name"]').type(fieldName);
-    cy.get('.FieldAdd footer button[kind="save"]').click();
+    cy.get('.FieldAdd footer button[type="save"]').click();
 
     // Find the newly created field
     cy.contains(".Fields article header h1", fieldLabel, {
@@ -84,7 +84,7 @@ describe("Fields", () => {
 
     cy.get('.FieldAdd input[name="label"]').type(fieldLabel);
     cy.get('.FieldAdd input[name="name"]').type(fieldName);
-    cy.get('.FieldAdd footer button[kind="save"]').click();
+    cy.get('.FieldAdd footer button[type="save"]').click();
 
     // Find the newly created field
     cy.contains(".Fields article header h1", fieldLabel, {

--- a/cypress/integration/schema/model_spec.js
+++ b/cypress/integration/schema/model_spec.js
@@ -24,7 +24,7 @@ describe("Schema", () => {
     cy.get('button[type="save"]').contains("Add Field").click();
 
     cy.contains("Delete Model").click({ force: true });
-    cy.get('button[kind="warn"]').contains("Delete Model").click();
+    cy.get('button[type="warn"]').contains("Delete Model").click();
     cy.get("#deleteConfirmButton").click();
   });
 });

--- a/cypress/integration/schema/model_spec.js
+++ b/cypress/integration/schema/model_spec.js
@@ -11,7 +11,7 @@ describe("Schema", () => {
   it("Create Model, Add Field, and Delete Model", () => {
     cy.get('input[name="label"]').type(SCHEMA_NAME);
 
-    cy.get('button[kind="save"]').contains("Create Model").click();
+    cy.get('button[type="save"]').contains("Create Model").click();
 
     cy.get(".FieldAdd").should("exist");
 
@@ -21,7 +21,7 @@ describe("Schema", () => {
 
     cy.get('input[name="label"]').type("my label", { force: true });
 
-    cy.get('button[kind="save"]').contains("Add Field").click();
+    cy.get('button[type="save"]').contains("Add Field").click();
 
     cy.contains("Delete Model").click({ force: true });
     cy.get('button[kind="warn"]').contains("Delete Model").click();

--- a/src/apps/active-preview/Preview.js
+++ b/src/apps/active-preview/Preview.js
@@ -147,7 +147,7 @@ export function Preview(props) {
               <FontAwesomeIcon icon={faSync} />
             </Button>
             {copied ? (
-              <Button onClick={handleCopy} kind="save">
+              <Button onClick={handleCopy} type="save">
                 <FontAwesomeIcon icon={faCheck} />
               </Button>
             ) : (
@@ -182,9 +182,9 @@ export function Preview(props) {
             >
               <Option value="fullscreen" text="Desktop" />
 
-              {/* 
-            Generate available options from templates, 
-            except the initial "No Template" template 
+              {/*
+            Generate available options from templates,
+            except the initial "No Template" template
             */}
               {Object.keys(templates)
                 .slice(1)

--- a/src/apps/analytics/src/components/GoogleAuthOverlay/GaAuthenticate.js
+++ b/src/apps/analytics/src/components/GoogleAuthOverlay/GaAuthenticate.js
@@ -15,7 +15,7 @@ export default function GaAuthenticate(props) {
     <Fragment>
       {canAuthenticate && (
         <div className={styles.buttonHolder}>
-          <Button kind="save" onClick={props.onClick}>
+          <Button type="save" onClick={props.onClick}>
             <FontAwesomeIcon icon={faKey} />
             Click here to Authenticate With Google
           </Button>

--- a/src/apps/code-editor/src/app/components/FileActions/components/Delete/Delete.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/Delete/Delete.js
@@ -24,7 +24,7 @@ export const Delete = memo(function Delete(props) {
     <div className={styles.DeleteBtn}>
       {props.fileName !== "loader" ? (
         <Button
-          kind="warn"
+          type="warn"
           onClick={() => setOpen(true)}
           className={styles.Button}
         >

--- a/src/apps/code-editor/src/app/components/FileActions/components/Delete/Delete.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/Delete/Delete.js
@@ -49,7 +49,7 @@ export const Delete = memo(function Delete(props) {
         </ModalContent>
         <ModalFooter className={styles.ModalFooter}>
           <Button
-            kind="save"
+            type="save"
             disabled={deleting}
             onClick={() => {
               setDeleting(true);

--- a/src/apps/code-editor/src/app/components/FileActions/components/Delete/Delete.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/Delete/Delete.js
@@ -74,7 +74,7 @@ export const Delete = memo(function Delete(props) {
             )}
             Delete File
           </Button>
-          <Button kind="cancel" onClick={() => setOpen(false)}>
+          <Button type="cancel" onClick={() => setOpen(false)}>
             <FontAwesomeIcon icon={faBan} />
             Cancel (ESC)
           </Button>

--- a/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
@@ -197,7 +197,7 @@ export const DifferActions = memo(function DifferActions(props) {
           <Button
             className={styles.Button}
             onClick={resolveSync}
-            kind="alt"
+            type="alt"
             disabled={saving}
           >
             {saving ? (

--- a/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
@@ -181,7 +181,7 @@ export const DifferActions = memo(function DifferActions(props) {
 
       {props.synced ? (
         <>
-          <Button className={styles.Button} onClick={loadVersion} kind="save">
+          <Button className={styles.Button} onClick={loadVersion} type="save">
             <FontAwesomeIcon icon={faHistory} />
             <span className={styles.Hide}>Load Version&nbsp;</span>{" "}
             {selectedVersion}

--- a/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Save/Save.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Save/Save.js
@@ -29,7 +29,7 @@ export function Save(props) {
   const metaShortcut = useMetaKey("s", onSave);
 
   return (
-    <Button kind="save" onClick={onSave} disabled={saving}>
+    <Button type="save" onClick={onSave} disabled={saving}>
       {saving ? (
         <FontAwesomeIcon spin icon={faSpinner} />
       ) : (

--- a/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Sync/Sync.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Sync/Sync.js
@@ -71,7 +71,7 @@ export const Sync = memo(function Sync(props) {
               )}
               Sync File
             </Button>
-            <Button kind="cancel" onClick={() => setOpen(false)}>
+            <Button type="cancel" onClick={() => setOpen(false)}>
               <FontAwesomeIcon icon={faBan} />
               Cancel (ESC)
             </Button>

--- a/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Sync/Sync.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Sync/Sync.js
@@ -63,7 +63,7 @@ export const Sync = memo(function Sync(props) {
         </ModalContent>
         <ModalFooter>
           <ButtonGroup className={styles.ModalActions}>
-            <Button kind="save" onClick={handleSync} disabled={loading}>
+            <Button type="save" onClick={handleSync} disabled={loading}>
               {loading ? (
                 <FontAwesomeIcon spin icon={faSpinner} />
               ) : (

--- a/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Sync/Sync.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/EditorActions/Sync/Sync.js
@@ -39,7 +39,7 @@ export const Sync = memo(function Sync(props) {
 
   return (
     <div>
-      <Button kind="alt" onClick={() => setOpen(true)}>
+      <Button type="alt" onClick={() => setOpen(true)}>
         {loading ? (
           <FontAwesomeIcon spin icon={faSpinner} />
         ) : (

--- a/src/apps/code-editor/src/app/components/FileDrawer/components/FileStatus/FileStatus.js
+++ b/src/apps/code-editor/src/app/components/FileDrawer/components/FileStatus/FileStatus.js
@@ -132,7 +132,7 @@ export default function FileStatus(props) {
           <li>
             File ZUID:&nbsp;
             <em>
-              <CopyButton kind="outlinedReversed" value={props.file.ZUID} />
+              <CopyButton size="compact" value={props.file.ZUID} />
             </em>
           </li>
           <li>

--- a/src/apps/code-editor/src/app/components/FileDrawer/components/FileStatus/FileStatus.js
+++ b/src/apps/code-editor/src/app/components/FileDrawer/components/FileStatus/FileStatus.js
@@ -132,7 +132,7 @@ export default function FileStatus(props) {
           <li>
             File ZUID:&nbsp;
             <em>
-              <CopyButton value={props.file.ZUID} />
+              <CopyButton kind="outlinedReversed" value={props.file.ZUID} />
             </em>
           </li>
           <li>

--- a/src/apps/code-editor/src/app/components/FileDrawer/components/PublishAll/PublishAll.js
+++ b/src/apps/code-editor/src/app/components/FileDrawer/components/PublishAll/PublishAll.js
@@ -95,7 +95,7 @@ export default connect((state) => {
         </Notice>
       </CardContent>
       <CardFooter>
-        <Button kind="save" onClick={handlePublishAll} disabled={loading}>
+        <Button type="save" onClick={handlePublishAll} disabled={loading}>
           {loading ? (
             <FontAwesomeIcon icon={faSpinner} />
           ) : (

--- a/src/apps/code-editor/src/app/components/FileList/components/CreateFile/CreateFile.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/CreateFile/CreateFile.js
@@ -170,7 +170,7 @@ export const CreateFile = memo(function CreateFile(props) {
           <ModalFooter>
             <ButtonGroup className={styles.ModalActions}>
               <Button
-                kind="save"
+                type="save"
                 onClick={handleCreateFile}
                 disabled={type === "" || type === "0" || loading}
               >

--- a/src/apps/code-editor/src/app/components/FileList/components/CreateFile/CreateFile.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/CreateFile/CreateFile.js
@@ -182,7 +182,7 @@ export const CreateFile = memo(function CreateFile(props) {
                 Create File
               </Button>
               <Button
-                kind="cancel"
+                type="cancel"
                 onClick={() => {
                   setName("");
                   setType("");

--- a/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
@@ -165,7 +165,7 @@ export default connect((state, props) => {
             </Notice>
           </ModalContent>
           <ModalFooter>
-            <Button kind="save" onClick={handleSaveSort} disabled={loading}>
+            <Button type="save" onClick={handleSaveSort} disabled={loading}>
               <FontAwesomeIcon icon={faSave} /> Save Order
             </Button>
             <Button kind="cancel" onClick={() => setOpen(false)}>

--- a/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
@@ -103,7 +103,6 @@ export default connect((state, props) => {
     <Fragment>
       <Button
         onClick={() => setOpen(true)}
-        kind="primary"
         title="Change combine and pre-process order"
       >
         <FontAwesomeIcon icon={faArrowsAlt} />

--- a/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
@@ -168,7 +168,7 @@ export default connect((state, props) => {
             <Button type="save" onClick={handleSaveSort} disabled={loading}>
               <FontAwesomeIcon icon={faSave} /> Save Order
             </Button>
-            <Button kind="cancel" onClick={() => setOpen(false)}>
+            <Button type="cancel" onClick={() => setOpen(false)}>
               <FontAwesomeIcon icon={faBan} /> Cancel (ESC)
             </Button>
           </ModalFooter>

--- a/src/apps/code-editor/src/app/components/FileList/components/PublishAll/PublishAll.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/PublishAll/PublishAll.js
@@ -119,7 +119,7 @@ export default connect((state) => {
           </ModalContent>
           <ModalFooter>
             <ButtonGroup className={styles.ModalActions}>
-              <Button kind="save" onClick={handlePublishAll} disabled={loading}>
+              <Button type="save" onClick={handlePublishAll} disabled={loading}>
                 {loading ? (
                   <FontAwesomeIcon spin icon={faSpinner} />
                 ) : (

--- a/src/apps/code-editor/src/app/components/FileList/components/PublishAll/PublishAll.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/PublishAll/PublishAll.js
@@ -128,7 +128,7 @@ export default connect((state) => {
                 Publish All Files
               </Button>
 
-              <Button kind="cancel" onClick={() => setOpen(false)}>
+              <Button type="cancel" onClick={() => setOpen(false)}>
                 <FontAwesomeIcon icon={faBan} />
                 Cancel (ESC)
               </Button>

--- a/src/apps/content-editor/src/app/components/LockedItem/LockedItem.js
+++ b/src/apps/content-editor/src/app/components/LockedItem/LockedItem.js
@@ -59,7 +59,7 @@ export const LockedItem = ({
           <ButtonGroup>
             <Button
               className={styles.ButtonBack}
-              kind="cancel"
+              type="cancel"
               onClick={goBack}
             >
               <FontAwesomeIcon icon={faStepBackward} /> Go Back

--- a/src/apps/content-editor/src/app/components/LockedItem/LockedItem.js
+++ b/src/apps/content-editor/src/app/components/LockedItem/LockedItem.js
@@ -64,7 +64,7 @@ export const LockedItem = ({
             >
               <FontAwesomeIcon icon={faStepBackward} /> Go Back
             </Button>
-            <Button kind="save" onClick={handleUnlock}>
+            <Button type="save" onClick={handleUnlock}>
               <FontAwesomeIcon icon={faUnlock} /> Unlock
             </Button>
           </ButtonGroup>

--- a/src/apps/content-editor/src/app/components/Nav/ContentNav.js
+++ b/src/apps/content-editor/src/app/components/Nav/ContentNav.js
@@ -118,7 +118,7 @@ export function ContentNav(props) {
 
           <Link to="/content">
             {" "}
-            <Button kind="outlined" type="tertiary" size="small">
+            <Button kind="outlined" size="small">
               <FontAwesomeIcon icon={faHome} title="Dashboard" />
             </Button>
           </Link>

--- a/src/apps/content-editor/src/app/components/Nav/ContentNav.js
+++ b/src/apps/content-editor/src/app/components/Nav/ContentNav.js
@@ -118,7 +118,7 @@ export function ContentNav(props) {
 
           <Link to="/content">
             {" "}
-            <Button size="small" kind="outlined">
+            <Button kind="outlined" type="tertiary" size="small">
               <FontAwesomeIcon icon={faHome} title="Dashboard" />
             </Button>
           </Link>

--- a/src/apps/content-editor/src/app/components/PendingEditsModal/PendingEditsModal.js
+++ b/src/apps/content-editor/src/app/components/PendingEditsModal/PendingEditsModal.js
@@ -96,7 +96,7 @@ export default memo(function PendingEditsModal(props) {
               )}
               Discard
             </Button>
-            <Button disabled={loading} kind="cancel" onClick={handler}>
+            <Button disabled={loading} type="cancel" onClick={handler}>
               <FontAwesomeIcon icon={faBan} />
               Cancel (ESC)
             </Button>

--- a/src/apps/content-editor/src/app/components/PendingEditsModal/PendingEditsModal.js
+++ b/src/apps/content-editor/src/app/components/PendingEditsModal/PendingEditsModal.js
@@ -88,7 +88,7 @@ export default memo(function PendingEditsModal(props) {
               )}
               Save
             </Button>
-            <Button disabled={loading} kind="warn" onClick={handler}>
+            <Button disabled={loading} type="warn" onClick={handler}>
               {loading ? (
                 <FontAwesomeIcon icon={faSpinner} spin />
               ) : (

--- a/src/apps/content-editor/src/app/components/PendingEditsModal/PendingEditsModal.js
+++ b/src/apps/content-editor/src/app/components/PendingEditsModal/PendingEditsModal.js
@@ -80,7 +80,7 @@ export default memo(function PendingEditsModal(props) {
         </ModalContent>
         <ModalFooter>
           <ButtonGroup className={styles.Actions}>
-            <Button disabled={loading} kind="save" onClick={handler}>
+            <Button disabled={loading} type="save" onClick={handler}>
               {loading ? (
                 <FontAwesomeIcon icon={faSpinner} spin />
               ) : (

--- a/src/apps/content-editor/src/app/components/ReorderNav/ReorderNav.js
+++ b/src/apps/content-editor/src/app/components/ReorderNav/ReorderNav.js
@@ -138,7 +138,7 @@ class ReorderNav extends Component {
                 Return to Root
               </Button>
               <Button
-                kind="save"
+                type="save"
                 onClick={this.requestForReorder}
                 disabled={!this.state.dirty || this.state.requesting}
               >

--- a/src/apps/content-editor/src/app/views/CSVImport/CSVImport.js
+++ b/src/apps/content-editor/src/app/views/CSVImport/CSVImport.js
@@ -333,7 +333,7 @@ class CSVImport extends Component {
             </label>
           </form>
           <Button
-            kind="save"
+            type="save"
             disabled={
               this.state.complete ||
               this.state.inFlight ||

--- a/src/apps/content-editor/src/app/views/ItemCreate/Header/Header.js
+++ b/src/apps/content-editor/src/app/views/ItemCreate/Header/Header.js
@@ -30,7 +30,7 @@ export function Header(props) {
 
       <ButtonGroup className={styles.Actions}>
         <Button
-          kind="save"
+          type="save"
           id="CreateItemSaveButton"
           disabled={props.saving || !props.isDirty}
           onClick={props.onSave}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/QuickView/QuickView.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/QuickView/QuickView.js
@@ -61,7 +61,11 @@ export const QuickView = memo(function QuickView(props) {
           <ul>
             <li>
               <strong>ZUID:</strong>&nbsp;
-              <CopyButton value={props.itemZUID} />
+              <CopyButton
+                kind="outlined"
+                size="compact"
+                value={props.itemZUID}
+              />
             </li>
             <li>
               <strong>Language:</strong>&nbsp;

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
@@ -88,7 +88,7 @@ export const WidgetDeleteItem = memo(function WidgetDeleteItem(props) {
         </Button>
         <Button
           id="deleteCancelButton"
-          kind="cancel"
+          type="cancel"
           onClick={() => setConfirmOpen(false)}
         >
           <FontAwesomeIcon icon={faBan} />

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
@@ -45,7 +45,7 @@ export const WidgetDeleteItem = memo(function WidgetDeleteItem(props) {
         </CardContent>
         <CardFooter>
           <Button
-            kind="warn"
+            type="warn"
             id="DeleteItemButton"
             onClick={() => setConfirmOpen(true)}
             disabled={deleting}
@@ -66,7 +66,7 @@ export const WidgetDeleteItem = memo(function WidgetDeleteItem(props) {
       >
         <Button
           id="deleteConfirmButton"
-          kind="warn"
+          type="warn"
           onClick={() => {
             setConfirmOpen(false);
             setDeleting(true);

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/ContentInsights/ContentInsights.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/ContentInsights/ContentInsights.js
@@ -335,9 +335,10 @@ export function ContentInsights(props) {
           })}
           {!showAllWords && (
             <Button
+              kind="outlined"
+              type="tertiary"
               size="small"
               className={styles.toggleButton}
-              kind="outlined"
               onClick={() => setShowAllWords(true)}
             >
               Show Non-Recurring Words
@@ -345,9 +346,10 @@ export function ContentInsights(props) {
           )}
           {showAllWords && (
             <Button
+              kind="outlined"
+              type="tertiary"
               size="small"
               className={styles.toggleButton}
-              kind="outlined"
               onClick={() => setShowAllWords(false)}
             >
               Hide Non-Recurring Words

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/ContentInsights/ContentInsights.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/ContentInsights/ContentInsights.js
@@ -336,7 +336,6 @@ export function ContentInsights(props) {
           {!showAllWords && (
             <Button
               kind="outlined"
-              type="tertiary"
               size="small"
               className={styles.toggleButton}
               onClick={() => setShowAllWords(true)}
@@ -347,7 +346,6 @@ export function ContentInsights(props) {
           {showAllWords && (
             <Button
               kind="outlined"
-              type="tertiary"
               size="small"
               className={styles.toggleButton}
               onClick={() => setShowAllWords(false)}

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -153,7 +153,7 @@ export function ItemVersioning(props) {
       )}
 
       <Button
-        kind="save"
+        type="save"
         disabled={props.saving || !props.item.dirty}
         onClick={props.onSave}
         id="SaveItemButton"

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -19,6 +19,7 @@ import { publish } from "shell/store/content";
 import { fetchAuditTrailPublish } from "shell/store/logs";
 import { usePermission } from "shell/hooks/use-permissions";
 import { useDomain } from "shell/hooks/use-domain";
+import { CopyButton } from "@zesty-io/core/CopyButton";
 
 import styles from "./ItemVersioning.less";
 export function ItemVersioning(props) {
@@ -152,7 +153,7 @@ export function ItemVersioning(props) {
         </ButtonGroup>
       )}
 
-      <Button
+      {/* <Button
         type="save"
         disabled={props.saving || !props.item.dirty}
         onClick={props.onSave}
@@ -166,7 +167,8 @@ export function ItemVersioning(props) {
         Save&nbsp;
         <span className={styles.HideVersion}>Version&nbsp;</span>
         {metaShortcut}
-      </Button>
+      </Button> */}
+      <CopyButton kind="outlinedReversed" value="david naimi" />
     </ButtonGroup>
   );
 }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -19,7 +19,6 @@ import { publish } from "shell/store/content";
 import { fetchAuditTrailPublish } from "shell/store/logs";
 import { usePermission } from "shell/hooks/use-permissions";
 import { useDomain } from "shell/hooks/use-domain";
-import { CopyButton } from "@zesty-io/core/CopyButton";
 
 import styles from "./ItemVersioning.less";
 export function ItemVersioning(props) {

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -153,7 +153,7 @@ export function ItemVersioning(props) {
         </ButtonGroup>
       )}
 
-      {/* <Button
+      <Button
         type="save"
         disabled={props.saving || !props.item.dirty}
         onClick={props.onSave}
@@ -167,8 +167,7 @@ export function ItemVersioning(props) {
         Save&nbsp;
         <span className={styles.HideVersion}>Version&nbsp;</span>
         {metaShortcut}
-      </Button> */}
-      <CopyButton kind="outlinedReversed" value="david naimi" />
+      </Button>
     </ButtonGroup>
   );
 }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ScheduleFlyout/ScheduleFlyout.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ScheduleFlyout/ScheduleFlyout.js
@@ -215,7 +215,7 @@ export default class ScheduleFlyout extends Component {
               </ModalContent>
               <ModalFooter className={styles.ModalFooter}>
                 <Button
-                  kind="save"
+                  type="save"
                   id="SchedulePublishButton"
                   onClick={this.handleSchedulePublish}
                   disabled={this.state.scheduling}

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ScheduleFlyout/ScheduleFlyout.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ScheduleFlyout/ScheduleFlyout.js
@@ -180,7 +180,7 @@ export default class ScheduleFlyout extends Component {
                 </Button>
                 <Button
                   className={styles.Cancel}
-                  kind="cancel"
+                  type="cancel"
                   onClick={this.props.toggleOpen}
                 >
                   <FontAwesomeIcon icon={faTimesCircle} />
@@ -225,7 +225,7 @@ export default class ScheduleFlyout extends Component {
                 </Button>
                 <Button
                   className={styles.Cancel}
-                  kind="cancel"
+                  type="cancel"
                   id="SchedulePublishClose"
                   onClick={this.props.toggleOpen}
                 >

--- a/src/apps/content-editor/src/app/views/ItemList/SetActions/SetActions.js
+++ b/src/apps/content-editor/src/app/views/ItemList/SetActions/SetActions.js
@@ -77,7 +77,7 @@ export class SetActions extends Component {
 
             {Boolean(this.props.isDirty) && (
               <Button
-                kind="save"
+                type="save"
                 className={cx(styles.Action, styles.Save)}
                 disabled={this.props.saving}
                 onClick={this.props.onSaveAll}

--- a/src/apps/content-editor/src/app/views/LinkCreate/LinkCreate.js
+++ b/src/apps/content-editor/src/app/views/LinkCreate/LinkCreate.js
@@ -228,7 +228,7 @@ export function LinkCreate() {
           <Button
             id="CreateLinkButton"
             disabled={state.saving}
-            kind="save"
+            type="save"
             onClick={saveLink}
           >
             Create Link

--- a/src/apps/content-editor/src/app/views/LinkEdit/LinkEdit.js
+++ b/src/apps/content-editor/src/app/views/LinkEdit/LinkEdit.js
@@ -313,7 +313,7 @@ export default function LinkEdit() {
               Save Changes
             </Button>
             <Button
-              kind="warn"
+              type="warn"
               disabled={state.saving}
               onClick={() => setShowConfirmation(true)}
             >

--- a/src/apps/content-editor/src/app/views/LinkEdit/LinkEdit.js
+++ b/src/apps/content-editor/src/app/views/LinkEdit/LinkEdit.js
@@ -308,7 +308,7 @@ export default function LinkEdit() {
             </label>
           </CardContent>
           <CardFooter className={styles.LinkEditActions}>
-            <Button kind="save" disabled={state.saving} onClick={saveLink}>
+            <Button type="save" disabled={state.saving} onClick={saveLink}>
               <FontAwesomeIcon icon={faSave} />
               Save Changes
             </Button>

--- a/src/apps/leads/src/app/components/LeadsTable/LeadsTable.js
+++ b/src/apps/leads/src/app/components/LeadsTable/LeadsTable.js
@@ -236,7 +236,7 @@ export default connect((state) => {
                 (lead) => lead.zuid === this.state.currentLead.zuid
               ) ? (
                 <Button
-                  kind="warn"
+                  type="warn"
                   className={styles.btnDanger}
                   disabled={this.state.loading}
                   onClick={() => this.deleteLead(this.state.currentLead.zuid)}

--- a/src/apps/media/src/app/components/MediaCreateGroupModal.js
+++ b/src/apps/media/src/app/components/MediaCreateGroupModal.js
@@ -42,7 +42,7 @@ export function MediaCreateGroupModal(props) {
             value={groupName}
             onChange={(event) => setGroupName(event.target.value)}
           />
-          <Button kind="save" onClick={handleCreateGroup}>
+          <Button type="save" onClick={handleCreateGroup}>
             <FontAwesomeIcon icon={faPlus} />
             <span>Create</span>
           </Button>

--- a/src/apps/media/src/app/components/MediaDeleteFileModal.js
+++ b/src/apps/media/src/app/components/MediaDeleteFileModal.js
@@ -36,7 +36,7 @@ export function MediaDeleteFileModal(props) {
         </p>
       </ModalContent>
       <ModalFooter className={styles.Footer}>
-        <Button kind="cancel" onClick={props.onClose}>
+        <Button type="cancel" onClick={props.onClose}>
           <FontAwesomeIcon icon={faBan} />
           <span>Cancel</span>
         </Button>

--- a/src/apps/media/src/app/components/MediaDeleteGroupModal.js
+++ b/src/apps/media/src/app/components/MediaDeleteGroupModal.js
@@ -37,7 +37,7 @@ export function MediaDeleteGroupModal(props) {
         </p>
       </ModalContent>
       <ModalFooter className={styles.Footer}>
-        <Button kind="cancel" onClick={props.onClose}>
+        <Button type="cancel" onClick={props.onClose}>
           <FontAwesomeIcon icon={faBan} />
           <span>Cancel</span>
         </Button>

--- a/src/apps/media/src/app/components/MediaDetailsModal.js
+++ b/src/apps/media/src/app/components/MediaDetailsModal.js
@@ -150,7 +150,7 @@ export const MediaDetailsModal = memo(function MediaDetailsModal(props) {
         </div>
       </ModalContent>
       <ModalFooter className={shared.ModalFooter}>
-        <Button kind="cancel" onClick={props.onClose}>
+        <Button type="cancel" onClick={props.onClose}>
           <FontAwesomeIcon icon={faBan} />
           <span>Cancel</span>
         </Button>

--- a/src/apps/media/src/app/components/MediaDetailsModal.js
+++ b/src/apps/media/src/app/components/MediaDetailsModal.js
@@ -160,7 +160,7 @@ export const MediaDetailsModal = memo(function MediaDetailsModal(props) {
             /* hide for Contributor */
             userRole.name !== "Contributor" ? (
               <Button
-                kind="warn"
+                type="warn"
                 onClick={props.showDeleteFileModal}
                 className={styles.Delete}
               >

--- a/src/apps/media/src/app/components/MediaDetailsModal.js
+++ b/src/apps/media/src/app/components/MediaDetailsModal.js
@@ -170,7 +170,7 @@ export const MediaDetailsModal = memo(function MediaDetailsModal(props) {
             ) : null
           }
 
-          <Button kind="save" onClick={saveFile}>
+          <Button type="save" onClick={saveFile}>
             <FontAwesomeIcon icon={faSave} />
             Save {metaShortcut}
           </Button>

--- a/src/apps/media/src/app/components/MediaEditGroupModal.js
+++ b/src/apps/media/src/app/components/MediaEditGroupModal.js
@@ -42,7 +42,7 @@ export function MediaEditGroupModal(props) {
             value={name}
             onChange={(event) => setName(event.target.value)}
           />
-          <Button kind="save" onClick={handleEditGroup}>
+          <Button type="save" onClick={handleEditGroup}>
             <FontAwesomeIcon icon={faSave} />
             <span>Save</span>
           </Button>

--- a/src/apps/media/src/app/components/MediaHeader.js
+++ b/src/apps/media/src/app/components/MediaHeader.js
@@ -68,7 +68,7 @@ export const MediaHeader = memo(function MediaHeader(props) {
           userRole.name !== "Contributor" ? (
             <Button
               title="Delete Group"
-              kind="warn"
+              type="warn"
               aria-label="Delete"
               onClick={props.showDeleteGroupModal}
             >

--- a/src/apps/media/src/app/components/MediaHeader.js
+++ b/src/apps/media/src/app/components/MediaHeader.js
@@ -47,7 +47,7 @@ export const MediaHeader = memo(function MediaHeader(props) {
           )}
 
           <Button
-            kind="cancel"
+            type="cancel"
             title="Edit"
             aria-label="Edit"
             onClick={() => setEditGroupModal(true)}

--- a/src/apps/media/src/app/components/MediaSelected.js
+++ b/src/apps/media/src/app/components/MediaSelected.js
@@ -38,7 +38,7 @@ export function MediaSelected(props) {
             >
               <Button
                 className={styles.ButtonLoad}
-                kind="save"
+                type="save"
                 onClick={() => props.addImages(props.selected)}
               >
                 <FontAwesomeIcon icon={faUpload} />

--- a/src/apps/publish/src/app/components/Header/Header.js
+++ b/src/apps/publish/src/app/components/Header/Header.js
@@ -41,7 +41,7 @@ export function Header({ plan }) {
       ) : null}
       {showPublishAll ? (
         <Button
-          kind="alt"
+          type="alt"
           disabled={!canPublish && "disabled"}
           onClick={onPublishAll}
         >

--- a/src/apps/schema/src/app/components/Wizard/Wizard.js
+++ b/src/apps/schema/src/app/components/Wizard/Wizard.js
@@ -71,7 +71,7 @@ export function Wizard(props) {
                     >
                       {showBack(child.props.showBack) && (
                         <Button
-                          kind="cancel"
+                          type="cancel"
                           onClick={prev}
                           className={styles.Button}
                         >

--- a/src/apps/schema/src/app/views/GettingStarted/components/FieldSuccess/FieldSuccess.js
+++ b/src/apps/schema/src/app/views/GettingStarted/components/FieldSuccess/FieldSuccess.js
@@ -23,7 +23,7 @@ export function FieldSuccess(props) {
           to={`/content/${props.modelZUID}/new`}
           onClick={props.goToContent}
         >
-          <Button kind="save">
+          <Button type="save">
             <FontAwesomeIcon icon={faCheck} /> I want to add content
           </Button>
         </AppLink>

--- a/src/apps/schema/src/app/views/SchemaCreate/SchemaCreate.js
+++ b/src/apps/schema/src/app/views/SchemaCreate/SchemaCreate.js
@@ -356,7 +356,7 @@ export default connect((state) => {
 
         <CardFooter>
           <Button
-            kind="save"
+            type="save"
             onClick={() => {
               const errors = [];
 

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldAdd/FieldAdd.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldAdd/FieldAdd.js
@@ -171,7 +171,7 @@ export function FieldAdd(props) {
         )}
       </CardContent>
       <CardFooter>
-        <Button kind="save" disabled={!field.dirty || loading} onClick={create}>
+        <Button type="save" disabled={!field.dirty || loading} onClick={create}>
           {loading ? (
             <FontAwesomeIcon icon={faSpinner} />
           ) : (

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldEdit/FieldEdit.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldEdit/FieldEdit.js
@@ -153,7 +153,7 @@ export function Footer(props) {
         ) : (
           <Button
             className="deactivate"
-            kind="cancel"
+            type="cancel"
             onClick={(evt) => {
               evt.preventDefault();
               setLoading(true);

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldEdit/FieldEdit.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldEdit/FieldEdit.js
@@ -124,7 +124,7 @@ export function Footer(props) {
   return (
     <footer className={styles.FieldFooter}>
       <ButtonGroup className={styles.FieldActions}>
-        <Button kind="save" disabled={!props.field.dirty} onClick={onSave}>
+        <Button type="save" disabled={!props.field.dirty} onClick={onSave}>
           {loading ? (
             <FontAwesomeIcon icon={faSpinner} spin />
           ) : (

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/DropdownOptions/DropdownOptions.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/DropdownOptions/DropdownOptions.js
@@ -70,7 +70,7 @@ export function DropdownOptions(props) {
             }}
           />
           <Button
-            kind="warn"
+            type="warn"
             onClick={() => {
               const newOptions = [...options];
               newOptions.splice(i, 1);

--- a/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/DropdownOptions/DropdownOptions.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/DropdownOptions/DropdownOptions.js
@@ -83,7 +83,7 @@ export function DropdownOptions(props) {
       ))}
 
       <Button
-        kind="save"
+        type="save"
         onClick={() => {
           setOptions([...options, { key: "", value: "" }]);
         }}

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Delete/Delete.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Delete/Delete.js
@@ -85,7 +85,7 @@ function Footer(props) {
         </Button>
         <Button
           id="deleteCancelButton"
-          kind="cancel"
+          type="cancel"
           onClick={() => setIsOpen(false)}
         >
           <FontAwesomeIcon icon={faBan} />

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Delete/Delete.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Delete/Delete.js
@@ -47,7 +47,7 @@ function Footer(props) {
   return (
     <Fragment>
       <CardFooter>
-        <Button kind="warn" onClick={() => setIsOpen(true)}>
+        <Button type="warn" onClick={() => setIsOpen(true)}>
           <FontAwesomeIcon icon={faTrash} />
           Delete Model
         </Button>
@@ -59,7 +59,7 @@ function Footer(props) {
       >
         <Button
           id="deleteConfirmButton"
-          kind="warn"
+          type="warn"
           onClick={() => {
             props
               .dispatch(deleteModel(props.model.ZUID))

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Info/Info.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Info/Info.js
@@ -84,7 +84,11 @@ export default connect((state) => {
           </li>
           <li>
             <abbr title="Zesty Universal ID">ZUID</abbr>:&nbsp;
-            <CopyButton value={props.model.ZUID} />
+            <CopyButton
+              kind="outlined"
+              size="compact"
+              value={props.model.ZUID}
+            />
           </li>
           <li>
             Instant API:&nbsp;

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Settings/Settings.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Settings/Settings.js
@@ -147,7 +147,7 @@ function Footer(props) {
     <CardFooter className={styles.CardFooter}>
       <ButtonGroup>
         <Button
-          kind="save"
+          type="save"
           disabled={!props.model.dirty || loading}
           onClick={() => {
             setLoading(true);

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
@@ -101,7 +101,7 @@ export function RedirectCreator(props) {
         )}
       </span>
       <span className={styles.RedirectCreatorCell}>
-        <Button className="save" kind="save" onClick={handleCreateRedirect}>
+        <Button className="save" type="save" onClick={handleCreateRedirect}>
           <FontAwesomeIcon icon={faPlus} />
           Create Redirect
         </Button>

--- a/src/apps/settings/src/app/views/Fonts/Browse.js
+++ b/src/apps/settings/src/app/views/Fonts/Browse.js
@@ -233,7 +233,7 @@ export default connect((state) => {
               </div>
               <div>
                 <Button
-                  kind="save"
+                  type="save"
                   id="InstallFont"
                   className={styles.SaveBtn}
                   onClick={() => onUpdateFont(itemFont.family)}

--- a/src/apps/settings/src/app/views/Fonts/Installed.js
+++ b/src/apps/settings/src/app/views/Fonts/Installed.js
@@ -181,7 +181,7 @@ export default connect((state) => {
                   All their equipment and instruments are alive.
                 </p>
                 <Button
-                  kind="warn"
+                  type="warn"
                   onClick={() => toggleEnableFont(null, "0", font.font)}
                   className={styles.ButtonRemoveFont}
                 >
@@ -206,7 +206,7 @@ export default connect((state) => {
                   All their equipment and instruments are alive.
                 </p>
                 <Button
-                  kind="warn"
+                  type="warn"
                   id="RemoveFont"
                   onClick={() =>
                     toggleEnableFont(variant.label, "0", font.font)

--- a/src/apps/settings/src/app/views/Instance/Instance.js
+++ b/src/apps/settings/src/app/views/Instance/Instance.js
@@ -127,7 +127,7 @@ export default connect((state) => {
             <Button
               className={styles.ButtonSave}
               id="saveSettings"
-              kind="save"
+              type="save"
               className={styles.saveButton}
               onClick={saveFields}
               disabled={saving || dirtyFields.length === 0}

--- a/src/apps/settings/src/app/views/Robots/Robots.js
+++ b/src/apps/settings/src/app/views/Robots/Robots.js
@@ -189,7 +189,7 @@ export default connect((state) => {
         </div>
 
         <Button
-          kind="save"
+          type="save"
           className={styles.SaveBtn}
           onClick={handleSave}
           disabled={loading}

--- a/src/apps/settings/src/app/views/Styles/Styles.js
+++ b/src/apps/settings/src/app/views/Styles/Styles.js
@@ -314,7 +314,7 @@ export default connect((state) => {
       ))}
       <Button
         id="SaveSettings"
-        kind="save"
+        type="save"
         className={styles.SaveBtn}
         onClick={saveSettings}
         disabled={saving || dirtyFields.length === 0}

--- a/src/shell/components/GlobalHelpMenu/GlobalHelpMenu.js
+++ b/src/shell/components/GlobalHelpMenu/GlobalHelpMenu.js
@@ -158,7 +158,7 @@ export default connect((state) => {
         )}
 
         <Url target="_blank" href="https://chat.zesty.io">
-          <Button className={styles.Button} kind="alt" title="Chat">
+          <Button className={styles.Button} type="alt" title="Chat">
             <FontAwesomeIcon icon={faComments} />
             chat.zesty.io
           </Button>

--- a/src/shell/components/Head/HeadTag/HeadTag.js
+++ b/src/shell/components/Head/HeadTag/HeadTag.js
@@ -200,7 +200,7 @@ export const HeadTag = (props) => {
       </CardContent>
       <CardFooter className={styles.CardFooter}>
         <Button
-          kind="save"
+          type="save"
           id="SaveItemButton"
           disabled={saving}
           onClick={tag.hasOwnProperty("createdAt") ? onSave : onCreate}

--- a/src/shell/components/Head/HeadTag/HeadTag.js
+++ b/src/shell/components/Head/HeadTag/HeadTag.js
@@ -136,14 +136,14 @@ export const HeadTag = (props) => {
           <Button
             className={styles.Delete}
             onClick={onDelete}
-            kind="warn"
+            type="warn"
             id="DelteHeadtag"
           >
             <FontAwesomeIcon className={styles.Del} icon={faTrash} />
             Delete Tag
           </Button>
         ) : (
-          <Button className={styles.Delete} onClick={onCancel} kind="warn">
+          <Button className={styles.Delete} onClick={onCancel} type="warn">
             <FontAwesomeIcon className={styles.Del} icon={faTrash} />
             Cancel
           </Button>
@@ -187,7 +187,7 @@ export const HeadTag = (props) => {
                 <Button
                   className={styles.Del}
                   onClick={() => dispatch(deleteTagAttribute(tag.ZUID, index))}
-                  kind="warn"
+                  type="warn"
                 >
                   <FontAwesomeIcon className={styles.Del} icon={faTrash} />
                 </Button>

--- a/src/shell/components/favicon/favicon.js
+++ b/src/shell/components/favicon/favicon.js
@@ -244,7 +244,7 @@ export default connect((state) => {
         </ModalContent>
         <ModalFooter>
           <ButtonGroup className={styles.Actions}>
-            <Button kind="save" className={styles.Button} onClick={handleSave}>
+            <Button type="save" className={styles.Button} onClick={handleSave}>
               {loading ? (
                 <FontAwesomeIcon icon={faSpinner} spin />
               ) : (

--- a/src/shell/components/favicon/favicon.js
+++ b/src/shell/components/favicon/favicon.js
@@ -252,7 +252,7 @@ export default connect((state) => {
               )}
               Save Favicon
             </Button>
-            <Button kind="cancel" onClick={handleClose}>
+            <Button type="cancel" onClick={handleClose}>
               <FontAwesomeIcon icon={faBan} />
               Cancel (ESC)
             </Button>

--- a/src/shell/components/global-account/GlobalAccount.js
+++ b/src/shell/components/global-account/GlobalAccount.js
@@ -56,7 +56,7 @@ export default connect((state) => {
 
         <li className={styles.zuid}>
           ZUID:&nbsp;
-          <CopyButton value={props.user.ZUID} />
+          <CopyButton kind="outlined" size="compact" value={props.user.ZUID} />
         </li>
 
         <li className={styles.role}>Instance: {props.userRole.name}</li>

--- a/src/shell/components/global-instance/GlobalInstance.js
+++ b/src/shell/components/global-instance/GlobalInstance.js
@@ -69,7 +69,8 @@ export default function GlobalInstance(props) {
 
       <main className={cx(styles.Instance, open ? null : styles.hide)}>
         <p className={cx(styles.bodyText, styles.zuid)}>
-          ZUID: <CopyButton value={instance.ZUID} />
+          ZUID:{" "}
+          <CopyButton kind="outlined" size="compact" value={instance.ZUID} />
         </p>
 
         <Select className={styles.Select} name="instance" value={instance.ZUID}>

--- a/src/shell/components/global-instance/GlobalInstance.less
+++ b/src/shell/components/global-instance/GlobalInstance.less
@@ -41,7 +41,7 @@
     right: 0;
     padding: 24px;
     background-color: @appBkgColor;
-    box-shadow: 1px 1px 10px @appBkgColor;
+    box-shadow: @boxShadow;
     border-radius: 0 0 0 4px;
     text-align: left;
     word-break: break-word;


### PR DESCRIPTION
The goal of this PR was to get the copyButton to fit well and be consistent with our Zeplin stylesheet, this resulted in a discussion with @shrunyan  on following styling format for <Button> EXAMPLE: <Button kind="outlined" type="tertiary" size="small">

I made overhaul to design systems Button.less & color.less file to follow Zeplin's stylessheet 
https://app.zeplin.io/project/5bb69f5bdfef6551f65f76e8/screen/5bbe83aa23bfd05fb6a9bff7

PR: design-systems: https://github.com/zesty-io/design-system/pull/149/files

Only a couple buttons were slightly changed every other buttons styles remain the same. What had to be changed to be consistent with Zeplin Buttons styles, see screenshots below.

Content home icon 
Before 
![Screen Shot 2021-08-29 at 2 49 07 PM](https://user-images.githubusercontent.com/22800749/131266402-3ed0320f-917f-4863-b93b-f6f63e965625.png)
Before &: hover
![Screen Shot 2021-08-29 at 2 49 41 PM](https://user-images.githubusercontent.com/22800749/131266414-b7ed75cf-afe7-4c17-abdc-42ec0d510f0b.png)

After
![Screen Shot 2021-08-29 at 2 50 09 PM](https://user-images.githubusercontent.com/22800749/131266430-a0b19931-fdbc-40b5-ae13-43607c594f4a.png)

After:hover
![Screen Shot 2021-08-29 at 2 50 31 PM](https://user-images.githubusercontent.com/22800749/131266445-a9bd9805-43b6-4c67-ba39-02075a76c2e1.png)

SEO & Meta >  Content Insights

Before 
![Screen Shot 2021-08-29 at 2 51 48 PM](https://user-images.githubusercontent.com/22800749/131266480-5ddf18d5-d89f-4d26-aaa3-94979a14b8ff.png)

Before & hover
![Screen Shot 2021-08-29 at 2 52 12 PM](https://user-images.githubusercontent.com/22800749/131266493-8a49e23c-fb68-4678-ad70-6b889a9c3444.png)


After
![Screen Shot 2021-08-29 at 2 56 13 PM](https://user-images.githubusercontent.com/22800749/131266595-d7f7319d-6524-43c4-aaf4-188ec31be973.png)

After : Hover
![Screen Shot 2021-08-29 at 2 56 40 PM](https://user-images.githubusercontent.com/22800749/131266613-de3bbbab-18a6-49a6-90f2-96fc6aa3d745.png)

Before Content Disabled
![Screen Shot 2021-08-29 at 2 59 55 PM](https://user-images.githubusercontent.com/22800749/131266680-5bf9639d-dca8-4ae1-9516-1401a0791e56.png)

After Content Disabled(Publish is a `kind="secondary` which has a different style disabled color compared to save)
![Screen Shot 2021-08-29 at 3 01 09 PM](https://user-images.githubusercontent.com/22800749/131266711-540f44a8-8bfd-40dc-9ce9-d482d4bac8a0.png)


*Side notes that need feedback @shrunyan : 
I Removed class `.subdued` never saw the style be used.

I would like to swap kind="save" to kind="primary" 
I would like to swap kind="warn" to kind="destructive"
Remove cancel or swap to tertiary? 
