### PR TITLE
Item Creation: Ensure null value when date value is undefined

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -899,7 +899,7 @@ export default function Field({
           }
           helperText={description}
           required={required}
-          value={moment(value || null).format("YYYY-MM-DD HH:mm:ss")}
+          value={value ? moment(value).format("YYYY-MM-DD HH:mm:ss") : null}
           inputFormat="yyyy-MM-dd"
           onChange={(date) => onDateChange(date, name, datatype)}
         />
@@ -931,7 +931,7 @@ export default function Field({
           }
           helperText={description}
           required={required}
-          value={moment(value || null).format("YYYY-MM-DD HH:mm:ss")}
+          value={value ? moment(value).format("YYYY-MM-DD HH:mm:ss") : null}
           inputFormat="yyyy-MM-dd HH:mm:ss.SSSSSS"
           onChange={(date) => onDateTimeChange(date, name, datatype)}
         />

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -899,7 +899,7 @@ export default function Field({
           }
           helperText={description}
           required={required}
-          value={moment(value).format("YYYY-MM-DD HH:mm:ss")}
+          value={moment(value || null).format("YYYY-MM-DD HH:mm:ss")}
           inputFormat="yyyy-MM-dd"
           onChange={(date) => onDateChange(date, name, datatype)}
         />
@@ -931,7 +931,7 @@ export default function Field({
           }
           helperText={description}
           required={required}
-          value={moment(value).format("YYYY-MM-DD HH:mm:ss")}
+          value={moment(value || null).format("YYYY-MM-DD HH:mm:ss")}
           inputFormat="yyyy-MM-dd HH:mm:ss.SSSSSS"
           onChange={(date) => onDateTimeChange(date, name, datatype)}
         />


### PR DESCRIPTION
Moment when given an undefined value generates a default date.

We pass default value to date picker on item creation causing undesired behavior.

On item load BE returns null value thus not causing undesired behavior

This PR ensures null value by only invoking moment if a value is present and if not returning null