### PR TITLE
Lower the time difference used to determine if model is auto generated or user created

### DIFF
--- a/src/apps/home/app/index.tsx
+++ b/src/apps/home/app/index.tsx
@@ -42,7 +42,8 @@ export const HomeApp = () => {
   const hasEditedHomepage = contentModelItems?.[0]?.web?.version > 1;
   const hasPublishedHomepage = !!contentItemPublishings?.length;
   const hasCreatedNewModel = models?.some(
-    (model) => moment(model.createdAt).diff(instanceCreatedAtDate, "hours") >= 1
+    (model) =>
+      moment(model.createdAt).diff(instanceCreatedAtDate, "minutes") >= 15
   );
   const isFetching =
     isModelsFetching ||

--- a/src/apps/home/app/index.tsx
+++ b/src/apps/home/app/index.tsx
@@ -43,7 +43,7 @@ export const HomeApp = () => {
   const hasPublishedHomepage = !!contentItemPublishings?.length;
   const hasCreatedNewModel = models?.some(
     (model) =>
-      moment(model.createdAt).diff(instanceCreatedAtDate, "minutes") >= 15
+      moment(model.createdAt).diff(instanceCreatedAtDate, "minutes") >= 10
   );
   const isFetching =
     isModelsFetching ||


### PR DESCRIPTION
1 hour is too long and users going through the setup too fast will experience unexpected behavior