### PR TITLE
Fix media infinite loading screen

### DIFF
--- a/src/apps/media/src/app/MediaApp.js
+++ b/src/apps/media/src/app/MediaApp.js
@@ -108,7 +108,11 @@ export default connect((state) => {
         setCurrentGroupID(binID);
       }
     }
-  }, [props.media.groups]);
+    /*
+      It is never valid to have a falsy currentGroupID
+      The falsy check in this effect will prevent infinite rerenders
+    */
+  }, [props.media.groups, params.groupID, currentGroupID]);
 
   // update URL when currentGroupID or currentFileID changes
   useEffect(() => {


### PR DESCRIPTION
Fixes the infinite loading screen that occurs when you navigate from media to media.

Forces a re-compute of `currentGroupID` whenever it is falsy, as it is never valid to have a falsy `currentGroupID` 

Closes #1313 