### PR TITLE
Feature/duomode header small viewports

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/PreviewMode/PreviewMode.less
+++ b/src/apps/content-editor/src/app/components/Editor/PreviewMode/PreviewMode.less
@@ -1,9 +1,8 @@
 @import "~@zesty-io/core/colors.less";
 @import "~@zesty-io/core/typography.less";
 
-@height: calc(
-  100vh - 207px
-); /* Scroll Calc (GlobalTopbar - Content Header - padding) */
+/* Scroll Calc (GlobalTopbar - Content Header - padding) */
+@height: calc(100vh - 218px);
 
 .DMContainer {
   position: relative;

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/ActionsDrawer/ActionsDrawer.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/ActionsDrawer/ActionsDrawer.less
@@ -1,21 +1,16 @@
 @import "~@zesty-io/core/colors.less";
 @import "~@zesty-io/core/typography.less";
 
-/* Scroll Calc (GlobalTopbar - Content Header - button - padding) */
-@height: calc(100vh - 54px - 73px);
-
 .Drawer {
   background-color: @white;
   display: flex;
   flex-direction: column;
   border: 1px solid @bright-gray;
   border-width: 1px 0 0 0;
-  height: @height;
+
   width: 40px;
 
   height: calc(100vh - 54px - 101px);
-  @media screen and (max-width: 1800px) {
-  }
 
   transition: width 350ms ease;
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/ActionsDrawer/ActionsDrawer.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/ActionsDrawer/ActionsDrawer.less
@@ -13,6 +13,10 @@
   height: @height;
   width: 40px;
 
+  @media screen and (max-width: 1753px) {
+    height: calc(100vh - 54px - 101px);
+  }
+
   transition: width 350ms ease;
 
   //Hide Scrollbar

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/ActionsDrawer/ActionsDrawer.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/ActionsDrawer/ActionsDrawer.less
@@ -13,8 +13,8 @@
   height: @height;
   width: 40px;
 
-  @media screen and (max-width: 1753px) {
-    height: calc(100vh - 54px - 101px);
+  height: calc(100vh - 54px - 101px);
+  @media screen and (max-width: 1800px) {
   }
 
   transition: width 350ms ease;

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/ActionsDrawer/ActionsDrawer.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/ActionsDrawer/ActionsDrawer.less
@@ -7,9 +7,7 @@
   flex-direction: column;
   border: 1px solid @bright-gray;
   border-width: 1px 0 0 0;
-
   width: 40px;
-
   height: calc(100vh - 54px - 101px);
 
   transition: width 350ms ease;

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.less
@@ -1,18 +1,12 @@
 @import "~@zesty-io/core/colors.less";
 @import "~@zesty-io/core/typography.less";
 
-//Scroll Calc (GlobalTopbar - Content Header - padding)
-@height: calc(100vh - 54px - 73px);
-
 .Content {
-  height: calc(100vh - 54px);
-
   .MainEditor {
     display: grid;
     grid-template-columns: 1fr 40px;
     align-items: flex-start;
     position: relative;
-    height: @height;
 
     //Hide Scrollbar
     scrollbar-width: none; /*  FireFox */

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/Meta.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/Meta.less
@@ -1,8 +1,7 @@
 .MetaEdit {
-  display: flex;
   height: calc(100vh - 54px);
   overflow: scroll;
-  flex-direction: column;
+
   .MetaWrap {
     margin: 32px;
   }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/DuoModeToggle/DuoModeToggle.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/DuoModeToggle/DuoModeToggle.js
@@ -47,22 +47,31 @@ export function DuoModeToggle(props) {
       </Fragment>
     )
   ) : (
-    <ToggleButton
-      title="Duo Mode Toggle"
-      className={styles.ToggleButton}
-      name={props.name}
-      value={Number(ui.duoMode)}
-      offValue={<FontAwesomeIcon icon={faWindowClose} />}
-      onValue={<FontAwesomeIcon icon={faDesktop} />}
-      onChange={(val) => {
-        if (val == 1) {
-          dispatch(actions.setDuoMode(true));
-          dispatch(actions.setContentActions(false));
-        } else {
-          dispatch(actions.setDuoMode(false));
-          dispatch(actions.setContentActions(true));
-        }
-      }}
-    />
+    <Fragment>
+      {!ui.duoMode && (
+        <div className={styles.ViewLinks}>
+          <LiveUrl item={props.item} />
+          <PreviewUrl item={props.item} instance={props.instance} />
+        </div>
+      )}
+
+      <ToggleButton
+        title="Duo Mode Toggle"
+        className={styles.ToggleButton}
+        name={props.name}
+        value={Number(ui.duoMode)}
+        offValue={<FontAwesomeIcon icon={faWindowClose} />}
+        onValue={<FontAwesomeIcon icon={faDesktop} />}
+        onChange={(val) => {
+          if (val == 1) {
+            dispatch(actions.setDuoMode(true));
+            dispatch(actions.setContentActions(false));
+          } else {
+            dispatch(actions.setDuoMode(false));
+            dispatch(actions.setContentActions(true));
+          }
+        }}
+      />
+    </Fragment>
   );
 }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/DuoModeToggle/DuoModeToggle.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/DuoModeToggle/DuoModeToggle.less
@@ -1,2 +1,7 @@
 .DuoModeToggle {
 }
+.ViewLinks {
+  display: flex;
+  gap: 8px;
+  margin-left: 8px;
+}

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/DuoModeToggle/DuoModeToggle.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/DuoModeToggle/DuoModeToggle.less
@@ -1,7 +1,4 @@
-.DuoModeToggle {
-}
 .ViewLinks {
   display: flex;
   gap: 8px;
-  margin-left: 8px;
 }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.js
@@ -1,17 +1,13 @@
 import React, { Fragment } from "react";
 import cx from "classnames";
-import { useSelector } from "react-redux";
 
 import { DuoModeToggle } from "./DuoModeToggle";
 import { LanguageSelector } from "./LanguageSelector";
-import { PreviewUrl } from "./PreviewUrl";
-import { LiveUrl } from "./LiveUrl";
+
 import ItemNavigation from "./ItemNavigation";
 
 import styles from "./Header.less";
 export function Header(props) {
-  const ui = useSelector((state) => state.ui);
-
   return (
     <header className={styles.Header}>
       <div className={cx(styles.Split)}>
@@ -21,13 +17,6 @@ export function Header(props) {
             itemZUID={props.itemZUID}
             item={props.item}
           />
-
-          {/* {!ui.duoMode && (
-            <div className={styles.ViewLinks}>
-              <LiveUrl item={props.item} />
-              <PreviewUrl item={props.item} instance={props.instance} />
-            </div>
-          )} */}
         </div>
         <div className={styles.Right}>
           <div className={styles.Actions}>

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.js
@@ -22,12 +22,12 @@ export function Header(props) {
             item={props.item}
           />
 
-          {!ui.duoMode && (
+          {/* {!ui.duoMode && (
             <div className={styles.ViewLinks}>
               <LiveUrl item={props.item} />
               <PreviewUrl item={props.item} instance={props.instance} />
             </div>
-          )}
+          )} */}
         </div>
         <div className={styles.Right}>
           <div className={styles.Actions}>

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.js
@@ -1,12 +1,17 @@
-import React from "react";
+import React, { Fragment } from "react";
 import cx from "classnames";
+import { useSelector } from "react-redux";
 
 import { DuoModeToggle } from "./DuoModeToggle";
 import { LanguageSelector } from "./LanguageSelector";
+import { PreviewUrl } from "./PreviewUrl";
+import { LiveUrl } from "./LiveUrl";
 import ItemNavigation from "./ItemNavigation";
 
 import styles from "./Header.less";
 export function Header(props) {
+  const ui = useSelector((state) => state.ui);
+
   return (
     <header className={styles.Header}>
       <div className={cx(styles.Split)}>
@@ -16,6 +21,13 @@ export function Header(props) {
             itemZUID={props.itemZUID}
             item={props.item}
           />
+
+          {!ui.duoMode && (
+            <div className={styles.ViewLinks}>
+              <LiveUrl item={props.item} />
+              <PreviewUrl item={props.item} instance={props.instance} />
+            </div>
+          )}
         </div>
         <div className={styles.Right}>
           <div className={styles.Actions}>

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.less
@@ -29,12 +29,6 @@
     .Left {
       display: flex;
       align-items: center;
-
-      .ViewLinks {
-        display: flex;
-        gap: 8px;
-        margin-left: 8px;
-      }
     }
     .Right {
     }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.less
@@ -18,6 +18,7 @@
     align-items: center;
     display: flex;
     gap: 8px;
+    justify-content: space-between;
 
     @media screen and (max-width: 2000px) {
       flex-wrap: wrap;
@@ -26,12 +27,21 @@
     .Left {
       display: flex;
       align-items: center;
+
+      .ViewLinks {
+        display: flex;
+        gap: 8px;
+        margin-left: 8px;
+      }
     }
     .Right {
       display: flex;
       align-items: center;
       flex-wrap: wrap;
-      margin-left: auto;
+
+      @media screen and (max-width: 1366px) {
+        margin-left: auto;
+      }
     }
   }
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/Header.less
@@ -2,6 +2,10 @@
 @import "~@zesty-io/core/typography.less";
 
 .Header {
+  box-sizing: border-box;
+  height: 101px;
+  display: flex;
+
   padding: 16px 32px;
   @media only screen and (min-width: 2000px) {
     padding: 16px 48px;
@@ -18,11 +22,9 @@
     align-items: center;
     display: flex;
     gap: 8px;
+    flex-wrap: wrap;
     justify-content: space-between;
-
-    @media screen and (max-width: 2000px) {
-      flex-wrap: wrap;
-    }
+    width: 100%;
 
     .Left {
       display: flex;
@@ -35,13 +37,6 @@
       }
     }
     .Right {
-      display: flex;
-      align-items: center;
-      flex-wrap: wrap;
-
-      @media screen and (max-width: 1366px) {
-        margin-left: auto;
-      }
     }
   }
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.js
@@ -1,5 +1,13 @@
 import cx from "classnames";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faEdit,
+  faCode,
+  faTags,
+  faDatabase,
+} from "@fortawesome/free-solid-svg-icons";
+
 import { AppLink } from "@zesty-io/core/AppLink";
 
 import styles from "./ItemNavigation.less";
@@ -23,7 +31,8 @@ export default function ItemNavigation({ modelZUID, itemZUID, item }) {
         )}
         to={`/content/${modelZUID}/${itemZUID}`}
       >
-        Edit Content
+        <FontAwesomeIcon icon={faEdit} title="Edit Content" />
+        <span>Edit Content</span>
       </AppLink>
       <AppLink
         title="SEO & Meta"
@@ -35,7 +44,8 @@ export default function ItemNavigation({ modelZUID, itemZUID, item }) {
         )}
         to={`/content/${modelZUID}/${itemZUID}/meta`}
       >
-        SEO &amp; Meta
+        <FontAwesomeIcon icon={faCode} title="SEO & Meta" />
+        <span>SEO &amp; Meta</span>
       </AppLink>
       {item.web.path && (
         <AppLink
@@ -48,7 +58,8 @@ export default function ItemNavigation({ modelZUID, itemZUID, item }) {
           )}
           to={`/content/${modelZUID}/${itemZUID}/head`}
         >
-          Head Tags
+          <FontAwesomeIcon icon={faTags} title="Head Tags" />
+          <span>Head Tags</span>
         </AppLink>
       )}
 
@@ -62,7 +73,8 @@ export default function ItemNavigation({ modelZUID, itemZUID, item }) {
         )}
         to={`/content/${modelZUID}/${itemZUID}/headless`}
       >
-        Headless <span className={styles.Hide}>Options</span>
+        <FontAwesomeIcon icon={faDatabase} title="Headless Options" />
+        <span>Headless Options</span>
       </AppLink>
     </nav>
   );

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.less
@@ -12,6 +12,12 @@
       margin-right: 8px;
     }
 
+    // @media screen and (max-width: 1366px) {
+    //   span{
+    //     display: none;
+    //   }
+    // }
+
     @media screen and (min-width: 2000px) {
       font-size: 18px;
     }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.less
@@ -12,12 +12,6 @@
       margin-right: 8px;
     }
 
-    // @media screen and (max-width: 1366px) {
-    //   span{
-    //     display: none;
-    //   }
-    // }
-
     @media screen and (min-width: 2000px) {
       font-size: 18px;
     }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.less
@@ -8,19 +8,31 @@
   a {
     font-size: 14px;
 
+    svg {
+      margin-right: 8px;
+    }
+
+    @media screen and (max-width: 1366px) {
+      span {
+        display: none;
+      }
+    }
+
     @media screen and (min-width: 2000px) {
       font-size: 18px;
     }
   }
 
   .Selected {
-    text-decoration: 2px underline @zesty-orange;
-    text-underline-position: under;
-  }
-  .Hide {
-    display: none;
-    @media screen and (min-width: 2000px) {
-      display: inline-block;
+    position: relative;
+    &::after {
+      position: absolute;
+      content: "";
+      height: 2px;
+      width: 100%;
+      bottom: -2px;
+      left: 0;
+      background: @zesty-orange;
     }
   }
 }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemNavigation/ItemNavigation.less
@@ -12,12 +12,6 @@
       margin-right: 8px;
     }
 
-    @media screen and (max-width: 1366px) {
-      span {
-        display: none;
-      }
-    }
-
     @media screen and (min-width: 2000px) {
       font-size: 18px;
     }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -174,7 +174,9 @@ export function ItemVersioning(props) {
         ) : (
           <FontAwesomeIcon icon={faSave} />
         )}
-        <span className={styles.Test}>&nbsp;Save Version {metaShortcut}</span>
+        <span className={styles.SaveVersion}>
+          &nbsp;Save Version {metaShortcut}
+        </span>
       </Button>
     </ButtonGroup>
   );

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.js
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
+import cx from "classnames";
 import { useMetaKey } from "shell/hooks/useMetaKey";
+import { useSelector } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -22,6 +24,8 @@ import { useDomain } from "shell/hooks/use-domain";
 
 import styles from "./ItemVersioning.less";
 export function ItemVersioning(props) {
+  const ui = useSelector((state) => state.ui);
+
   const canPublish = usePermission("PUBLISH");
   const domain = useDomain();
 
@@ -133,9 +137,9 @@ export function ItemVersioning(props) {
                 title="CDN out of sync"
               />
             )}
-            <span className={styles.Hide}>Publish</span>
+            <span>Publish</span>
             <span className={styles.Hide}>&nbsp;Version&nbsp;</span>
-            <span className={styles.Hide}>&nbsp;{props.item.meta.version}</span>
+            <span>&nbsp;{props.item.meta.version}</span>
           </Button>
           <Button
             title="Publish Schedule"
@@ -174,9 +178,11 @@ export function ItemVersioning(props) {
         ) : (
           <FontAwesomeIcon icon={faSave} />
         )}
-        <span className={styles.SaveVersion}>
-          &nbsp;Save Version {metaShortcut}
+        <span className={styles.SaveVersion}>&nbsp;Save</span>
+        <span className={cx(ui.openNav && styles.SmHide)}>
+          &nbsp;Version&nbsp;
         </span>
+        <span className={styles.Hide}>&nbsp;{metaShortcut}</span>
       </Button>
     </ButtonGroup>
   );

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.less
@@ -24,36 +24,36 @@
       background-color: @zesty-orange;
     }
   }
