### PR TITLE
Feature/#899 content item lang

### DIFF
--- a/cypress/integration/content/seoandmeta_spec.js
+++ b/cypress/integration/content/seoandmeta_spec.js
@@ -1,0 +1,11 @@
+describe("Content SEO & Meta", () => {
+  before(() => {
+    cy.login();
+  });
+
+  it("Check if multi lang exist", () => {
+    cy.visit("/content/6-a4d6e6f087-1jmlbx/7-b8da98dea8-1nwkc9");
+    // Waiting 15 secs for app to fully render dom
+    cy.get("[data-cy=meta]", { timeout: 15000 });
+  });
+});

--- a/cypress/integration/content/seoandmeta_spec.js
+++ b/cypress/integration/content/seoandmeta_spec.js
@@ -4,8 +4,12 @@ describe("Content SEO & Meta", () => {
   });
 
   it("Check if multi lang exist", () => {
-    cy.visit("/content/6-a4d6e6f087-1jmlbx/7-b8da98dea8-1nwkc9");
+    cy.visit("/content/6-a4d6e6f087-1jmlbx/7-b8da98dea8-1nwkc9/meta");
     // Waiting 15 secs for app to fully render dom
-    cy.get("[data-cy=meta]", { timeout: 15000 });
+    cy.get("[data-cy=meta]", { timeout: 15000 }).click();
+    cy.get("header").find(".Select").first().click();
+    cy.get('[data-value="es"]').click();
+    cy.get("[data-cy=meta]").click();
+    cy.get("[data-cy=itemParent]").contains("/es").should("exist");
   });
 });

