### PR TITLE
updating title attr and info tips in media modal

### DIFF
--- a/src/apps/media/src/app/components/MediaDetailsModal.js
+++ b/src/apps/media/src/app/components/MediaDetailsModal.js
@@ -78,32 +78,31 @@ export const MediaDetailsModal = memo(function MediaDetailsModal(props) {
             kind="outlined"
             value={props.file.url}
           />
-
-          <FieldTypeText
-            className={styles.Field}
-            name="title"
-            value={title}
-            label={
-              <label>
-                <Infotip title="Edit title. | Use for alt text with Parsley's .getImageTitle()" />
-                &nbsp;Title
-              </label>
-            }
-            placeholder={"Image Title"}
-            onChange={(val) => setTitle(val)}
-          />
           <FieldTypeText
             className={styles.Field}
             name="filename"
             value={filename}
             label={
               <label>
-                <Infotip title="Edit Filename " />
-                &nbsp;Filename
+                <Infotip title="Edit Filename to update your image URL " />
+                &nbsp;Edit Filename URL
               </label>
             }
             placeholder={"Image Filename"}
             onChange={(val) => setFilename(val)}
+          />
+          <FieldTypeText
+            className={styles.Field}
+            name="title"
+            value={title}
+            label={
+              <label>
+                <Infotip title=" Use for alt text with Parsley's .getImageTitle() | Image alt text is used to describe your image textually so that search engines and screen readers can understand what that image is. It’s important to note that using alt text correctly can enhance your SEO strategy" />
+                &nbsp; Alt Title
+              </label>
+            }
+            placeholder={"Image ALT Title"}
+            onChange={(val) => setTitle(val)}
           />
 
           <dl className={styles.DescriptionList}>


### PR DESCRIPTION
fixes #949 
PR: design systems : https://github.com/zesty-io/design-system/pull/159

![Screen Shot 2022-01-24 at 11 56 18 AM](https://user-images.githubusercontent.com/22800749/150855002-82a1c499-7397-4398-8b04-cc845eb28122.png)

![Screen Shot 2022-01-24 at 11 56 28 AM](https://user-images.githubusercontent.com/22800749/150855023-9fccba9e-0b60-41e5-b445-aade9044cf92.png)

I think the idea of combining  filename and title would cause confusion. I went with more descriptive titles and added better information in the info tip.  