-  .Save,
-  .PublishButton {
-    align-self: stretch;
-    svg {
-      margin-right: 0;
-    }
-    @media screen and (min-width: 2000px) {
-      svg {
-        margin-right: 8px;
-      }
-    }
-  }
+  // .Save,
+  // .PublishButton {
+  //   align-self: stretch;
+  //   svg {
+  //     margin-right: 0;
+  //   }
+  //   @media screen and (min-width: 2000px) {
+  //     svg {
+  //       margin-right: 8px;
+  //     }
+  //   }
+  // }
   .Hide {
-    display: none;
+    // display: none;
 
     @media screen and (min-width: 2000px) {
       display: block;
     }
   }
-  .Test {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    display: none;
-    @media screen and (min-width: 1440px) {
-      width: 120px;
-      display: block;
-    }
-    @media screen and (min-width: 1680px) {
-      width: 100%;
-    }
-  }
+  // .SaveVersion {
+  //   overflow: hidden;
+  //   white-space: nowrap;
+  //   text-overflow: ellipsis;
+  //   display: none;
+  //   @media screen and (min-width: 1440px) {
+  //     width: 120px;
+  //     display: block;
+  //   }
+  //   @media screen and (min-width: 1680px) {
+  //     width: 100%;
+  //   }
+  // }
 }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/Header/ItemVersioning/ItemVersioning.less
