### PR TITLE
Fix Media selection locking when group id equals string 0

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.js
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.js
@@ -438,7 +438,11 @@ export default function Field({
                 <MediaApp
                   limitSelected={imageModal.limit - images.length}
                   isSelectDialog={true}
-                  lockedToGroupId={settings.group_id}
+                  lockedToGroupId={
+                    settings?.group_id && settings?.group_id !== "0"
+                      ? settings.group_id
+                      : null
+                  }
                   addImagesCallback={(images) => {
                     imageModal.callback(images);
                     setImageModal();


### PR DESCRIPTION
When removing the media group lock in schema a "0" is provided as the group id. 
This was unaccounted for.

Follow-up conversation points:
Why do we set it to "0"? 
Is it misleading?
Can we set it to null?

Specific logic to account for this was set previously but was missed 
