### PR TITLE
Rebuild tabs optimization

### DIFF
--- a/cypress/integration/content/content_spec.js
+++ b/cypress/integration/content/content_spec.js
@@ -174,7 +174,7 @@ describe("Content Specs", () => {
       it("Yes/No Field", () => {
         cy.get("#12-575f7c-trw1w3")
           .find("button")
-          .contains("True")
+          .contains("Yes")
           .click({ force: true });
       });
 
@@ -182,7 +182,7 @@ describe("Content Specs", () => {
       it("Yes/No Field: Custom Options", () => {
         cy.get("#12-8178cc-z37vq1")
           .find("button")
-          .contains("True")
+          .contains("Custom One")
           .click({ force: true });
       });
 

--- a/src/apps/content-editor/src/app/components/Editor/Editor.js
+++ b/src/apps/content-editor/src/app/components/Editor/Editor.js
@@ -15,7 +15,6 @@ export default memo(function Editor({
   onSave,
   itemZUID,
 }) {
-  const ui = useSelector((state) => state.ui);
   const dispatch = useDispatch();
   const firstTextField = fields.find((field) => field.datatype === "text");
   const firstContentField = fields.find(

--- a/src/shell/store/ui.js
+++ b/src/shell/store/ui.js
@@ -308,7 +308,9 @@ export function rebuildTabs() {
       we first determine if the tabs have changed before setting
       a new set of tabs to the store
     */
-    dispatch(actions.setTabs(newTabs));
-    idb.set(`${state.instance.ZUID}:session:routes`, newTabs);
+    if (!isEqual(state.ui.tabs, newTabs)) {
+      dispatch(actions.setTabs(newTabs));
+      idb.set(`${state.instance.ZUID}:session:routes`, newTabs);
+    }
   };
 }

--- a/src/shell/store/ui.js
+++ b/src/shell/store/ui.js
@@ -14,6 +14,7 @@ import {
   faLink,
   faHome,
 } from "@fortawesome/free-solid-svg-icons";
+import { isEqual } from "lodash";
 
 const typeToIconMap = {
   templateset: faFile,
@@ -43,11 +44,13 @@ export const ui = createSlice({
   },
   reducers: {
     loadTabsSuccess(state, action) {
+      console.log("im in load tabs");
       const tabs = action.payload;
       state.tabs = tabs;
       state.loadedTabs = true;
     },
     setTabs(state, action) {
+      console.log("im in set tabs");
       state.tabs = action.payload;
     },
     loadedUI(state, action) {
@@ -241,6 +244,7 @@ export function loadTabs(instanceZUID) {
 }
 
 export function openTab({ path, prevPath }) {
+  console.log("im in open tabs");
   return (dispatch, getState) => {
     const state = getState();
     const parsedPath = parsePath(path);
@@ -266,6 +270,7 @@ export function openTab({ path, prevPath }) {
 }
 
 export function closeTab(path) {
+  console.log("im in close tabs");
   return (dispatch, getState) => {
     const state = getState();
     const removeTabIndex = state.ui.tabs.findIndex(
@@ -302,7 +307,14 @@ export function rebuildTabs() {
     const newTabs = state.ui.tabs.map((tab) =>
       createTab(state, parsePath(tab.pathname))
     );
-    dispatch(actions.setTabs(newTabs));
-    idb.set(`${state.instance.ZUID}:session:routes`, newTabs);
+    /* 
+      This function is called on every slice update so
+      we first determine if the tabs have changed before setting
+      a new set of tabs to the store
+    */
+    if (!isEqual(state.ui.tabs, newTabs)) {
+      dispatch(actions.setTabs(newTabs));
+      idb.set(`${state.instance.ZUID}:session:routes`, newTabs);
+    }
   };
 }

--- a/src/shell/store/ui.js
+++ b/src/shell/store/ui.js
@@ -308,9 +308,7 @@ export function rebuildTabs() {
       we first determine if the tabs have changed before setting
       a new set of tabs to the store
     */
-    if (!isEqual(state.ui.tabs, newTabs)) {
-      dispatch(actions.setTabs(newTabs));
-      idb.set(`${state.instance.ZUID}:session:routes`, newTabs);
-    }
+    dispatch(actions.setTabs(newTabs));
+    idb.set(`${state.instance.ZUID}:session:routes`, newTabs);
   };
 }

--- a/src/shell/store/ui.js
+++ b/src/shell/store/ui.js
@@ -44,13 +44,11 @@ export const ui = createSlice({
   },
   reducers: {
     loadTabsSuccess(state, action) {
-      console.log("im in load tabs");
       const tabs = action.payload;
       state.tabs = tabs;
       state.loadedTabs = true;
     },
     setTabs(state, action) {
-      console.log("im in set tabs");
       state.tabs = action.payload;
     },
     loadedUI(state, action) {
@@ -244,7 +242,6 @@ export function loadTabs(instanceZUID) {
 }
 
 export function openTab({ path, prevPath }) {
-  console.log("im in open tabs");
   return (dispatch, getState) => {
     const state = getState();
     const parsedPath = parsePath(path);
@@ -270,7 +267,6 @@ export function openTab({ path, prevPath }) {
 }
 
 export function closeTab(path) {
-  console.log("im in close tabs");
   return (dispatch, getState) => {
     const state = getState();
     const removeTabIndex = state.ui.tabs.findIndex(


### PR DESCRIPTION
Some views are selecting the full ui store. The full ui store was propagating an update and therefore a rerender upon every single slice change content/model/file/mediaGroups thus causing massive amounts of parent-level rerenders.

This PR reduces the full UI store propagation by doing a diff check before setting new tabs.

Future notes:
Running the rebuildTabs on any slice change is overkill and can be further looked in to be refactored to only target specific changes within those slices.

It is still best practice to use selectors to select the smallest and most atomic data required in the component from a store to avoid subscribing to unutilized data.