### PR TITLE
fixing missing collapse button for safari Leads page

### DIFF
--- a/src/apps/leads/src/app/views/GetStarted/GetStarted.less
+++ b/src/apps/leads/src/app/views/GetStarted/GetStarted.less
@@ -2,8 +2,5 @@
 @import "~@zesty-io/core/typography.less";
 
 .GetStarted {
-  margin: 32px;
-
-  h1 {
-  }
+  padding: 32px;
 }


### PR DESCRIPTION
Safari Leads view is missing collapse button. 

Broken-Ui 
<img width="674" alt="Screen Shot 2021-11-17 at 1 09 23 PM" src="https://user-images.githubusercontent.com/22800749/142283092-6e84ec08-c4a4-462a-99ae-19caeac84b6c.png">


Fixed
<img width="557" alt="Screen Shot 2021-11-17 at 1 11 25 PM" src="https://user-images.githubusercontent.com/22800749/142283120-f7b6136b-47a9-41c1-880a-25b731ee6a30.png">

