### PR TITLE
Fix: content editor request infinite loop

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -1,4 +1,4 @@
-import { memo, useMemo, useCallback, useState } from "react";
+import { memo, useMemo, useCallback, useState, useEffect } from "react";
 import ReactDOM from "react-dom";
 import { useDispatch, useSelector } from "react-redux";
 import moment from "moment-timezone";
@@ -188,6 +188,18 @@ export default function Field({
 
   const value = item?.data?.[name];
   const version = item?.meta?.version;
+
+  useEffect(() => {
+    // On mount, if the initial value doesn't exist in local store load from API
+    if (value && (!allItems[value] || !allItems[value].meta)) {
+      if (relatedModelZUID && value) {
+        if (value != "0") {
+          console.log("one_to_one", relatedModelZUID);
+          dispatch(fetchItem(relatedModelZUID, value));
+        }
+      }
+    }
+  }, []);
 
   function renderMediaModal() {
     return ReactDOM.createPortal(
@@ -519,15 +531,6 @@ export default function Field({
       );
 
     case "one_to_one":
-      // If the initial value doesn't exist in local store load from API
-      if (value && (!allItems[value] || !allItems[value].meta)) {
-        if (relatedModelZUID && value) {
-          if (value != "0") {
-            dispatch(fetchItem(relatedModelZUID, value));
-          }
-        }
-      }
-
       const onOneToOneOpen = useCallback(() => {
         return dispatch(
           fetchItems(relatedModelZUID, {

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -593,21 +593,6 @@ export default function Field({
       );
 
     case "one_to_many":
-      //TODO: we need to implement specific fetches for items
-      // when an endpoint is available for that purpose
-      // if (value) {
-      //   const resolved = resolveRelatedOptions(
-      //     allFields,
-      //     allItems,
-      //     relatedFieldZUID,
-      //     relatedModelZUID
-      //   );
-      //   if (value.split(",").length > resolved.length) {
-      //     dispatch(fetchFields(relatedModelZUID));
-      //     dispatch(fetchItems(relatedModelZUID));
-      //   }
-      // }
-
       const oneToManyOptions = useMemo(() => {
         return resolveRelatedOptions(
           allFields,

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -2,6 +2,8 @@ import { memo, useMemo, useCallback, useState, useEffect } from "react";
 import ReactDOM from "react-dom";
 import { useDispatch, useSelector } from "react-redux";
 import moment from "moment-timezone";
+import zuid from "zuid";
+
 import { fetchFields } from "shell/store/fields";
 import { fetchItem, fetchItems, searchItems } from "shell/store/content";
 
@@ -190,14 +192,11 @@ export default function Field({
   const version = item?.meta?.version;
 
   useEffect(() => {
-    // On mount, if the initial value doesn't exist in local store load from API
-    if (value && (!allItems[value] || !allItems[value].meta)) {
-      if (relatedModelZUID && value) {
-        if (value != "0") {
-          console.log("one_to_one", relatedModelZUID);
-          dispatch(fetchItem(relatedModelZUID, value));
-        }
-      }
+    if (
+      zuid.isValid(value) &&
+      !zuid.matches(value, zuid.prefix["MEDIA_FILE"])
+    ) {
+      dispatch(searchItems(value));
     }
   }, []);
 
@@ -504,11 +503,6 @@ export default function Field({
           value: value,
           text: `Related item: ${value}`,
         });
-
-        // load related item from API
-        if (value && value != "0") {
-          dispatch(searchItems(value));
-        }
       }
 
       const onInternalLinkSearch = useCallback(

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -192,11 +192,12 @@ export default function Field({
   const version = item?.meta?.version;
 
   useEffect(() => {
-    if (
-      zuid.isValid(value) &&
-      !zuid.matches(value, zuid.prefix["MEDIA_FILE"])
-    ) {
-      dispatch(searchItems(value));
+    if (value && typeof value === "string") {
+      value.split(",").forEach((z) => {
+        if (zuid.isValid(z) && !zuid.matches(z, zuid.prefix["MEDIA_FILE"])) {
+          dispatch(searchItems(z));
+        }
+      });
     }
   }, []);
 


### PR DESCRIPTION
**Issue**: When we load a view to display a content item all the related values need to be resolved. We start by checking the redux store. If the value is not present there we make an API request. When this request completes it updates the redux store and triggers a render. If the related item has been deleted then no data was returned and we enter into a loop repeating these steps.

**Solution**: Move lookup into a one-time `useEffect` on component mount

The solution solves this issue for the following related fields types
 - one-to-one
 - many-to-one
 - internal links