### PR TITLE
Fix tooltip icon alignment

### DIFF
--- a/src/apps/code-editor/src/app/components/FileList/FileList.js
+++ b/src/apps/code-editor/src/app/components/FileList/FileList.js
@@ -93,17 +93,17 @@ export const FileList = memo(function FileList(props) {
           />
 
           <header className={styles.Title}>
-            {/* TODO: Make this visible on the background */}
-            <Tooltip
-              title="Site.css is a dynamically created file from the instance
-              stylesheet files"
-              arrow
-              placement="top-start"
-            >
-              <InfoIcon fontSize="small" />
-            </Tooltip>
-            &nbsp;
-            <h1>site.css</h1>
+            <h1>
+              <Tooltip
+                title="Site.css is a dynamically created file from the instance
+                stylesheet files"
+                arrow
+                placement="top-start"
+              >
+                <InfoIcon fontSize="small" />
+              </Tooltip>
+              &nbsp;site.css
+            </h1>
             <OrderFiles type="text/css" />
           </header>
           <Nav
@@ -115,16 +115,16 @@ export const FileList = memo(function FileList(props) {
           />
 
           <header className={styles.Title}>
-            {/* TODO: Make this visible on the background */}
-            <Tooltip
-              title="Site.js is a dynamically created file from the instance JavaScript files"
-              arrow
-              placement="top-start"
-            >
-              <InfoIcon fontSize="small" />
-            </Tooltip>
-            &nbsp;
-            <h1>site.js</h1>
+            <h1>
+              <Tooltip
+                title="Site.js is a dynamically created file from the instance JavaScript files"
+                arrow
+                placement="top-start"
+              >
+                <InfoIcon fontSize="small" color="asdf" />
+              </Tooltip>
+              &nbsp;site.js
+            </h1>
             <OrderFiles type="text/javascript" />
           </header>
           <Nav

--- a/src/apps/code-editor/src/app/components/FileList/FileList.less
+++ b/src/apps/code-editor/src/app/components/FileList/FileList.less
@@ -53,6 +53,8 @@
     h1 {
       color: @zesty-light-blue;
       text-transform: uppercase;
+      display: flex;
+      align-items: center;
       margin-right: auto;
     }
   }

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetListed/WidgetListed.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetListed/WidgetListed.less
@@ -2,4 +2,8 @@
   article {
     margin-bottom: 16px;
   }
+  span {
+    display: flex;
+    align-items: center;
+  }
 }

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/CanonicalTag.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/CanonicalTag.less
@@ -1,6 +1,7 @@
 .CanonicalTag {
   label {
     display: flex;
+    align-items: center;
   }
   .settings {
     & > * {

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
@@ -152,7 +152,7 @@ export const ItemParent = connect((state) => {
             >
               <InfoIcon fontSize="small" />
             </Tooltip>
-            &nbsp; Select this Page's Parent
+            &nbsp;Select this Page's Parent
           </label>
 
           {/*

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.less
@@ -1,6 +1,9 @@
+@import "~@zesty-io/core/colors.less";
+
 .ItemParent {
   label {
     display: flex;
-    font-size: 16px;
+    color: @zesty-dark-blue;
+    font-size: 14px;
   }
 }

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemRoute.less
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemRoute.less
@@ -1,8 +1,11 @@
 @import "~@zesty-io/core/keyframes.less";
+@import "~@zesty-io/core/colors.less";
 
 .ItemRoute {
   label {
     display: flex;
+    color: @zesty-dark-blue;
+    font-size: 14px;
   }
   .Path {
     display: flex;

--- a/src/apps/media/src/app/components/MediaDetailsModal.less
+++ b/src/apps/media/src/app/components/MediaDetailsModal.less
@@ -32,6 +32,7 @@
     .FieldsContainer {
       label {
         margin-bottom: 16px;
+        display: flex;
       }
     }
 

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableHeader/RedirectsTableHeader.less
@@ -3,16 +3,25 @@
 
 .RedirectsTableHeader {
   display: grid;
-  grid-template-columns: minmax(200px, 1fr) auto auto minmax(200px, 1fr) 200px 200px;
+  grid-template-columns: minmax(200px, 1fr) 180px max-content minmax(200px, 1fr) 200px 200px;
+  //grid-template-columns: minmax(200px, 1fr) auto auto minmax(200px, 1fr) 200px 200px;
   z-index: 1;
   align-items: baseline;
   padding: 0 16px 16px 16px;
   background-color: @appBkgColor;
+  @media only screen and (max-width: 1500px) {
+    //grid-template-columns: minmax(200px, 1fr) 180px max-content minmax(200px, 1fr) 170px 170px;
+    grid-template-columns: 200px 180px max-content 200px auto 170px;
+  }
 
   .RedirectsTableHeaderCell {
     cursor: pointer;
     font-weight: 900;
     padding: 0 8px;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     .column {
       border-bottom: 3px solid @zesty-field-blue;


### PR DESCRIPTION
# Aligns tooltip icons with label text

Closes #1055 

## Notable tangential changes include:

### Changing content editors meta info page to have more consistent styling:

Old:
<img width="265" alt="Screen Shot 2022-05-12 at 11 27 47 AM" src="https://user-images.githubusercontent.com/16678143/168111837-69d8a4c5-5912-48b2-8bfd-9442ff5a350b.png">

New:
<img width="264" alt="Screen Shot 2022-05-12 at 11 27 17 AM" src="https://user-images.githubusercontent.com/16678143/168111652-6c42fb5e-1c93-4259-8485-8ddf5e2eef60.png">

### Changing SEO page styling so table headers don't wrap on small screens

Old:
<img width="769" alt="Screen Shot 2022-05-12 at 11 31 55 AM" src="https://user-images.githubusercontent.com/16678143/168112812-685ad6e6-263b-44ef-ac8d-40ab08233339.png">

New:
<img width="762" alt="Screen Shot 2022-05-12 at 11 32 50 AM" src="https://user-images.githubusercontent.com/16678143/168112971-fce5ebd0-c80f-49b2-9435-ef68d481dc98.png">

 This layout is not perfect, (you can see the titles are slightly misaligned) but because the table was implemented with `<span>`s and 3 separate css `<grid>`s, it is the best we can get without a complete refactor.
