### PR TITLE
adding text to copy button to prevent user confusion

### DIFF
--- a/src/apps/active-preview/Preview.js
+++ b/src/apps/active-preview/Preview.js
@@ -130,23 +130,34 @@ export function Preview(props) {
               src="https://brand.zesty.io/zesty-io-logo-dark.svg"
             />
             &nbsp;
-            <figcaption>Active Preview</figcaption>
+            <figcaption>ActivePreview</figcaption>
           </figure>
           <div className={styles.ActionInfo}>
-            <div className={styles.Url}>
-              <Button
-                onClick={() => setRefresh(Date.now())}
-                title="Reload current url in active preview"
+            {instance.domain && (
+              <Url
+                className={styles.Live}
+                href={`//${instance.domain}${route}`}
+                target="_blank"
+                title="Open live link in standard browser window"
               >
-                <FontAwesomeIcon icon={faSync} />
-              </Button>
+                <FontAwesomeIcon icon={faExternalLinkAlt} />
+                &nbsp;Live
+              </Url>
+            )}
 
+            <div className={styles.Url}>
               <CopyButton
                 className={styles.CopyButton}
                 value={`${domain}${route}`}
               >
                 Preview
               </CopyButton>
+              <Button
+                onClick={() => setRefresh(Date.now())}
+                title="Reload current url in ActivePreview"
+              >
+                <FontAwesomeIcon icon={faSync} />
+              </Button>
               <Input
                 ref={input}
                 className={styles.Route}
@@ -155,14 +166,6 @@ export function Preview(props) {
             </div>
 
             <div className={styles.Device}>
-              <Button onClick={() => setRotate(!rotate)} title="Rotate device">
-                <FontAwesomeIcon
-                  icon={faMobileAlt}
-                  style={{
-                    transform: `rotate(${rotate ? "-90deg" : "0deg"})`,
-                  }}
-                />
-              </Button>
               <Select
                 className={styles.Select}
                 name="device"
@@ -185,19 +188,15 @@ export function Preview(props) {
                     />
                   ))}
               </Select>
+              <Button onClick={() => setRotate(!rotate)} title="Rotate device">
+                <FontAwesomeIcon
+                  icon={faMobileAlt}
+                  style={{
+                    transform: `rotate(${rotate ? "-90deg" : "0deg"})`,
+                  }}
+                />
+              </Button>
             </div>
-
-            {instance.domain && (
-              <Url
-                className={styles.Live}
-                href={`//${instance.domain}${route}`}
-                target="_blank"
-                title="Open live link in standard browser window"
-              >
-                <FontAwesomeIcon icon={faExternalLinkAlt} />
-                &nbsp;Live
-              </Url>
-            )}
 
             <div className={styles.Menu}>
               <Button

--- a/src/apps/active-preview/Preview.js
+++ b/src/apps/active-preview/Preview.js
@@ -144,7 +144,9 @@ export function Preview(props) {
               <CopyButton
                 className={styles.CopyButton}
                 value={`${domain}${route}`}
-              />
+              >
+                Preview
+              </CopyButton>
               <Input
                 ref={input}
                 className={styles.Route}

--- a/src/apps/active-preview/Preview.less
+++ b/src/apps/active-preview/Preview.less
@@ -122,14 +122,4 @@
   [title~="Reload"] {
     margin-right: 8px;
   }
-
-  //Hide copy url text for smaller screens windows
-
-  .CopyButton {
-    display: flex;
-    font-size: 0;
-    svg {
-      margin-right: initial;
-    }
-  }
 }

--- a/src/apps/active-preview/Preview.less
+++ b/src/apps/active-preview/Preview.less
@@ -17,57 +17,56 @@
     .Logo {
       display: flex;
       align-items: center;
-      margin-right: 8px;
+      margin-right: 16px;
       // media query on iframe
-      @media screen and (max-width: 1280px) {
+      @media (max-width: 1280px) {
         display: none;
       }
     }
 
     .ActionInfo {
-      display: flex;
-      margin-left: auto;
       flex: 2;
-    }
+      display: grid;
+      grid-template-columns: 40px 1fr 184px 44px;
+      grid-gap: 16px;
 
-    .Url {
-      display: flex;
-      flex: 1;
-      .Route {
-        flex: 1;
-        // media query on iframe
-        @media screen and (max-width: 650px) {
-          display: none;
+      .Live {
+        display: flex;
+        align-items: center;
+      }
+
+      .Url {
+        display: flex;
+        .CopyButton {
+          margin-right: 3px;
+          width: 101px; // needs exact width to avoid breaking grid
         }
-      }
-    }
-
-    .Device {
-      display: flex;
-      margin: 0 8px;
-      [title="Rotate device"] {
-        margin-right: 8px;
-      }
-      .Select {
-        li {
-          small {
-            color: @zesty-gray;
+        .Route {
+          flex: 1;
+          @media (max-width: 650px) {
+            display: none;
           }
         }
       }
-    }
 
-    .Live {
-      display: flex;
-      align-items: center;
-    }
+      .Device {
+        display: flex;
+        .Select {
+          margin-right: 3px;
+          width: 140px;
+          ul {
+            width: 170px;
+          }
+          li {
+            small {
+              color: @zesty-gray;
+            }
+          }
+        }
+      }
 
-    .Menu {
-      display: flex;
-      align-items: center;
-      margin-left: 16px;
-      button {
-        align-self: stretch;
+      .Menu {
+        display: flex;
       }
     }
   }
@@ -117,9 +116,5 @@
         width: calc(100% + 15px);
       }
     }
-  }
-  [title~="Rotate"],
-  [title~="Reload"] {
-    margin-right: 8px;
   }
 }

--- a/src/apps/active-preview/index.html
+++ b/src/apps/active-preview/index.html
@@ -107,7 +107,7 @@
     <main id="root">
       <div id="appBoot">
         <div id="center">
-          <h1>Starting Active Preview</h1>
+          <h1>Starting ActivePreview</h1>
           <div class="loader">
             <span class="bar"></span>
             <span class="bar"></span>


### PR DESCRIPTION
Added `Preview` to copy button in duo mode iframe.

We are getting customer request on where is the Preview link. This is a hot fix to bring more awareness to the copy button as it was missing text letting the user know what the button is.

![Screen Shot 2022-01-24 at 3 46 50 PM](https://user-images.githubusercontent.com/22800749/150884372-852f5b0d-daa5-4d4e-9c10-1de04dbbd3d5.png)
![Screen Shot 2022-01-24 at 3 46 42 PM](https://user-images.githubusercontent.com/22800749/150884373-7a2bf691-2457-42bf-874c-12ea147119c9.png)