--- a/cypress/integration/content/seoandmeta_spec.js
+++ b/cypress/integration/content/seoandmeta_spec.js
@@ -10,6 +10,12 @@ describe("Content SEO & Meta", () => {
     cy.get("header").find(".Select").first().click();
     cy.get('[data-value="es"]').click();
     cy.get("[data-cy=meta]").click();
-    cy.get("[data-cy=itemParent]").contains("/es").should("exist");
+
+    // cy.get("[data-cy=itemParent]").contains("/es").should("exist");
+    cy.get("[data-cy=itemParent]").find(".Select").click();
+
+    cy.get(".Select li").then((list) => {
+      expect(list.text()).contains("/es");
+    });
   });
 });

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/ItemSettings.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/ItemSettings.js
@@ -52,7 +52,7 @@ export const ItemSettings = memo(
                 parentZUID={web.parentZUID}
                 path={web.path}
                 onChange={onChange}
-                parentLangID={props.item.meta.langID}
+                currentItemLangID={props.item.meta.langID}
               />
               <ItemRoute
                 ZUID={meta.ZUID}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/ItemSettings.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/ItemSettings.js
@@ -52,6 +52,7 @@ export const ItemSettings = memo(
                 parentZUID={web.parentZUID}
                 path={web.path}
                 onChange={onChange}
+                parentLangID={props.item.meta.langID}
               />
               <ItemRoute
                 ZUID={meta.ZUID}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
@@ -26,7 +26,7 @@ export const ItemParent = connect((state) => {
       });
 
       const [parents, setParents] = useState(
-        parentOptions(props.parentLangID, props.path, props.content)
+        parentOptions(props.currentItemLangID, props.path, props.content)
       );
 
       const onSearch = debounce((term) => {
@@ -35,7 +35,7 @@ export const ItemParent = connect((state) => {
           props.dispatch(searchItems(term)).then((res) => {
             setLoading(false);
             setParents(
-              parentOptions(props.parentLangID, props.path, {
+              parentOptions(props.currentItemLangID, props.path, {
                 ...props.content,
                 ...res?.data,
               })
@@ -104,7 +104,7 @@ export const ItemParent = connect((state) => {
                * API to allow it to be pre-selected while avoiding re-renders on changes to this item.
                */
               setParents(
-                parentOptions(props.parentLangID, props.path, {
+                parentOptions(props.currentItemLangID, props.path, {
                   ...props.content,
                   [res.data[0].meta.ZUID]: res.data[0],
                 })
@@ -182,7 +182,7 @@ export const ItemParent = connect((state) => {
   )
 );
 
-function parentOptions(parentLangID, path, items) {
+function parentOptions(currentItemLangID, path, items) {
   return (
     Object.keys(items)
       // Filter items into list of zuids
@@ -195,7 +195,7 @@ function parentOptions(parentLangID, path, items) {
           items[itemZUID].web.path && // must have a path
           items[itemZUID].web.path !== "/" && // Exclude homepage
           items[itemZUID].web.path !== path && // Exclude current item
-          items[itemZUID].meta.langID === parentLangID
+          items[itemZUID].meta.langID === currentItemLangID
       )
       // De-dupe list of zuids & convert to item objects
       .reduce((acc, zuid) => {

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
@@ -195,7 +195,7 @@ function parentOptions(currentItemLangID, path, items) {
           items[itemZUID].web.path && // must have a path
           items[itemZUID].web.path !== "/" && // Exclude homepage
           items[itemZUID].web.path !== path && // Exclude current item
-          items[itemZUID].meta.langID === currentItemLangID
+          items[itemZUID].meta.langID === currentItemLangID // display only relevant language options
       )
       // De-dupe list of zuids & convert to item objects
       .reduce((acc, zuid) => {

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
@@ -26,7 +26,7 @@ export const ItemParent = connect((state) => {
       });
 
       const [parents, setParents] = useState(
-        parentOptions(props.path, props.content)
+        parentOptions(props.parentLangID, props.path, props.content)
       );
 
       const onSearch = debounce((term) => {
@@ -35,7 +35,7 @@ export const ItemParent = connect((state) => {
           props.dispatch(searchItems(term)).then((res) => {
             setLoading(false);
             setParents(
-              parentOptions(props.path, {
+              parentOptions(props.parentLangID, props.path, {
                 ...props.content,
                 ...res?.data,
               })
@@ -104,7 +104,7 @@ export const ItemParent = connect((state) => {
                * API to allow it to be pre-selected while avoiding re-renders on changes to this item.
                */
               setParents(
-                parentOptions(props.path, {
+                parentOptions(props.parentLangID, props.path, {
                   ...props.content,
                   [res.data[0].meta.ZUID]: res.data[0],
                 })
@@ -182,7 +182,7 @@ export const ItemParent = connect((state) => {
   )
 );
 
-function parentOptions(path, items) {
+function parentOptions(parentLangID, path, items) {
   return (
     Object.keys(items)
       // Filter items into list of zuids
@@ -194,7 +194,8 @@ function parentOptions(path, items) {
           items[itemZUID].web &&
           items[itemZUID].web.path && // must have a path
           items[itemZUID].web.path !== "/" && // Exclude homepage
-          items[itemZUID].web.path !== path // Exclude current item
+          items[itemZUID].web.path !== path && // Exclude current item
+          items[itemZUID].meta.langID === parentLangID
       )
       // De-dupe list of zuids & convert to item objects
       .reduce((acc, zuid) => {


### PR DESCRIPTION
fixes #899 

A user can currently select any item as an item's parent page for routing which can cause routing issues if the same parent page is selected for another item with the same path part (i.e: a multi lang item)

Now filtering on item's parent langID and comparing to current selected items langID

Original Dropdown with all options:
![Screen Shot 2021-10-27 at 1 32 04 PM](https://user-images.githubusercontent.com/22800749/139145606-b8bbd1bf-dead-4cb3-b29d-771a644002b0.png)


New dropdown with correlating langID options 
![Screen Shot 2021-10-27 at 1 52 20 PM](https://user-images.githubusercontent.com/22800749/139145711-4f8991a0-608c-4dc8-8020-c32d6b711b40.png)
 