@@ -24,36 +24,13 @@
       background-color: @zesty-orange;
     }
   }
-  // .Save,
-  // .PublishButton {
-  //   align-self: stretch;
-  //   svg {
-  //     margin-right: 0;
-  //   }
-  //   @media screen and (min-width: 2000px) {
-  //     svg {
-  //       margin-right: 8px;
-  //     }
-  //   }
-  // }
-  .Hide {
-    // display: none;
 
-    @media screen and (min-width: 2000px) {
-      display: block;
+  @media screen and (max-width: 1366px) {
+    .Hide {
+      display: none;
+    }
+    .SmHide {
+      display: none;
     }
   }
-  // .SaveVersion {
-  //   overflow: hidden;
-  //   white-space: nowrap;
-  //   text-overflow: ellipsis;
-  //   display: none;
-  //   @media screen and (min-width: 1440px) {
-  //     width: 120px;
-  //     display: block;
-  //   }
-  //   @media screen and (min-width: 1680px) {
-  //     width: 100%;
-  //   }
-  // }
 }


### PR DESCRIPTION
Updated Duo Mode header 

Set height on header so no huge jumps/jankyness across different viewport sizes.
Brought back save and publish buttons content info 
Brought back preview URL and Live url when duo mode is off( numerous customer/staff request) 

Deployed to Dev : https://8-f48cf3a682-7fthvk.manager.dev.zesty.io/content/6-a1a600-k0b6f0/7-a1be38-1b42ht

https://www.screencast.com/t/sh2dduaTbP