### PR TITLE
fix workflows

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -5,8 +5,8 @@ on:
   # pull_request:
   #   branches: [ master ]
   push:
-    branches: 
-      - master 
+    branches:
+      - master
 
 jobs:
   deploy_to_dev:
@@ -15,134 +15,136 @@ jobs:
       ENV: "dev"
 
     steps:
-    # This Clean step simply checks if there's already a workflow running from the last
-    # commit and cancels it if there is. This helps us save on cloud cost in the long run.
-    # See https://github.com/rokroskar/workflow-run-cleanup-action for more information.
-    - name: Clean
-      uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      if: "github.ref != 'refs/heads/master'"
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-    - name: Set up Gcloud SDK
-      uses: google-github-actions/setup-gcloud@master
-      with:
-        project_id: zesty-dev
-        service_account_key: ${{ secrets.GCP_DEV_SA_KEY }}
-        export_default_credentials: true
-    - name: Set up Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: "16.5.0"
-        cache: "npm"
-        cache-dependency-path: package-lock.json
-    - name: Install Dependencies
-      run: npm install
-    - name: Build
-      run: npm run build-dev
-    - name: Deploy to Dev
-      run: gcloud app deploy app.yaml --quiet --project zesty-dev
-    - name: Post Successful Dev Deploy Notification To Slack
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_CHANNEL: devops
-        SLACK_COLOR: ${{ job.status }}
-        SLACK_ICON: https://clipart.world/wp-content/uploads/2021/06/Rocket-Ship-clipart-png.png
-        SLACK_MESSAGE: |
-          Use :eyes: to signal you have seen this message.
-          Use :white_check_mark: to signal you have successfully manually tested the deployed changes.
-          Use :x: to signal manual tests on deployed changes were unsuccessful and start a thread under this alert describing your remediation steps.
-        SLACK_TITLE: Successfully Deployed manager-ui to Dev
-        SLACK_USERNAME: Deploy Bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      # This Clean step simply checks if there's already a workflow running from the last
+      # commit and cancels it if there is. This helps us save on cloud cost in the long run.
+      # See https://github.com/rokroskar/workflow-run-cleanup-action for more information.
+      - name: Clean
+        uses: rokroskar/workflow-run-cleanup-action@v0.2.2
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        if: "github.ref != 'refs/heads/master'"
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Set up Gcloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: zesty-dev
+          service_account_key: ${{ secrets.GCP_DEV_SA_KEY }}
+          export_default_credentials: true
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16.5.0"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+      - name: Install Dependencies
+        run: npm install
+      - name: Build
+        run: npm run build-dev
+      - name: Deploy to Dev
+        run: gcloud app deploy app.yaml --quiet --project zesty-dev
+      - name: Post Successful Dev Deploy Notification To Slack
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: devops
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_ICON: https://clipart.world/wp-content/uploads/2021/06/Rocket-Ship-clipart-png.png
+          SLACK_MESSAGE: |
+            Use :eyes: to signal you have seen this message.
+            Use :white_check_mark: to signal you have successfully manually tested the deployed changes.
+            Use :x: to signal manual tests on deployed changes were unsuccessful and start a thread under this alert describing your remediation steps.
+          SLACK_TITLE: Successfully Deployed manager-ui to Dev
+          SLACK_USERNAME: Deploy Bot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
   cancel_workflow_if_dev_deploy_failed:
-      runs-on: ubuntu-latest
-      if: ${{ failure() }}
-      needs:
-          - deploy_to_dev
-      steps:
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+    needs:
+      - deploy_to_dev
+    steps:
       - name: Post Failed Dev Deploy Notification To Slack
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: devops
-          SLACK_COLOR: '#FF0000'
+          SLACK_COLOR: "#FF0000"
           SLACK_ICON: https://clipart.world/wp-content/uploads/2021/06/Rocket-Ship-clipart-png.png
-          SLACK_MESSAGE: 'PR merge by ${{ github.actor }} has failed to deploy to dev.'
+          SLACK_MESSAGE: "PR merge by ${{ github.actor }} has failed to deploy to dev."
           SLACK_TITLE: Dev Deployment Failed for manager-ui
           SLACK_USERNAME: Deploy Bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       - name: Cancel current workflow run
         uses: actions/github-script@v4
         with:
-            script: |
-                github.actions.cancelWorkflowRun({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    run_id: context.runId
-                })
+          script: |
+            github.actions.cancelWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId
+            })
   deploy_to_stage:
     runs-on: ubuntu-latest
     env:
       ENV: "stage"
     needs:
-        - deploy_to_dev
+      - deploy_to_dev
 
     steps:
-    # This Clean step simply checks if there's already a workflow running from the last
-    # commit and cancels it if there is. This helps us save on cloud cost in the long run.
-    # See https://github.com/rokroskar/workflow-run-cleanup-action for more information.
-    - name: Clean
-      uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      if: "github.ref != 'refs/heads/master'"
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-    - name: Set up Gcloud SDK
-      uses: google-github-actions/setup-gcloud@master
-      with:
-        project_id: zesty-stage
-        service_account_key: ${{ secrets.GCP_SA_KEY }}
-        export_default_credentials: true
-    - name: Set up Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: "16.5.0"
-        cache: "npm"
-        cache-dependency-path: package-lock.json
-    - name: Install Dependencies
-      run: npm install
-    - name: Build
-      run: npm run build-stage
-    - name: Deploy to Staging
-      run: gcloud app deploy app.yaml --quiet --project zesty-stage
-    - name: Post Successful Stage Deploy Notification To Slack
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_CHANNEL: devops
-        SLACK_COLOR: ${{ job.status }}
-        SLACK_ICON: https://clipart.world/wp-content/uploads/2021/06/Rocket-Ship-clipart-png.png
-        SLACK_MESSAGE: |
-          Use :eyes: to signal you have seen this message.
-          Use :white_check_mark: to signal you have successfully manually tested the deployed changes.
-          Use :x: to signal manual tests on deployed changes were unsuccessful and start a thread under this alert describing your remediation steps.
-        SLACK_TITLE: Successfully Deployed manager-ui to Stage
-        SLACK_USERNAME: Deploy Bot
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      # This Clean step simply checks if there's already a workflow running from the last
+      # commit and cancels it if there is. This helps us save on cloud cost in the long run.
+      # See https://github.com/rokroskar/workflow-run-cleanup-action for more information.
+      - name: Clean
+        uses: rokroskar/workflow-run-cleanup-action@v0.2.2
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        if: "github.ref != 'refs/heads/master'"
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Auth with Gcloud
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_DEV_SA_KEY }}
+      - name: Set up Gcloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: zesty-dev
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16.5.0"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+      - name: Install Dependencies
+        run: npm install
+      - name: Build
+        run: npm run build-stage
+      - name: Deploy to Staging
+        run: gcloud app deploy app.yaml --quiet --project zesty-stage
+      - name: Post Successful Stage Deploy Notification To Slack
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: devops
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_ICON: https://clipart.world/wp-content/uploads/2021/06/Rocket-Ship-clipart-png.png
+          SLACK_MESSAGE: |
+            Use :eyes: to signal you have seen this message.
+            Use :white_check_mark: to signal you have successfully manually tested the deployed changes.
+            Use :x: to signal manual tests on deployed changes were unsuccessful and start a thread under this alert describing your remediation steps.
+          SLACK_TITLE: Successfully Deployed manager-ui to Stage
+          SLACK_USERNAME: Deploy Bot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
   post_failed_stage_deploy_notification_to_slack:
-      runs-on: ubuntu-latest
-      if: ${{ failure() }}
-      needs:
-          - deploy_to_stage
-      steps:
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+    needs:
+      - deploy_to_stage
+    steps:
       - name: Post Failed Staging Deploy Notification To Slack
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: devops
-          SLACK_COLOR: '#FF0000'
+          SLACK_COLOR: "#FF0000"
           SLACK_ICON: https://clipart.world/wp-content/uploads/2021/06/Rocket-Ship-clipart-png.png
-          SLACK_MESSAGE: 'PR merge by ${{ github.actor }} has failed to deploy to staging.'
+          SLACK_MESSAGE: "PR merge by ${{ github.actor }} has failed to deploy to staging."
           SLACK_TITLE: Staging Deployment Failed for manager-ui
           SLACK_USERNAME: Deploy Bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,12 +19,14 @@ jobs:
         if: "github.ref != 'refs/heads/master'"
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - name: Auth with Gcloud
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_DEV_SA_KEY }}
       - name: Set up Gcloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: zesty-dev
-          service_account_key: ${{ secrets.GCP_DEV_SA_KEY }}
-          export_default_credentials: true
       - name: Delete Old Screenshots
         run: gsutil rm gs://cypress_screenshots/* || true
       - name: Set up Node


### PR DESCRIPTION
# What this does

Fixes this error for both CI and CD:

```
Error: On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.
```