### PR TITLE
Hotfix: insights media data

### DIFF
--- a/src/apps/media/src/app/views/InsightsMedia.tsx
+++ b/src/apps/media/src/app/views/InsightsMedia.tsx
@@ -136,7 +136,7 @@ export const InsightsMedia: FC = () => {
       </Box>
       <InsightsTable
         files={uniqBy(
-          usage?.TopMedia.map((file: any, key: number) => ({
+          usage?.TopMedia?.map((file: any, key: number) => ({
             id: key,
             ...file,
             ...(files?.find((f) => f.url === file.FullPath?.split("?")?.[0]) ||


### PR DESCRIPTION
This fix is related to the issue that I found on prod testing where the insights page crashes when TopMedia object is empty.
There's no ticket opened on this issue.