### PR TITLE
fix pipelines

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Auth with Gcloud
       uses: google-github-actions/auth@v0
       with:
-        credentials_json: ${{ secrets.GCP_SA_KEY }}
+        credentials_json: ${{ secrets.GCP_DEV_SA_KEY }}
     - name: Set up Gcloud SDK
       uses: google-github-actions/setup-gcloud@v0
       with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -25,12 +25,14 @@ jobs:
       if: "github.ref != 'refs/heads/master'"
     - name: Checkout Repo
       uses: actions/checkout@v2
+    - name: Auth with Gcloud
+      uses: google-github-actions/auth@v0
+      with:
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
     - name: Set up Gcloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: zesty-dev
-        service_account_key: ${{ secrets.GCP_DEV_SA_KEY }}
-        export_default_credentials: true
     - name: Set up Node
       uses: actions/setup-node@v2
       with:
@@ -106,7 +108,7 @@ jobs:
     - name: Set up Gcloud SDK
       uses: google-github-actions/setup-gcloud@v0
       with:
-        project_id: zesty-dev
+        project_id: zesty-stage
     - name: Set up Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -99,12 +99,14 @@ jobs:
       if: "github.ref != 'refs/heads/master'"
     - name: Checkout Repo
       uses: actions/checkout@v2
-    - name: Set up Gcloud SDK
-      uses: google-github-actions/setup-gcloud@master
+    - name: Auth with Gcloud
+      uses: google-github-actions/auth@v0
       with:
-        project_id: zesty-stage
-        service_account_key: ${{ secrets.GCP_SA_KEY }}
-        export_default_credentials: true
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+    - name: Set up Gcloud SDK
+      uses: google-github-actions/setup-gcloud@v0
+      with:
+        project_id: zesty-dev
     - name: Set up Node
       uses: actions/setup-node@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Auth with Gcloud
         uses: google-github-actions/auth@v0
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: ${{ secrets.GCP_DEV_SA_KEY }}
       - name: Set up Gcloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,12 +19,14 @@ jobs:
         if: "github.ref != 'refs/heads/master'"
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - name: Auth with Gcloud
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
       - name: Set up Gcloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: zesty-dev
-          service_account_key: ${{ secrets.GCP_DEV_SA_KEY }}
-          export_default_credentials: true
       - name: Delete Old Screenshots
         run: gsutil rm gs://cypress_screenshots/* || true
       - name: Set up Node


### PR DESCRIPTION
# What this does

Fixes this error for both CI and CD:

```
Error: On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.
```