### PR TITLE
Sentry: pass missing dispatch props to global search

### DIFF
--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -158,6 +158,7 @@ export default forwardRef((props, providedRef) => {
         onFocus={handleFocus}
         ref={providedRef}
         value={term}
+        dispatch={props.dispatch}
       />
       {term && showResults && (
         <List

--- a/src/shell/components/ContentSearch/index.js
+++ b/src/shell/components/ContentSearch/index.js
@@ -158,7 +158,6 @@ export default forwardRef((props, providedRef) => {
         onFocus={handleFocus}
         ref={providedRef}
         value={term}
-        dispatch={props.dispatch}
       />
       {term && showResults && (
         <List

--- a/src/shell/components/global-search/index.js
+++ b/src/shell/components/global-search/index.js
@@ -7,7 +7,7 @@ import { useMetaKey } from "shell/hooks/useMetaKey";
 import ContentSearch from "shell/components/ContentSearch";
 import { notify } from "shell/store/notifications";
 
-export default function GlobalSearch(props) {
+export default function GlobalSearch() {
   const dispatch = useDispatch();
   const ref = useRef();
   const history = useHistory();

--- a/src/shell/components/global-search/index.js
+++ b/src/shell/components/global-search/index.js
@@ -1,3 +1,4 @@
+import { useDispatch } from "react-redux";
 import { useRef } from "react";
 
 import { useHistory } from "react-router-dom";
@@ -7,6 +8,7 @@ import ContentSearch from "shell/components/ContentSearch";
 import { notify } from "shell/store/notifications";
 
 export default function GlobalSearch(props) {
+  const dispatch = useDispatch();
   const ref = useRef();
   const history = useHistory();
   const metaShortcut = useMetaKey("k", "shift", () => {
@@ -17,7 +19,7 @@ export default function GlobalSearch(props) {
     if (item?.meta) {
       history.push(`/content/${item.meta.contentModelZUID}/${item.meta.ZUID}`);
     } else {
-      props.dispatch(
+      dispatch(
         notify({
           kind: "warn",
           message: "Selected item is missing meta data",


### PR DESCRIPTION
Fixes: 
https://sentry.io/organizations/zestyio/issues/2498409363
https://sentry.io/organizations/zestyio/issues/2597535999
https://sentry.io/organizations/zestyio/issues/2801413946
https://sentry.io/organizations/zestyio/issues/2940269375
