### PR TITLE
Fix hardcoded url to match appropriate file type

### DIFF
--- a/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
@@ -45,7 +45,7 @@ export const DifferActions = memo(function DifferActions(props) {
       );
     }
 
-    history.push(`/code/file/views/${props.fileZUID}`);
+    history.push(`/code/file/${props.fileType}/${props.fileZUID}`);
   }
 
   function resolveSync() {
@@ -73,12 +73,13 @@ export const DifferActions = memo(function DifferActions(props) {
   }
 
   useEffect(() => {
+    console.log("im in", props.fileType);
     props.setLoading(true);
     props
       .dispatch(fetchFileVersions(props.fileZUID, props.fileType))
       .then((res) => {
         props.setLoading(false);
-
+        console.log("from fetch", res, props.status);
         let versions = res.data
           .filter((v) => v.status === props.status)
           .sort((a, b) => {
@@ -136,6 +137,8 @@ export const DifferActions = memo(function DifferActions(props) {
       value: version.version,
     };
   });
+
+  console.log("testing options", versions, options);
 
   return (
     <div className={styles.DifferActions}>

--- a/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
@@ -73,13 +73,11 @@ export const DifferActions = memo(function DifferActions(props) {
   }
 
   useEffect(() => {
-    console.log("im in", props.fileType);
     props.setLoading(true);
     props
       .dispatch(fetchFileVersions(props.fileZUID, props.fileType))
       .then((res) => {
         props.setLoading(false);
-        console.log("from fetch", res, props.status);
         let versions = res.data
           .filter((v) => v.status === props.status)
           .sort((a, b) => {
@@ -137,8 +135,6 @@ export const DifferActions = memo(function DifferActions(props) {
       value: version.version,
     };
   });
-
-  console.log("testing options", versions, options);
 
   return (
     <div className={styles.DifferActions}>

--- a/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
+++ b/src/apps/code-editor/src/app/components/FileActions/components/DifferActions/DifferActions.js
@@ -78,6 +78,7 @@ export const DifferActions = memo(function DifferActions(props) {
       .dispatch(fetchFileVersions(props.fileZUID, props.fileType))
       .then((res) => {
         props.setLoading(false);
+
         let versions = res.data
           .filter((v) => v.status === props.status)
           .sort((a, b) => {


### PR DESCRIPTION
Bug was caused by hardcoded 'view' path pushed after loading a version causing the following endpoint

https://8-f48cf3a682-7fthvk.api.zesty.io/v1/web/scripts/zuid/versions/ to be called as https://8-f48cf3a682-7fthvk.api.zesty.io/v1/web/views/10-5c7db4-cv90bt/versions/

returning an empty version array