### PR TITLE
prevent crash if term.meta is missing

### DIFF
--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
@@ -27,7 +27,7 @@ export function RedirectCreator(props) {
 
   const determineTerm = (term) => {
     // ContentSearch return Object while Search return string
-    let contentSearchValue = term.meta ? term.web.path : term;
+    let contentSearchValue = term?.meta ? term.web.path : term;
     setContentSearchValue(contentSearchValue);
 
     term = term.meta ? term.meta.ZUID : term;


### PR DESCRIPTION
Sentry Bug
onSelect(src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator)

TypeError
Cannot read properties of undefined (reading 'meta')

https://sentry.io/organizations/zestyio/issues/3001042130/?project=5441698&query=is%3Aunresolved&statsPeriod=14d