### PR TITLE
Reset file list order on close

### DIFF
--- a/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
@@ -100,7 +100,6 @@ export default connect((state, props) => {
   };
 
   const handleClose = () => {
-    console.log("Hello world!");
     setOpen(false);
     setFiles(props.fileHeaders);
   };

--- a/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
+++ b/src/apps/code-editor/src/app/components/FileList/components/OrderFiles/OrderFiles.js
@@ -99,6 +99,12 @@ export default connect((state, props) => {
       });
   };
 
+  const handleClose = () => {
+    console.log("Hello world!");
+    setOpen(false);
+    setFiles(props.fileHeaders);
+  };
+
   return (
     <Fragment>
       <Button
@@ -112,8 +118,9 @@ export default connect((state, props) => {
       {open && (
         <Modal
           className={styles.OrderFilesModal}
+          type="global"
           open={open}
-          onClose={() => setOpen(false)}
+          onClose={handleClose}
         >
           <ModalHeader>
             <h2>Order {props.typePathPart}</h2>
@@ -173,7 +180,7 @@ export default connect((state, props) => {
             >
               <FontAwesomeIcon icon={faSave} /> Save Order
             </Button>
-            <Button type="cancel" onClick={() => setOpen(false)}>
+            <Button type="cancel" onClick={handleClose}>
               <FontAwesomeIcon icon={faBan} /> Cancel (ESC)
             </Button>
           </ModalFooter>


### PR DESCRIPTION
Reset the order of files when closing the file sort modal in the Code app.

See #979 