### PR TITLE
Improve activity log navigation via global tabs

### DIFF
--- a/src/apps/reports/src/app/components/ReportingNav.js
+++ b/src/apps/reports/src/app/components/ReportingNav.js
@@ -21,16 +21,19 @@ export function ReportingNav() {
   const tree = [
     {
       label: "Activity Log",
-      path: "/reports/activity-log",
+      rootPath: "/reports/activity-log",
+      path: "/reports/activity-log/resources",
       icon: <HistoryIcon />,
     },
     {
       label: "Metrics",
+      rootPath: "/reports/metrics",
       path: "/reports/metrics",
       icon: <PieChartIcon />,
     },
     {
       label: "Analytics",
+      rootPath: "/reports/analytics",
       path: "/reports/analytics",
       icon: <InsightsIcon />,
     },
@@ -53,11 +56,11 @@ export function ReportingNav() {
           </Typography>
         </Box>
         <List sx={{ p: 1 }} color="primary">
-          {tree.map(({ label, path, icon }) => (
+          {tree.map(({ label, path, icon, rootPath }) => (
             <ListItem
               key={path}
               disablePadding
-              selected={location.pathname.includes(path)}
+              selected={location.pathname.includes(rootPath)}
               sx={{
                 mb: 1,
                 borderRadius: "4px",

--- a/src/apps/reports/src/app/views/ActivityLog/index.js
+++ b/src/apps/reports/src/app/views/ActivityLog/index.js
@@ -33,7 +33,7 @@ export const ActivityLog = () => {
             path="/reports/activity-log/users/:id"
             component={UserDetails}
           />
-          <Route path="/reports/activity-log/:tab" component={Home} />
+          <Route exact path="/reports/activity-log/:tab" component={Home} />
           <Redirect to="/reports/activity-log/resources" />
         </Switch>
       </Box>

--- a/src/apps/reports/src/app/views/ActivityLog/views/Home.js
+++ b/src/apps/reports/src/app/views/ActivityLog/views/Home.js
@@ -52,7 +52,7 @@ export const Home = () => {
       if API call is ready to be executed
     */
     setInitialized(true);
-  }, []);
+  }, [location.pathname]);
 
   const {
     data: actions,

--- a/src/apps/reports/src/app/views/ActivityLog/views/ResourceDetails.js
+++ b/src/apps/reports/src/app/views/ActivityLog/views/ResourceDetails.js
@@ -52,7 +52,7 @@ export const ResourceDetails = () => {
       if API call is ready to be executed
     */
     setInitialized(true);
-  }, []);
+  }, [location.pathname]);
 
   // Sets date parameters from when the resource was created
   const setDefaultDateParams = () => {

--- a/src/apps/reports/src/app/views/ActivityLog/views/UserDetails.js
+++ b/src/apps/reports/src/app/views/ActivityLog/views/UserDetails.js
@@ -42,7 +42,7 @@ export const UserDetails = () => {
       if API call is ready to be executed
     */
     setInitialized(true);
-  }, [usersLoading]);
+  }, [usersLoading, location.pathname]);
 
   const {
     data: actionsByZuid,


### PR DESCRIPTION
Global tabs do not save URL parameters causing some unexpected behavior. This PR handles those cases by re-adding default URL params while navigating through global tabs