### PR TITLE
fixed: handle 404 responses for content items

### DIFF
--- a/src/apps/content-editor/src/app/ContentEditor.js
+++ b/src/apps/content-editor/src/app/ContentEditor.js
@@ -1,9 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Switch, Route } from "react-router-dom";
 import cx from "classnames";
-
-import { actions } from "shell/store/ui";
 
 import { fetchModels } from "shell/store/models";
 import { fetchNav } from "../store/navContent";
@@ -25,7 +23,7 @@ import { CSVImport } from "./views/CSVImport";
 import "@zesty-io/core/vendor.css";
 
 import styles from "./ContentEditor.less";
-export default function ContentEditor(props) {
+export default function ContentEditor() {
   const contentModels = useSelector((state) => state.models);
   const navContent = useSelector((state) => state.navContent);
   const ui = useSelector((state) => state.ui);
@@ -68,9 +66,7 @@ export default function ContentEditor(props) {
           <div className={styles.ContentWrap}>
             <Switch>
               <Route exact path="/content" component={Dashboard} />
-
               <Route exact path="/content/link/new" component={LinkCreate} />
-
               <Route
                 exact
                 path="/content/:modelZUID/new"
@@ -87,7 +83,6 @@ export default function ContentEditor(props) {
                 component={ItemEdit}
               />
               <Route exact path="/content/:modelZUID" component={ItemList} />
-
               <Route path="*" component={NotFound} />
             </Switch>
           </div>

--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -80,10 +80,10 @@ export default function ItemEdit() {
   const [checkingLock, setCheckingLock] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [notFound, setNotFound] = useState(false);
+  const [notFound, setNotFound] = useState("");
 
   useEffect(() => {
-    setNotFound(false);
+    setNotFound("");
 
     // on mount and modelZUID/itemZUID update,
     // lock item and load all item data
@@ -128,17 +128,8 @@ export default function ItemEdit() {
     try {
       const itemResponse = await dispatch(fetchItem(modelZUID, itemZUID));
 
-      if (itemResponse.status === 404) {
-        setNotFound(true);
-      }
-
-      if (itemResponse.status === 400) {
-        dispatch(
-          notify({
-            message: itemResponse.message,
-            kind: "error",
-          })
-        );
+      if (itemResponse.status === 404 || itemResponse.status === 400) {
+        setNotFound(itemResponse.message || itemResponse.error);
       }
 
       if (itemResponse?.data?.meta?.langID) {
@@ -243,7 +234,7 @@ export default function ItemEdit() {
   return (
     <Fragment>
       {notFound ? (
-        <NotFound />
+        <NotFound message={notFound} />
       ) : (
         <WithLoader
           condition={!loading && item && Object.keys(item).length}

--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import {
   Switch,
   Route,
@@ -240,139 +240,143 @@ export default function ItemEdit() {
   const handleLockedItem =
     !checkingLock && lockState.userZUID !== user.user_zuid;
 
-  return notFound ? (
-    <NotFound />
-  ) : (
-    <WithLoader
-      condition={!loading && item && Object.keys(item).length}
-      message={
-        model?.label ? `Loading ${model.label} Content` : "Loading Content"
-      }
-    >
-      {handleLockedItem && (
-        <LockedItem
-          timestamp={lockState.timestamp}
-          userFirstName={lockState.firstName}
-          userLastName={lockState.lastName}
-          userEmail={lockState.email}
-          itemName={item?.web?.metaLinkText}
-          handleUnlock={forceUnlock}
-          goBack={() => history.goBack()}
-          handleLockedItem={handleLockedItem}
-        />
+  return (
+    <Fragment>
+      {notFound ? (
+        <NotFound />
+      ) : (
+        <WithLoader
+          condition={!loading && item && Object.keys(item).length}
+          message={
+            model?.label ? `Loading ${model.label} Content` : "Loading Content"
+          }
+        >
+          {handleLockedItem && (
+            <LockedItem
+              timestamp={lockState.timestamp}
+              userFirstName={lockState.firstName}
+              userLastName={lockState.lastName}
+              userEmail={lockState.email}
+              itemName={item?.web?.metaLinkText}
+              handleUnlock={forceUnlock}
+              goBack={() => history.goBack()}
+              handleLockedItem={handleLockedItem}
+            />
+          )}
+
+          <PendingEditsModal
+            show={item?.dirty}
+            title="Unsaved Changes"
+            message="You have unsaved changes that will be lost if you leave this page."
+            loading={saving}
+            onSave={save}
+            onDiscard={discard}
+          />
+
+          <section>
+            <Switch>
+              <Route
+                exact
+                path="/content/:modelZUID/:itemZUID/head"
+                render={({ match }) => {
+                  // All roles except contributor are allowed to edit the document head
+                  return userRole.name !== "Contributor" ? (
+                    <ItemHead
+                      instance={instance}
+                      modelZUID={modelZUID}
+                      model={model}
+                      itemZUID={itemZUID}
+                      item={item}
+                      tags={tags}
+                      dispatch={dispatch}
+                    />
+                  ) : (
+                    <Redirect
+                      to={`/content/${match.params.modelZUID}/${match.params.itemZUID}`}
+                    />
+                  );
+                }}
+              />
+              <Route
+                exact
+                path="/content/:modelZUID/:itemZUID/meta"
+                render={() => (
+                  <Meta
+                    instance={instance}
+                    modelZUID={modelZUID}
+                    model={model}
+                    itemZUID={itemZUID}
+                    item={item}
+                    items={items}
+                    fields={fields}
+                    user={user}
+                    onSave={save}
+                    dispatch={dispatch}
+                    saving={saving}
+                  />
+                )}
+              />
+              <Route
+                exact
+                path="/content/:modelZUID/:itemZUID/preview"
+                render={() => (
+                  <WebEnginePreview
+                    instance={instance}
+                    modelZUID={modelZUID}
+                    model={model}
+                    itemZUID={itemZUID}
+                    item={item}
+                    items={items}
+                    fields={fields}
+                    user={user}
+                    onSave={save}
+                    dispatch={dispatch}
+                    saving={saving}
+                  />
+                )}
+              />
+              <Route
+                exact
+                path="/content/:modelZUID/:itemZUID/headless"
+                render={() => (
+                  <HeadlessOptions
+                    instance={instance}
+                    modelZUID={modelZUID}
+                    model={model}
+                    itemZUID={itemZUID}
+                    item={item}
+                    items={items}
+                    fields={fields}
+                    user={user}
+                    dispatch={dispatch}
+                    saving={saving}
+                  />
+                )}
+              />
+              <Route
+                exact
+                path="/content/:modelZUID/:itemZUID"
+                render={() => (
+                  <Content
+                    instance={instance}
+                    modelZUID={modelZUID}
+                    model={model}
+                    itemZUID={itemZUID}
+                    item={item}
+                    items={items}
+                    fields={fields}
+                    user={user}
+                    onSave={save}
+                    dispatch={dispatch}
+                    loading={loading}
+                    saving={saving}
+                  />
+                )}
+              />
+            </Switch>
+          </section>
+        </WithLoader>
       )}
-
-      <PendingEditsModal
-        show={item?.dirty}
-        title="Unsaved Changes"
-        message="You have unsaved changes that will be lost if you leave this page."
-        loading={saving}
-        onSave={save}
-        onDiscard={discard}
-      />
-
-      <section>
-        <Switch>
-          <Route
-            exact
-            path="/content/:modelZUID/:itemZUID/head"
-            render={({ match }) => {
-              // All roles except contributor are allowed to edit the document head
-              return userRole.name !== "Contributor" ? (
-                <ItemHead
-                  instance={instance}
-                  modelZUID={modelZUID}
-                  model={model}
-                  itemZUID={itemZUID}
-                  item={item}
-                  tags={tags}
-                  dispatch={dispatch}
-                />
-              ) : (
-                <Redirect
-                  to={`/content/${match.params.modelZUID}/${match.params.itemZUID}`}
-                />
-              );
-            }}
-          />
-          <Route
-            exact
-            path="/content/:modelZUID/:itemZUID/meta"
-            render={() => (
-              <Meta
-                instance={instance}
-                modelZUID={modelZUID}
-                model={model}
-                itemZUID={itemZUID}
-                item={item}
-                items={items}
-                fields={fields}
-                user={user}
-                onSave={save}
-                dispatch={dispatch}
-                saving={saving}
-              />
-            )}
-          />
-          <Route
-            exact
-            path="/content/:modelZUID/:itemZUID/preview"
-            render={() => (
-              <WebEnginePreview
-                instance={instance}
-                modelZUID={modelZUID}
-                model={model}
-                itemZUID={itemZUID}
-                item={item}
-                items={items}
-                fields={fields}
-                user={user}
-                onSave={save}
-                dispatch={dispatch}
-                saving={saving}
-              />
-            )}
-          />
-          <Route
-            exact
-            path="/content/:modelZUID/:itemZUID/headless"
-            render={() => (
-              <HeadlessOptions
-                instance={instance}
-                modelZUID={modelZUID}
-                model={model}
-                itemZUID={itemZUID}
-                item={item}
-                items={items}
-                fields={fields}
-                user={user}
-                dispatch={dispatch}
-                saving={saving}
-              />
-            )}
-          />
-          <Route
-            exact
-            path="/content/:modelZUID/:itemZUID"
-            render={() => (
-              <Content
-                instance={instance}
-                modelZUID={modelZUID}
-                model={model}
-                itemZUID={itemZUID}
-                item={item}
-                items={items}
-                fields={fields}
-                user={user}
-                onSave={save}
-                dispatch={dispatch}
-                loading={loading}
-                saving={saving}
-              />
-            )}
-          />
-        </Switch>
-      </section>
-    </WithLoader>
+    </Fragment>
   );
 }

--- a/src/apps/content-editor/src/app/views/ItemList/ItemList.js
+++ b/src/apps/content-editor/src/app/views/ItemList/ItemList.js
@@ -220,7 +220,6 @@ export default connect((state, props) => {
         setBackgroundLoading(false);
       }
     } catch (err) {
-      console.error("ItemList:load:error", err);
       if (_isMounted.current) {
         setInitialLoading(false);
         setBackgroundLoading(false);

--- a/src/apps/content-editor/src/app/views/NotFound/NotFound.js
+++ b/src/apps/content-editor/src/app/views/NotFound/NotFound.js
@@ -1,5 +1,4 @@
 import { Component } from "react";
-// import cx from "classnames";
 
 import { Url } from "@zesty-io/core/Url";
 
@@ -8,17 +7,20 @@ export class NotFound extends Component {
   render() {
     return (
       <section className={styles.NotFound}>
-        <h1 className={styles.display}>This item is missing</h1>
-        <h2 className={styles.title}>
-          If you expected an item to be here please contact support with this
-          url
-        </h2>
-        <Url
-          title={`Provide this URL: ${window.location.href} with your bug ticket`}
-          href={window.location.href}
-        >
-          {window.location.href}
-        </Url>
+        <main className={styles.wrap}>
+          <h1 className={styles.display}>Requested item not found</h1>
+          <p className={styles.title}>
+            If an item is missing please contact support and provide the url;
+          </p>
+          <p className={styles.title}>
+            <Url
+              title={`Provide this URL: ${window.location.href} with your bug ticket`}
+              href={window.location.href}
+            >
+              {window.location.href}
+            </Url>
+          </p>
+        </main>
       </section>
     );
   }

--- a/src/apps/content-editor/src/app/views/NotFound/NotFound.js
+++ b/src/apps/content-editor/src/app/views/NotFound/NotFound.js
@@ -1,27 +1,24 @@
-import { Component } from "react";
-
 import { Url } from "@zesty-io/core/Url";
 
 import styles from "./NotFound.less";
-export class NotFound extends Component {
-  render() {
-    return (
-      <section className={styles.NotFound}>
-        <main className={styles.wrap}>
-          <h1 className={styles.display}>Requested item not found</h1>
-          <p className={styles.title}>
-            If an item is missing please contact support and provide the url;
-          </p>
-          <p className={styles.title}>
-            <Url
-              title={`Provide this URL: ${window.location.href} with your bug ticket`}
-              href={window.location.href}
-            >
-              {window.location.href}
-            </Url>
-          </p>
-        </main>
-      </section>
-    );
-  }
+export function NotFound(props) {
+  return (
+    <section className={styles.NotFound}>
+      <main className={styles.wrap}>
+        <h1 className={styles.display}>{props.message}</h1>
+        {/* <h2>{props.message}</h2> */}
+        <p className={styles.title}>
+          If an item is missing please contact support and provide the url;
+        </p>
+        <p className={styles.title}>
+          <Url
+            title={`Provide this URL: ${window.location.href} with your bug ticket`}
+            href={window.location.href}
+          >
+            {window.location.href}
+          </Url>
+        </p>
+      </main>
+    </section>
+  );
 }

--- a/src/apps/content-editor/src/app/views/NotFound/NotFound.js
+++ b/src/apps/content-editor/src/app/views/NotFound/NotFound.js
@@ -8,11 +8,9 @@ export class NotFound extends Component {
   render() {
     return (
       <section className={styles.NotFound}>
-        <h1 className={styles.title}>
-          We are sorry but it seems this page is missing
-        </h1>
-        <h2 className={styles.display}>
-          If you expected something to be here please contact support with this
+        <h1 className={styles.display}>This item is missing</h1>
+        <h2 className={styles.title}>
+          If you expected an item to be here please contact support with this
           url
         </h2>
         <Url

--- a/src/apps/content-editor/src/app/views/NotFound/NotFound.less
+++ b/src/apps/content-editor/src/app/views/NotFound/NotFound.less
@@ -7,6 +7,11 @@
   align-items: center;
   justify-content: center;
   flex-direction: column;
+
+  .wrap {
+    width: 70rem;
+  }
+
   & > * {
     margin: 8px 0;
   }

--- a/src/apps/content-editor/src/app/views/NotFound/NotFound.less
+++ b/src/apps/content-editor/src/app/views/NotFound/NotFound.less
@@ -11,8 +11,4 @@
   .wrap {
     width: 70rem;
   }
-
-  & > * {
-    margin: 8px 0;
-  }
 }

--- a/src/apps/content-editor/src/app/views/NotFound/NotFound.less
+++ b/src/apps/content-editor/src/app/views/NotFound/NotFound.less
@@ -1,12 +1,10 @@
 @import "~@zesty-io/core/typography.less";
 .NotFound {
-  width: 85vw;
   height: 100vh;
   padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-direction: column;
 
   .wrap {
     width: 70rem;

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -321,14 +321,12 @@ export function fetchItems(modelZUID, options = {}) {
       uri: `${CONFIG.API_INSTANCE}/content/models/${modelZUID}/items?${params}`,
       handler: (res) => {
         if (res.status === 400) {
-          console.error("fetchItems():response", res);
           dispatch(
             notify({
               kind: "warn",
               message: res.error,
             })
           );
-          throw res;
         }
 
         if (res.status === 200) {


### PR DESCRIPTION
fixes https://sentry.io/organizations/zestyio/issues/?project=5441698&query=is%3Aunresolved+No+Results+Found+for+ZUID&statsPeriod=14d

This PR introduces logic to explicitly handle when the API returns a 404 not found response for a 7- content item. Which typically indicates the record has been deleted or never existed. Showing a not found view.