### PR TITLE
Force close hover state when closing content nav tree and Actions panel

### DIFF
--- a/src/apps/content-editor/src/app/components/Nav/components/ContentNavToggle/ContentNavToggle.js
+++ b/src/apps/content-editor/src/app/components/Nav/components/ContentNavToggle/ContentNavToggle.js
@@ -26,6 +26,7 @@ export function ContentNavToggle() {
       )}
       onClick={() => {
         dispatch(actions.setContentNav(!ui.contentNav));
+        dispatch(actions.setContentNavHover(false));
       }}
     >
       {ui.contentNav || ui.contentNavHover ? (

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/ActionsDrawer/ActionsDrawer.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/ActionsDrawer/ActionsDrawer.js
@@ -117,6 +117,7 @@ export default function ActionsDrawer(props) {
         title="Open for additional file information"
         onClick={() => {
           dispatch(actions.setContentActions(!ui.contentActions));
+          dispatch(actions.setContentActionsHover(false));
         }}
       >
         {ui.contentActions || ui.contentActionsHover ? (


### PR DESCRIPTION
When closing the content nav or actions panel the hover state is still true keeping the panels open until user moves mouse outside of the containers then the panels will finally close as intended. This fixes this potential confusion for the user. 

This PR: Force closes hover state when closing toggle buttons. 

Fix Demo: https://www.loom.com/share/51e3a6ac02b34144a4cc06a06958ba43 