### PR TITLE
Remove incorrect notification when item url path part is valid and fi…

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemRoute.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemRoute.js
@@ -76,12 +76,7 @@ export const ItemRoute = connect((state) => {
 
                   setUnique(!matches.length);
                 } else {
-                  props.dispatch(
-                    notify({
-                      kind: "warn",
-                      message: `Path not found ${res.status}`,
-                    })
-                  );
+                  setUnique(true);
                 }
               } else {
                 props.dispatch(


### PR DESCRIPTION
…x state handling

The notification was placed on the logical block that runs when the URL path part is unique. This was causing user confusion

Removed notification and set the state to unique. Previously the state was not reset to unique therefore if an invalid URL was inserted and then modified to a valid one it would still show as invalid.