### PR TITLE
Notice page for user's that deleted all models and items

### DIFF
--- a/src/apps/content-editor/src/app/ContentEditor.js
+++ b/src/apps/content-editor/src/app/ContentEditor.js
@@ -1,11 +1,14 @@
-import { useEffect } from "react";
+import { useEffect, Fragment } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Switch, Route } from "react-router-dom";
 import cx from "classnames";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faDatabase } from "@fortawesome/free-solid-svg-icons";
 
 import { fetchModels } from "shell/store/models";
 import { fetchNav } from "../store/navContent";
 
+import { AppLink } from "@zesty-io/core/AppLink";
 import { WithLoader } from "@zesty-io/core/WithLoader";
 import { ContentNav } from "./components/Nav";
 import { ContentNavToggle } from "./components/Nav/components/ContentNavToggle";
@@ -37,57 +40,80 @@ export default function ContentEditor() {
   }, []);
 
   return (
-    <WithLoader
-      condition={navContent.nav.length || navContent.headless.length}
-      message="Starting Content Editor"
-    >
-      <section
-        className={cx(
-          styles.ContentEditor,
-          ui.contentNav ? styles.ContentGridOpen : "",
-          ui.contentNavHover && !ui.contentNav ? styles.ContentGridHover : ""
-          // true ? styles.ContentNavHover : ""
-        )}
-      >
-        <ContentNav
-          data-cy="contentNav"
-          dispatch={dispatch}
-          models={contentModels}
-          nav={navContent}
-        />
-
-        <ContentNavToggle />
-        <div
-          className={cx(
-            styles.Content,
-            ui.openNav ? styles.GlobalOpen : styles.GlobalClosed
-          )}
-        >
-          <div className={styles.ContentWrap}>
-            <Switch>
-              <Route exact path="/content" component={Dashboard} />
-              <Route exact path="/content/link/new" component={LinkCreate} />
-              <Route
-                exact
-                path="/content/:modelZUID/new"
-                component={ItemCreate}
-              />
-              <Route path="/content/link/:linkZUID" component={LinkEdit} />
-              <Route
-                exact
-                path="/content/:modelZUID/import"
-                component={CSVImport}
-              />
-              <Route
-                path="/content/:modelZUID/:itemZUID"
-                component={ItemEdit}
-              />
-              <Route exact path="/content/:modelZUID" component={ItemList} />
-              <Route path="*" component={NotFound} />
-            </Switch>
-          </div>
+    <Fragment>
+      {navContent.headless.length === 0 ? (
+        <div className={styles.SchemaRedirect}>
+          <h1 className={styles.headline}>Please create a new content model</h1>
+          <AppLink to={`schema/new`}>
+            <FontAwesomeIcon icon={faDatabase} />
+            &nbsp; Schema
+          </AppLink>
         </div>
-      </section>
-    </WithLoader>
+      ) : (
+        <WithLoader
+          condition={navContent.headless.length}
+          message="Starting Content Editor"
+        >
+          <section
+            className={cx(
+              styles.ContentEditor,
+              ui.contentNav ? styles.ContentGridOpen : "",
+              ui.contentNavHover && !ui.contentNav
+                ? styles.ContentGridHover
+                : ""
+            )}
+          >
+            <ContentNav
+              data-cy="contentNav"
+              dispatch={dispatch}
+              models={contentModels}
+              nav={navContent}
+            />
+
+            <ContentNavToggle />
+            <div
+              className={cx(
+                styles.Content,
+                ui.openNav ? styles.GlobalOpen : styles.GlobalClosed
+              )}
+            >
+              <div className={styles.ContentWrap}>
+                <Switch>
+                  <Route exact path="/content" component={Dashboard} />
+                  <Route
+                    exact
+                    path="/content/link/new"
+                    component={LinkCreate}
+                  />
+                  <Route
+                    exact
+                    path="/content/:modelZUID/new"
+                    component={ItemCreate}
+                  />
+                  <Route path="/content/link/:linkZUID" component={LinkEdit} />
+                  <Route
+                    exact
+                    path="/content/:modelZUID/import"
+                    component={CSVImport}
+                  />
+                  <Route
+                    path="/content/:modelZUID/:itemZUID"
+                    component={ItemEdit}
+                  />
+                  <Route
+                    exact
+                    path="/content/:modelZUID"
+                    component={ItemList}
+                  />
+                  <Route path="*" component={NotFound} />
+                </Switch>
+              </div>
+            </div>
+          </section>
+        </WithLoader>
+      )}
+      console.log("🚀 ~ file: ContentEditor.js ~ line 121 ~ ContentEditor ~
+      navContent.headless.length", navContent.headless.length)
+    </Fragment>
   );
 }

