### PR TITLE
Update dropzone to support controlled inputs

### DIFF
--- a/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/FieldSettings.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/FieldSettings/FieldSettings.js
@@ -1,4 +1,4 @@
-import { Fragment } from "react";
+import { Fragment, useEffect } from "react";
 import cx from "classnames";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -70,9 +70,7 @@ export default function FieldSettings(props) {
             className={styles.Setting}
             name="label"
             label="Field Label"
-            {...(props.new
-              ? { value: props.field.label }
-              : { defaultValue: props.field.label })}
+            value={props.field.label}
             maxLength="200"
             onChange={(evt) => {
               const val = evt.target.value;
@@ -92,9 +90,7 @@ export default function FieldSettings(props) {
             name="name"
             label="Field Name (Parsley Code Reference)"
             helperText="Can not contain spaces, uppercase or special characters."
-            {...(props.new
-              ? { value: props.field.name }
-              : { defaultValue: props.field.name })}
+            value={props.field.name}
             maxLength="50"
             onChange={(evt) => {
               props.updateValue(formatName(evt.target.value), "name");
@@ -161,7 +157,7 @@ export default function FieldSettings(props) {
             className={styles.Setting}
             name="description"
             label="Description displayed to content editors"
-            defaultValue={props.field.description || ""}
+            value={props.field.description || ""}
             maxLength="250"
             onChange={(evt) =>
               props.updateValue(evt.target.value, "description")

--- a/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Settings/Settings.js
+++ b/src/apps/schema/src/app/views/SchemaEdit/SchemaMeta/Settings/Settings.js
@@ -50,7 +50,13 @@ export default function Settings(props) {
 
           <FieldTypeText
             name="name"
-            label="Parsley reference name (no spaces)"
+            label={
+              <>
+                Parsley reference name
+                <br />
+                (no spaces)
+              </>
+            }
             value={props.model.name}
             onChange={(evt) => update(evt.target.value, "name")}
           />


### PR DESCRIPTION
<img width="1021" alt="Screen Shot 2022-10-12 at 1 07 06 PM" src="https://user-images.githubusercontent.com/10054410/195438045-02d4a979-7a2a-4a47-9ffa-798fd4dac49e.png">

Dropzone clones children before children actually get processed un-updated. Therefore on an expected update, it would clone the previous state of children before cloning the new state of children. This was causing unintended side effects when working with controlled inputs