### PR TITLE
Handle duplicate groups request causing undefined payload

### DIFF
--- a/src/shell/store/media.js
+++ b/src/shell/store/media.js
@@ -432,6 +432,11 @@ export function fetchAllGroups() {
     const binIDs = groups[0].children.concat(groups[1].children);
     return Promise.all(binIDs.map((id) => dispatch(fetchGroups(id)))).then(
       (groups) => {
+        /*
+          If a fetchGroup call gets duplicated it will return undefined, so if
+          we are in a dispatch that is the duplicate we can ignore it
+        */
+        if (groups.some((group) => group === undefined)) return;
         return dispatch(fetchGroupsSuccess(groups.flat()));
       }
     );

--- a/src/shell/store/media.js
+++ b/src/shell/store/media.js
@@ -433,8 +433,9 @@ export function fetchAllGroups() {
     return Promise.all(binIDs.map((id) => dispatch(fetchGroups(id)))).then(
       (groups) => {
         /*
-          If a fetchGroup call gets duplicated it will return undefined, so if
-          we are in a dispatch that is the duplicate we can ignore it
+          If a fetchGroup call gets duplicated it will return undefined, so
+          here we check if the current execution is coming from the duplicate 
+          in order to ignore it
         */
         if (groups.some((group) => group === undefined)) return;
         return dispatch(fetchGroupsSuccess(groups.flat()));


### PR DESCRIPTION
Cause:
Toggling schema triggers a fetch all groups call. 

If done quickly it will cause a duplicate request

The way we handle duplicate requests is simply by resolving the promise

<img width="474" alt="Screen Shot 2022-10-04 at 8 28 31 PM" src="https://user-images.githubusercontent.com/10054410/193975399-3c997698-9b50-4124-bebe-7d5d542eb748.png">

Thus returning 'undefined' as a payload

Solution:

Low impact - Check if any payload was undefined if so do not continue

Higher impact - reject promise on duplicate request