### PR TITLE
Display error message on new field page when model is not found

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.js
+++ b/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.js
@@ -8,6 +8,7 @@ import { createSelector } from "@reduxjs/toolkit";
 import Divider from "@mui/material/Divider";
 
 import { WithLoader } from "@zesty-io/core/WithLoader";
+import { NotFound } from "shell/components/NotFound";
 import { Header } from "./Header";
 import { Editor } from "../../components/Editor";
 import { ItemSettings } from "../ItemEdit/Meta/ItemSettings";
@@ -37,7 +38,6 @@ export default function ItemCreate() {
   const item = useSelector((state) => state.content[itemZUID]);
   const instance = useSelector((state) => state.instance);
   const content = useSelector((state) => state.content);
-  const platform = useSelector((state) => state.platform);
   const fields = useSelector((state) =>
     selectSortedModelFields(state, modelZUID)
   );
@@ -127,6 +127,10 @@ export default function ItemCreate() {
         setSaving(false);
       }
     }
+  }
+
+  if (!loading && !model) {
+    return <NotFound message={`Model "${modelZUID}" not found`} />;
   }
 
   return (


### PR DESCRIPTION
Page crashes when navigating to `/content/${ZUID}/new` when ZUID does not exist.

Solution is to copy [the pattern from the list component](https://github.com/zesty-io/manager-ui/blob/master/src/apps/content-editor/src/app/views/ItemList/ItemList.js#L622-L624) and display a `<NotFound>` component when the item is not found

Closes #1259 