### PR TITLE
Add support for CSV import redirect target type

### DIFF
--- a/src/apps/seo/src/store/imports.js
+++ b/src/apps/seo/src/store/imports.js
@@ -191,7 +191,9 @@ function CSVToArray(csv) {
   });
   const columns = rows[0];
   const validColumns = ["from", "target", "targetType", "code"];
-  const columnIndexes = validColumns.map((column) => columns.indexOf(column));
+  const columnIndexes = validColumns.map((column) =>
+    columns.indexOf(column.toLowerCase())
+  );
   const redirects = rows
     .slice(1)
     .map((row) => {

--- a/src/apps/seo/src/store/imports.js
+++ b/src/apps/seo/src/store/imports.js
@@ -5,6 +5,7 @@ export const IMPORT_REDIRECTS = "IMPORT_REDIRECTS";
 export const IMPORT_CODE = "IMPORT_CODE";
 export const IMPORT_TARGET = "IMPORT_TARGET";
 export const IMPORT_QUERY = "IMPORT_QUERY";
+export const IMPORT_TARGET_TYPE = "IMPORT_TARGET_TYPE";
 
 export function imports(state = {}, action) {
   switch (action.type) {
@@ -53,6 +54,15 @@ export function imports(state = {}, action) {
         return acc;
       }, {});
 
+    case IMPORT_TARGET_TYPE:
+      return Object.keys(state).reduce((acc, key) => {
+        acc[key] = { ...state[key] };
+        if (key === action.path) {
+          acc[key].targetType = action.targetType;
+        }
+        return acc;
+      }, {});
+
     default:
       return state;
   }
@@ -83,6 +93,13 @@ export function importTarget(path, target, targetZuid) {
 export function importQuery(path, query) {
   return {
     type: IMPORT_QUERY,
+    path,
+    query,
+  };
+}
+export function importTargetType(path, query) {
+  return {
+    type: IMPORT_TARGET_TYPE,
     path,
     query,
   };
@@ -173,15 +190,19 @@ function CSVToArray(csv) {
     skip_empty_lines: true,
   });
   const columns = rows[0];
+  const validColumns = ["from", "target", "targetType", "code"];
+  const columnIndexes = validColumns.map((column) => columns.indexOf(column));
   const redirects = rows
     .slice(1)
     .map((row) => {
-      const [original, target, code] = row;
+      const [original, target, targetType, code] = columnIndexes.map(
+        (columnIndex) => row[columnIndex]
+      );
       const [path, query] = original.split("?");
       return {
         path: path,
         query_string: query || null,
-        target_type: "path",
+        targetType: targetType || "path",
         target_zuid: null,
         target: target,
         code: code || "301",
@@ -259,7 +280,7 @@ function parseXML(xml, dispatch) {
     redirects[path] = {
       path: path,
       query_string: query || null,
-      target_type: "path",
+      targetType: "path",
       target_zuid: null,
       target: "/", // Default to homepage
       code: "301",

--- a/src/apps/seo/src/store/imports.js
+++ b/src/apps/seo/src/store/imports.js
@@ -97,11 +97,11 @@ export function importQuery(path, query) {
     query,
   };
 }
-export function importTargetType(path, query) {
+export function importTargetType(path, targetType) {
   return {
     type: IMPORT_TARGET_TYPE,
     path,
-    query,
+    targetType,
   };
 }
 
@@ -189,11 +189,10 @@ function CSVToArray(csv) {
   const rows = parse(csv, {
     skip_empty_lines: true,
   });
-  const columns = rows[0];
-  const validColumns = ["from", "target", "targetType", "code"];
-  const columnIndexes = validColumns.map((column) =>
-    columns.indexOf(column.toLowerCase())
-  );
+  const columns = rows[0].map((col) => col.toLowerCase());
+  const validColumns = ["from", "target", "targettype", "code"];
+  const columnIndexes = validColumns.map((column) => columns.indexOf(column));
+
   const redirects = rows
     .slice(1)
     .map((row) => {

--- a/src/apps/seo/src/store/redirects.js
+++ b/src/apps/seo/src/store/redirects.js
@@ -94,7 +94,7 @@ export function createRedirect(redirect) {
           dispatch(
             notify({
               kind: "error",
-              message: `Failed creating redirect from ${redirect.path}. Must be a relative path.`,
+              message: `Failed creating redirect from ${redirect.path}. ${json.error}`,
             })
           );
         }

--- a/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTable.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTable.js
@@ -5,8 +5,6 @@ import Button from "@mui/material/Button";
 import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
 
-import { Notice } from "@zesty-io/core/Notice";
-
 import RedirectImportTableRow from "./RedirectImportTableRow";
 import ImportTableRowDisabled from "./ImportTableRowDisabled";
 
@@ -28,7 +26,7 @@ function RedirectImportTable(props) {
           createRedirect({
             path: redirect.path,
             query_string: redirect.query_string,
-            targetType: redirect.target_type,
+            targetType: redirect.targetType,
             target: redirect.target_zuid || redirect.target,
             code: +redirect.code,
           })
@@ -39,9 +37,6 @@ function RedirectImportTable(props) {
   return (
     <section className={styles.RedirectImportTable}>
       <div className={styles.Actions}>
-        <Notice>
-          Import CSV does not allow for external and wildcard redirects
-        </Notice>
         <div className={styles.RedirectButtons}>
           <Button
             variant="contained"
@@ -63,7 +58,7 @@ function RedirectImportTable(props) {
       </div>
       <div className={styles.Header}>
         <span className={cx(styles.Cell, styles.subheadline)}>From</span>
-
+        <span className={cx(styles.Cell, styles.subheadline)}>Code</span>
         <span className={cx(styles.Cell, styles.subheadline)}>Type</span>
         <span className={cx(styles.Cell, styles.subheadline)}>To</span>
       </div>

--- a/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTable.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTable.less
@@ -15,10 +15,10 @@
   }
   .Header {
     display: grid;
-    grid-template-columns: minmax(200px, 1fr) 100px 344px minmax(200px, 1fr);
+    grid-template-columns: minmax(200px, 1fr) 110px 150px 1fr 155px;
     z-index: 1;
     align-items: baseline;
-    padding: 0 16px 16px 16px;
+    padding: 16px 0;
     gap: 0 36px;
 
     .Cell {

--- a/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTableRow/RedirectImportTableRow.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTableRow/RedirectImportTableRow.js
@@ -74,7 +74,7 @@ function RedirectImportTableRow(props) {
 
       <span className={styles.RowCell}>
         <Select
-          onChange={(evt) => handleTargetType(evt.target.value)}
+          onChange={handleTargetType}
           size="small"
           fullWidth
           value={props.targetType}

--- a/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTableRow/RedirectImportTableRow.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTableRow/RedirectImportTableRow.js
@@ -15,21 +15,23 @@ import AddIcon from "@mui/icons-material/Add";
 import { createRedirect } from "../../../../store/redirects";
 import { importTarget } from "../../../../store/imports";
 import { importQuery } from "../../../../store/imports";
+import { importCode } from "../../../../store/imports";
+import { importTargetType } from "../../../../store/imports";
 
 import styles from "./RedirectImportTableRow.less";
 
 function RedirectImportTableRow(props) {
-  const [code, setCode] = useState(301); // Toggle defaults to 301
-  const [type, setType] = useState("page");
-
-  const handlePageTarget = (evt) => {
-    const path = props.paths[evt.target.dataset.value];
-    props.dispatch(importTarget(props.path, path.path_full, path.zuid));
+  const handleCode = (val) => {
+    props.dispatch(importCode(props.path, val));
   };
 
   const handlePathTarget = (evt) => {
-    console.log("// TODO handlePathTarget", evt);
-    // setType()
+    // const path = props.paths[evt.target.dataset.value];
+    props.dispatch(importTarget(props.path, evt.target.value, ""));
+  };
+
+  const handleTargetType = (evt) => {
+    props.dispatch(importTargetType(props.path, evt.target.value));
   };
 
   const handleQuery = (evt) => {
@@ -41,16 +43,16 @@ function RedirectImportTableRow(props) {
       createRedirect({
         path: props.path,
         query_string: props.query_string,
-        targetType: props.target_type,
+        targetType: props.targetType,
         target: props.target_zuid || props.target,
-        code, // API expects a 301/302 value
+        code: Number(props.code), // API expects a 301/302 numeric value
       })
     );
   };
 
   const handleToggle = (val) => {
     if (val === null) return;
-    setCode(val);
+    handleCode(val);
   };
 
   return (
@@ -60,21 +62,34 @@ function RedirectImportTableRow(props) {
       <span className={styles.RedirectCreatorCell}>
         <ToggleButtonGroup
           color="secondary"
-          value={code}
+          value={props.code}
           size="small"
           exclusive
           onChange={(evt, val) => handleToggle(val)}
         >
-          <ToggleButton value={302}>302</ToggleButton>
-          <ToggleButton value={301}>301</ToggleButton>
+          <ToggleButton value={"302"}>302</ToggleButton>
+          <ToggleButton value={"301"}>301</ToggleButton>
         </ToggleButtonGroup>
       </span>
 
       <span className={styles.RowCell}>
-        {props.target_type === "page" ? (
+        <Select
+          onChange={(evt) => handleTargetType(evt.target.value)}
+          size="small"
+          fullWidth
+          value={props.targetType}
+        >
+          <MenuItem value={"path"}>Wildcard</MenuItem>
+          <MenuItem value={"page"}>Internal</MenuItem>
+          <MenuItem value={"external"}>External</MenuItem>
+        </Select>
+      </span>
+
+      <span className={styles.RowCell}>
+        {/* {props.target_type === "page" ? (
           <Select
             className={styles.selector}
-            onChange={(evt) => handlePageTarget(evt.target.value)}
+            onChange={(evt) => handlePathTarget(evt.target.value)}
             size="small"
             fullWidth
           >
@@ -96,23 +111,25 @@ function RedirectImportTableRow(props) {
               }
             })}
           </Select>
-        ) : (
+        ) : ( */}
+        <TextField
+          onChange={handlePathTarget}
+          defaultValue={props.target}
+          size="small"
+          variant="outlined"
+          color="primary"
+        />
+        {/* )} */}
+        {props.targetType === "path" && (
           <TextField
-            onChange={handlePathTarget}
-            defaultValue={props.target}
+            onChange={handleQuery}
+            placeholder="Redirect query string"
+            defaultValue={props.query_string}
             size="small"
             variant="outlined"
             color="primary"
           />
         )}
-        <TextField
-          onChange={handleQuery}
-          placeholder="Redirect query string"
-          defaultValue={props.query_string}
-          size="small"
-          variant="outlined"
-          color="primary"
-        />
       </span>
 
       <span className={cx(styles.RowCell, styles.RedirectButton)}>

--- a/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTableRow/RedirectImportTableRow.less
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectImportTable/RedirectImportTableRow/RedirectImportTableRow.less
@@ -1,7 +1,7 @@
 @import "~@zesty-io/core/colors.less";
 .RedirectImportTableRow {
   display: grid;
-  grid-template-columns: minmax(200px, 1fr) auto auto minmax(200px, 1fr);
+  grid-template-columns: minmax(200px, 1fr) auto 150px 1fr auto;
   gap: 0 8px;
   align-items: center;
 


### PR DESCRIPTION
- Added CSV parse functionality to look for column names and determine index as opposed to requiring user to have columns in a specific order
- Added ability to choose target type for a redirect
- Added more verbose error on notifications to better convey what might be incorrect/missing

<img width="772" alt="Screen Shot 2022-08-28 at 10 39 00 PM" src="https://user-images.githubusercontent.com/10054410/187131491-e8749ae0-59bc-4a4d-8fa3-427c7dc856fd.png">
