### PR TITLE
Fix "insert from media" header always showing

### DIFF
--- a/src/apps/media/src/app-revamp/components/MediaGrid.tsx
+++ b/src/apps/media/src/app-revamp/components/MediaGrid.tsx
@@ -146,7 +146,7 @@ export const MediaGrid = ({ groups, files, hideHeaders = false }: Props) => {
                 group_id={files[gridItemIndex].group_id}
                 bin_id={files[gridItemIndex].bin_id}
                 file={files[gridItemIndex]}
-                selectable={isSelectDialog}
+                selectable={true}
                 onClick={() => {
                   const params = new URLSearchParams(location.search);
                   params.set("fileId", files[gridItemIndex]?.id);

--- a/src/apps/media/src/app-revamp/index.tsx
+++ b/src/apps/media/src/app-revamp/index.tsx
@@ -30,7 +30,7 @@ interface Props {
 export const MediaApp = ({
   lockedToGroupId,
   showHeaderActions = true,
-  isSelectDialog = true,
+  isSelectDialog = false,
   addImagesCallback,
   limitSelected = null,
 }: Props) => {
@@ -50,7 +50,7 @@ export const MediaApp = ({
 
   useEffect(() => {
     return () => {
-      dispatch(setIsSelectDialog(true));
+      dispatch(setIsSelectDialog(false));
       dispatch(clearSelectedFiles());
       dispatch(setLimitSelected(null));
     };


### PR DESCRIPTION
Reverting change to default isSelectDialog to false and properly making files selectable across all Media Grids