### PR TITLE
adding missing import

### DIFF
--- a/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/DropdownOptions/DropdownOptions.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/DropdownOptions/DropdownOptions.js
@@ -5,7 +5,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
 
 import { FieldTypeText } from "@zesty-io/core/FieldTypeText";
-
+import { formatName } from "utility/formatName";
 import { updateField } from "shell/store/fields";
 
 import styles from "./DropdownOptions.less";


### PR DESCRIPTION
brought back missing import for dropdownoptions.js 

fixes
loom.com/share/18cc5bc553bc47ebabc96ba8a1c91cf1?t=0