### PR TITLE
fix: added space support for content nav filter

### DIFF
--- a/src/apps/content-editor/src/app/components/Nav/ItemsFilter.js
+++ b/src/apps/content-editor/src/app/components/Nav/ItemsFilter.js
@@ -20,19 +20,19 @@ const ItemsFilter = (props) => {
         ),
       }}
       onChange={(evt) => {
-        const term = evt.target.value.toLowerCase();
+        const term = evt.target.value;
 
         props.setSearchTerm(term);
         if (term) {
-          const trimmedTerm = term.trim();
+          const filterTerm = term.trim().toLowerCase();
 
           props.setFilteredItems(
             props.nav.raw.filter((f) => {
               return (
-                f.label.toLowerCase().includes(trimmedTerm) ||
-                f.path.toLowerCase().includes(trimmedTerm) ||
-                f.contentModelZUID === trimmedTerm ||
-                f.ZUID === trimmedTerm
+                f.label.toLowerCase().includes(filterTerm) ||
+                f.path.toLowerCase().includes(filterTerm) ||
+                f.contentModelZUID === filterTerm ||
+                f.ZUID === filterTerm
               );
             })
           );

--- a/src/apps/content-editor/src/app/components/Nav/ItemsFilter.js
+++ b/src/apps/content-editor/src/app/components/Nav/ItemsFilter.js
@@ -20,16 +20,19 @@ const ItemsFilter = (props) => {
         ),
       }}
       onChange={(evt) => {
-        const term = evt.target.value.trim().toLowerCase();
+        const term = evt.target.value.toLowerCase();
+
         props.setSearchTerm(term);
         if (term) {
+          const trimmedTerm = term.trim();
+
           props.setFilteredItems(
             props.nav.raw.filter((f) => {
               return (
-                f.label.toLowerCase().includes(term) ||
-                f.path.toLowerCase().includes(term) ||
-                f.contentModelZUID === term ||
-                f.ZUID === term
+                f.label.toLowerCase().includes(trimmedTerm) ||
+                f.path.toLowerCase().includes(trimmedTerm) ||
+                f.contentModelZUID === trimmedTerm ||
+                f.ZUID === trimmedTerm
               );
             })
           );


### PR DESCRIPTION
Added support for spaces in content nav filter
Closes #1568 

Screenshot:
![nav-filter-fix](https://user-images.githubusercontent.com/28705606/204951629-513556f0-84eb-4f25-af20-19b75a053900.png)
