### PR TITLE
Add ref check to MemoizedEditor useEffect cleanup function

### DIFF
--- a/src/apps/code-editor/src/app/components/Editor/components/MemoizedEditor/MemoizedEditor.js
+++ b/src/apps/code-editor/src/app/components/Editor/components/MemoizedEditor/MemoizedEditor.js
@@ -45,12 +45,14 @@ export const MemoizedEditor = memo(
 
         // Saves cursor position to the store on file change
         return () => {
-          dispatch(
-            actions.setCodeEditorPosition({
-              ...codeEditorPosition,
-              [props.fileZUID]: ref.current.editor.getPosition(),
-            })
-          );
+          if (ref.current) {
+            dispatch(
+              actions.setCodeEditorPosition({
+                ...codeEditorPosition,
+                [props.fileZUID]: ref.current.editor.getPosition(),
+              })
+            );
+          }
         };
       }
     }, [props.fileName]);


### PR DESCRIPTION
Add check to make sure editor ref still exists before accessing `getPosition()` method

Closes #1254 