### PR TITLE
Fix code drawer log display on fetch failure

### DIFF
--- a/src/apps/code-editor/src/app/components/FileDrawer/FileDrawer.js
+++ b/src/apps/code-editor/src/app/components/FileDrawer/FileDrawer.js
@@ -21,6 +21,7 @@ import { fetchItems } from "shell/store/content";
 import { fetchFields } from "shell/store/fields";
 
 import styles from "./FileDrawer.less";
+import { notify } from "../../../../../../shell/store/notifications";
 export const FileDrawer = memo(function FileDrawer(props) {
   const dispatch = useDispatch();
 
@@ -54,7 +55,16 @@ export const FileDrawer = memo(function FileDrawer(props) {
       .then((res) => {
         const [logs, fields, items] = res;
 
-        if (logs.status !== 200) throw new Error(`${logs.status}`);
+        if (logs?.status !== 200) {
+          dispatch(
+            notify({
+              message: "Unable to load Code file logs",
+              kind: "warn",
+            })
+          );
+          setLogs(null);
+          return;
+        }
 
         // Logs should always exist
         setLogs(

--- a/src/apps/code-editor/src/app/components/FileDrawer/components/AuditTrail/AuditTrail.js
+++ b/src/apps/code-editor/src/app/components/FileDrawer/components/AuditTrail/AuditTrail.js
@@ -33,7 +33,10 @@ export default function AuditTrail(props) {
       ></CardHeader>
 
       <CardContent>
-        {props.logs.length === 0 && (
+        {props.logs === null && (
+          <Notice className={styles.NoLogs}>Unable to load activity log</Notice>
+        )}
+        {props.logs && props.logs?.length === 0 && (
           <Notice className={styles.NoLogs}>
             When this file is saved or published you will be able to see logs of
             when and by whom.
@@ -41,17 +44,18 @@ export default function AuditTrail(props) {
         )}
 
         <ul>
-          {props.logs.map((log) => (
-            <li key={log.ZUID} className={styles.Log}>
-              {`${moment(log.createdAt).format("YYYY-MM-DD")} ${
-                log.firstName
-              } ${log.lastName}`}
-              {log.firstName === "Unknown" && log.lastName === "User"
-                ? `(${log.actionByUserZUID})`
-                : null}
-              {`: ${log.meta.message}`}
-            </li>
-          ))}
+          {props.logs &&
+            props.logs.map((log) => (
+              <li key={log.ZUID} className={styles.Log}>
+                {`${moment(log.createdAt).format("YYYY-MM-DD")} ${
+                  log.firstName
+                } ${log.lastName}`}
+                {log.firstName === "Unknown" && log.lastName === "User"
+                  ? `(${log.actionByUserZUID})`
+                  : null}
+                {`: ${log.meta.message}`}
+              </li>
+            ))}
         </ul>
       </CardContent>
       <CardActions sx={{ marginTop: "auto" }}>


### PR DESCRIPTION
When a fetch error occurs on the Code app file drawer (i.e. no internet connection), the Redux action does not return any data but the consumer (File drawer action log) tries to access the `status` property in the undefined response. 

This fix checks for the existence of data in the response instead of checking the `status`. If there is no response, we display a warning to the user.

Closes #1538 