--- a/src/apps/content-editor/src/app/ContentEditor.js
+++ b/src/apps/content-editor/src/app/ContentEditor.js
@@ -39,11 +39,12 @@ export default function ContentEditor() {
     dispatch(fetchModels());
   }, []);
 
+  console.log("navContent", navContent);
   return (
     <Fragment>
       {navContent.headless.length === 0 ? (
         <div className={styles.SchemaRedirect}>
-          <h1 className={styles.headline}>Please create a new content model</h1>
+          <h1 className={styles.display}>Please create a new content model</h1>
           <AppLink to={`schema/new`}>
             <FontAwesomeIcon icon={faDatabase} />
             &nbsp; Schema
@@ -112,8 +113,6 @@ export default function ContentEditor() {
           </section>
         </WithLoader>
       )}
-      console.log("🚀 ~ file: ContentEditor.js ~ line 121 ~ ContentEditor ~
-      navContent.headless.length", navContent.headless.length)
     </Fragment>
   );
 }

--- a/src/apps/content-editor/src/app/ContentEditor.js
+++ b/src/apps/content-editor/src/app/ContentEditor.js
@@ -39,10 +39,9 @@ export default function ContentEditor() {
     dispatch(fetchModels());
   }, []);
 
-  console.log("navContent", navContent);
   return (
     <Fragment>
-      {navContent.headless.length === 0 ? (
+      {navContent.raw.length === 0 ? (
         <div className={styles.SchemaRedirect}>
           <h1 className={styles.display}>Please create a new content model</h1>
           <AppLink to={`schema/new`}>

--- a/src/apps/content-editor/src/app/ContentEditor.less
+++ b/src/apps/content-editor/src/app/ContentEditor.less
@@ -1,4 +1,13 @@
 @import "~@zesty-io/core/colors.less";
+@import "~@zesty-io/core/typography.less";
+
+.SchemaRedirect {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  height: calc(100vh - 54px);
+}
 
 .ContentEditor {
   height: calc(100vh - 54px);

--- a/src/apps/content-editor/src/app/ContentEditor.less
+++ b/src/apps/content-editor/src/app/ContentEditor.less
@@ -7,6 +7,9 @@
   align-items: center;
   flex-direction: column;
   height: calc(100vh - 54px);
+  a {
+    font-size: 16px;
+  }
 }
 
 .ContentEditor {


### PR DESCRIPTION
fixes #961 

When a user deletes all models and items the content shows a hanging loader.
This PR shows a notice letting the user know to create a new schema and provides a link.
Using DS display class 

![Screen Shot 2022-03-01 at 1 55 10 PM](https://user-images.githubusercontent.com/22800749/156255560-11603f08-ed68-458c-81b9-a9c0f6c45d85.png)


Side Notes* 
if the user deletes their image/bin as well there is a broken/hanging loading media bin page. I tried creating a new model with an image field but have no way of accessing the upload image button.
 
<img width="1215" alt="Screen Shot 2022-02-16 at 3 36 00 PM" src="https://user-images.githubusercontent.com/22800749/154376245-7efa74dc-0a54-4153-b1f1-69f21615a436.png">
CC: @MukeshGKastala @shrunyan 

