### PR TITLE
Tabs: Keep tab position & dropdown menu sorting update

### DIFF
--- a/src/shell/components/global-tabs/GlobalTabs.tsx
+++ b/src/shell/components/global-tabs/GlobalTabs.tsx
@@ -10,10 +10,11 @@ import { useDispatch, useSelector } from "react-redux";
 import { useWindowSize } from "react-use";
 import { useLocation } from "react-router-dom";
 import debounce from "lodash/debounce";
+import isEqual from "lodash/isEqual";
 
 import { Dropdown } from "./components/Dropdown";
 import { GlobalDirtyCodeModal } from "./components/GlobalDirtyCodeModal";
-import { TopBarTab, UnpinnedTopBarTab } from "./components/Tab";
+import { PinnedTopBarTab, UnpinnedTopBarTab } from "./components/Tab";
 import Stack from "@mui/material/Stack";
 
 import {
@@ -81,7 +82,6 @@ export default memo(function GlobalTabs() {
   useEffect(() => {
     dispatch(setDocumentTitle(location, queryData));
 
-    console.log("loc data", location);
     // If current location is not in topbartabs array, add it
   }, [location.pathname, location.search]);
 
@@ -154,7 +154,6 @@ export default memo(function GlobalTabs() {
   const numTabs = Math.floor(tabBarWidth / tabWidth);
   const { topbar, dropdown } = getTabs(numTabs);
 
-  // TODO: Fix pin/unpin on topbar tabs
   return (
     <>
       <GlobalDirtyCodeModal />
@@ -191,13 +190,13 @@ export default memo(function GlobalTabs() {
         >
           {!isCurrLocPinned && <UnpinnedTopBarTab tabWidth={tabWidth} />}
           {topbar.map((tab) => (
-            <TopBarTab
+            <PinnedTopBarTab
+              key={tab.pathname + tab.search}
               tab={tab}
               tabWidth={tabWidth}
-              variant="fill"
               isDarkMode={tab.app === "Code"}
               isActive={tabLocationEquality(tab, location)}
-              onPinClick={() => {}}
+              isPinned={pinnedTabs.some((t) => isEqual(t, tab))}
             />
           ))}
           <Dropdown

--- a/src/shell/components/global-tabs/GlobalTabs.tsx
+++ b/src/shell/components/global-tabs/GlobalTabs.tsx
@@ -42,6 +42,7 @@ export default memo(function GlobalTabs() {
   const ecoId = useSelector((state: any) => state.instance.ecoID);
   const dispatch = useDispatch();
   const pinnedTabs = useSelector((state: AppState) => state.ui.pinnedTabs);
+  const [tabs, setTabs] = useState([]);
 
   const instanceZUID = useSelector((state: AppState) => state.instance.ZUID);
   const loadedTabs = useSelector((state: AppState) => state.ui.loadedTabs);
@@ -90,6 +91,10 @@ export default memo(function GlobalTabs() {
     }
   }, [loadedTabs, models, content, files, queryData, apps, users]);
 
+  useEffect(() => {
+    setTabs(pinnedTabs);
+  }, [pinnedTabs]);
+
   // measure the tab bar width and set state
   // to trigger a synchronous re-render before paint
   // recalculate tab bar width if window is resized
@@ -102,14 +107,18 @@ export default memo(function GlobalTabs() {
     }
   }, [windowWidth]);
 
+  /**
+   * Determines which tabs will be placed on the topbar and dropdown menu.
+   */
   const getTabs = (numTabs: number) => {
-    const isCurrLocPinned = pinnedTabs.filter(
+    // TODO: Determine if curr loc is on dropdown tab
+    const isCurrLocPinned = tabs.filter(
       (tab) =>
         tab.pathname === location.pathname && tab.search === location.search
     ).length;
     const tabCount = isCurrLocPinned ? numTabs : numTabs - 1;
-    const topbar = pinnedTabs.filter((_, i) => i < tabCount);
-    const dropdown = pinnedTabs.filter((_, i) => i >= tabCount);
+    const topbar = tabs.filter((_, i) => i < tabCount);
+    const dropdown = tabs.filter((_, i) => i >= tabCount);
 
     return { topbar, dropdown };
   };
@@ -117,14 +126,15 @@ export default memo(function GlobalTabs() {
   const tabWidth =
     Math.floor(
       Math.min(
-        Math.max(tabBarWidth / pinnedTabs.length, MIN_TAB_WIDTH),
+        Math.max(tabBarWidth / tabs.length, MIN_TAB_WIDTH),
         MAX_TAB_WIDTH
       )
     ) -
     TAB_PADDING -
     TAB_BORDER;
 
-  const isCurrLocPinned = pinnedTabs.filter((tab) =>
+  // Determines if the opened url is a pinned tab or not. Used to show/hide the unpinned tab component.
+  const isCurrLocPinned = tabs.filter((tab) =>
     tabLocationEquality(tab, location)
   ).length;
   const numTabs = Math.floor(tabBarWidth / tabWidth);
@@ -137,7 +147,8 @@ export default memo(function GlobalTabs() {
   // });
   // console.log(isCurrLocPinned, numTabs);
 
-  // TODO: Find a way to adjust the tabs when a tab from dropdown is clicked
+  // TODO: Fix pin/unpin on topbar tabs
+  // TODO: Handle setting a tab from dropdown menu on topbar on page load
   return (
     <>
       <GlobalDirtyCodeModal />

--- a/src/shell/components/global-tabs/GlobalTabs.tsx
+++ b/src/shell/components/global-tabs/GlobalTabs.tsx
@@ -14,7 +14,7 @@ import isEqual from "lodash/isEqual";
 
 import { Dropdown } from "./components/Dropdown";
 import { GlobalDirtyCodeModal } from "./components/GlobalDirtyCodeModal";
-import { PinnedTopBarTab, UnpinnedTopBarTab } from "./components/Tab";
+import { TopBarTab, UnpinnedTopBarTab } from "./components/Tab";
 import Stack from "@mui/material/Stack";
 
 import {
@@ -186,11 +186,14 @@ export default memo(function GlobalTabs() {
             "& .tab-item[data-active=true] + .tab-item > div": {
               borderColor: "transparent",
             },
+            "& .tab-item[data-active=true] + .more-menu-tab > span": {
+              borderColor: "transparent",
+            },
           }}
         >
           {!isCurrLocPinned && <UnpinnedTopBarTab tabWidth={tabWidth} />}
           {topbar.map((tab) => (
-            <PinnedTopBarTab
+            <TopBarTab
               key={tab.pathname + tab.search}
               tab={tab}
               tabWidth={tabWidth}

--- a/src/shell/components/global-tabs/GlobalTabs.tsx
+++ b/src/shell/components/global-tabs/GlobalTabs.tsx
@@ -4,22 +4,15 @@ import {
   useLayoutEffect,
   useRef,
   useState,
-  FC,
   useMemo,
 } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useWindowSize } from "react-use";
 import { useLocation } from "react-router-dom";
-import { debounce } from "lodash";
 
 import { Dropdown } from "./components/Dropdown";
 import { GlobalDirtyCodeModal } from "./components/GlobalDirtyCodeModal";
-import {
-  ActiveTab,
-  InactiveTabGroup,
-  TopBarTab,
-  UnpinnedTopBarTab,
-} from "./components/Tab";
+import { TopBarTab, UnpinnedTopBarTab } from "./components/Tab";
 import Stack from "@mui/material/Stack";
 
 import {
@@ -49,7 +42,6 @@ export default memo(function GlobalTabs() {
   const ecoId = useSelector((state: any) => state.instance.ecoID);
   const dispatch = useDispatch();
   const pinnedTabs = useSelector((state: AppState) => state.ui.pinnedTabs);
-  const [tabs, setTabs] = useState([]);
 
   const instanceZUID = useSelector((state: AppState) => state.instance.ZUID);
   const loadedTabs = useSelector((state: AppState) => state.ui.loadedTabs);
@@ -89,41 +81,6 @@ export default memo(function GlobalTabs() {
     console.log("loc data", location);
     // If current location is not in topbartabs array, add it
   }, [location.pathname, location.search]);
-
-  // useEffect(() => {
-
-  // }, [tabs])
-
-  // useEffect(() => {
-  //   // setTabs(pinnedTabs);
-  //   if (pinnedTabs.length) {
-  //     console.log(pinnedTabs);
-
-  //     const tabs = pinnedTabs.map((tab, i) => (
-  //       {
-  //         ...tab,
-  //         type: i >= numTabs ? 'dropdown' : 'pinned'
-  //       }
-  //     ));
-
-  //     const currLoc = tabs.filter(tab => tab.pathname === location.pathname && tab.search === location.search);
-
-  //     if (!currLoc.length) {
-  //       console.log('THIS PAGE IS NOT PINNED')
-  //       tabs.push({
-  //         pathname: location.pathname,
-  //         search: location.search,
-  //         type: 'unpinned'
-  //       })
-  //     }
-
-  //     setTabs(tabs);
-  //     // Check current location
-  //       // if pinned set as type pinned
-  //       // if not, set as type unpinned
-  //   }
-
-  // }, [pinnedTabs])
 
   // rebuild tabs if any of the store slices changes
   // slices could include tab.name updates
@@ -167,22 +124,10 @@ export default memo(function GlobalTabs() {
     TAB_PADDING -
     TAB_BORDER;
 
-  //const inactiveTabs = [] //tabs.filter(tab => tab.pathname !== location.pathname)
-  const inactiveTabs = pinnedTabs.filter(
-    (tab) => !tabLocationEquality(tab, location)
-  );
-
-  const isCurrLocPinned = pinnedTabs.filter(
-    (tab) =>
-      tab.pathname === location.pathname && tab.search === location.search
+  const isCurrLocPinned = pinnedTabs.filter((tab) =>
+    tabLocationEquality(tab, location)
   ).length;
-  // const numTabs = isCurrLocPinned ? Math.floor(tabBarWidth / tabWidth) : Math.floor(tabBarWidth / tabWidth) - 1;
   const numTabs = Math.floor(tabBarWidth / tabWidth);
-
-  // Adjust by 1 to accommodate the active tab
-  const topBarTabs = inactiveTabs.filter((_, i) => i < numTabs - 1);
-  const dropDownTabs = inactiveTabs.filter((_, i) => i >= numTabs - 1);
-
   const { topbar, dropdown } = getTabs(numTabs);
   // console.table({
   //   'curr loc pinned': isCurrLocPinned,
@@ -192,6 +137,7 @@ export default memo(function GlobalTabs() {
   // });
   // console.log(isCurrLocPinned, numTabs);
 
+  // TODO: Find a way to adjust the tabs when a tab from dropdown is clicked
   return (
     <>
       <GlobalDirtyCodeModal />
@@ -237,8 +183,6 @@ export default memo(function GlobalTabs() {
               onPinClick={() => {}}
             />
           ))}
-          {/* <ActiveTab tabWidth={tabWidth} />
-          <InactiveTabGroup tabs={topBarTabs} tabWidth={tabWidth} /> */}
           <Dropdown
             tabs={dropdown}
             tabWidth={MORE_MENU_WIDTH}

--- a/src/shell/components/global-tabs/GlobalTabs.tsx
+++ b/src/shell/components/global-tabs/GlobalTabs.tsx
@@ -7,15 +7,13 @@ import {
   FC,
   useMemo,
 } from "react";
-import { createDispatchHook, useDispatch, useSelector } from "react-redux";
-import { useLocation, Link as Link } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 import { debounce } from "lodash";
 
 import { Dropdown } from "./components/Dropdown";
 import { GlobalDirtyCodeModal } from "./components/GlobalDirtyCodeModal";
 import { ActiveTab, InactiveTabGroup } from "./components/Tab";
-import { ThemeProvider } from "@mui/material/styles";
-import { theme } from "@zesty-io/material";
 import Stack from "@mui/material/Stack";
 
 import {
@@ -147,13 +145,13 @@ export default memo(function GlobalTabs() {
           },
         }}
       >
-        {/* TODO: Remove border color on tab adjacent to active */}
         <Stack
           component="div"
           overflow="hidden"
           display="grid"
           gridTemplateColumns={`repeat(${numTabs + 1}, ${tabWidth}px)`}
           sx={{
+            // TODO: change to :first-of-type
             "& .tab-item:first-child > div": {
               borderColor: "transparent",
             },
@@ -167,7 +165,6 @@ export default memo(function GlobalTabs() {
         >
           <ActiveTab tabWidth={tabWidth} />
           <InactiveTabGroup tabs={topBarTabs} tabWidth={tabWidth} />
-          {/* TODO: Add border left to dropdown */}
           <Dropdown
             tabs={dropDownTabs}
             tabWidth={tabWidth}

--- a/src/shell/components/global-tabs/components/Dropdown.tsx
+++ b/src/shell/components/global-tabs/components/Dropdown.tsx
@@ -2,7 +2,6 @@ import { useState, FC } from "react";
 import { Link as Link } from "react-router-dom";
 
 import { ConfirmDialog } from "@zesty-io/material";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import PinIcon from "@mui/icons-material/PushPin";
 import SearchIcon from "@mui/icons-material/Search";
 
@@ -16,6 +15,7 @@ import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import IconButton from "@mui/material/IconButton";
 import InputBase from "@mui/material/InputBase";
+import SvgIcon from "@mui/material/SvgIcon";
 
 import { Tab } from "../../../../shell/store/ui";
 import { Typography } from "@mui/material";
@@ -289,10 +289,20 @@ const DropdownItem: FC<DropdownItem> = ({ tab, remove }) => {
         borderColor: "border",
       }}
     >
-      {/* TODO: Change to MUI icons once Zosh provides list */}
-      <Box component="span" pr={0.5} sx={{ color: "action.active" }}>
+      <Box
+        component="span"
+        pr={0.5}
+        sx={{ color: "action.active" }}
+        fontSize={18}
+      >
         {tab.icon && (
-          <FontAwesomeIcon icon={tab.icon} style={{ fontSize: "18px" }} />
+          <SvgIcon
+            component={tab.icon}
+            fontSize="inherit"
+            sx={{
+              verticalAlign: "middle",
+            }}
+          />
         )}
       </Box>
       <MuiLink

--- a/src/shell/components/global-tabs/components/Dropdown.tsx
+++ b/src/shell/components/global-tabs/components/Dropdown.tsx
@@ -16,9 +16,9 @@ import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import IconButton from "@mui/material/IconButton";
 import InputBase from "@mui/material/InputBase";
 import SvgIcon from "@mui/material/SvgIcon";
+import Typography from "@mui/material/Typography";
 
 import { Tab } from "../../../../shell/store/ui";
-import { Typography } from "@mui/material";
 
 export type Dropdown = {
   tabs: Tab[];
@@ -29,7 +29,12 @@ export type Dropdown = {
 
 const ITEM_HEIGHT = 56;
 
-export const Dropdown: FC<Dropdown> = ({ tabs, removeOne, removeMany }) => {
+export const Dropdown: FC<Dropdown> = ({
+  tabs,
+  removeOne,
+  removeMany,
+  tabWidth,
+}) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const [filter, setFilter] = useState("");
@@ -69,41 +74,49 @@ export const Dropdown: FC<Dropdown> = ({ tabs, removeOne, removeMany }) => {
   return (
     <>
       <Box
+        height={34}
+        width={tabWidth}
+        py={0.5}
+        borderRadius="8px 8px 0px 0px"
+        className="more-menu-tab"
         sx={{
           "&:hover": {
-            borderBottom: 2,
-            borderColor: "grey.50",
+            backgroundColor: "grey.50",
+            cursor: "pointer",
           },
         }}
       >
-        <Button
-          id="basic-button"
+        <Stack
+          direction="row"
+          component="span"
+          height={24}
+          alignItems="center"
+          justifyContent="flex-start"
+          borderLeft={1}
+          borderColor="grey.300"
+          sx={{
+            "&:hover": {
+              borderColor: "transparent",
+            },
+          }}
+          data-cy="TabsDropdownButton"
+          onClick={handleClick}
           aria-controls={open ? "basic-menu" : undefined}
           aria-haspopup="true"
           aria-expanded={open ? "true" : undefined}
-          onClick={handleClick}
-          disableRipple
-          disableElevation
-          disableTouchRipple
-          data-cy="TabsDropdownButton"
-          endIcon={<ArrowDropDownIcon color="action" />}
-          sx={{
-            backgroundColor: "grey.100",
-            "&:hover": {
-              backgroundColor: "grey.50",
-            },
-            /*
-             Needed to prevent button from outgrowing parent
-             which will push the dropdown below the nav bar,
-             creating an unsightly gap
-            */
-            lineHeight: "inherit",
-          }}
         >
-          <Typography color="text.secondary" fontWeight={600} variant="caption">
+          <Typography
+            // @ts-expect-error missing body3 module augmentation
+            variant="body3"
+            fontWeight={600}
+            pl={1.5}
+          >
             More
           </Typography>
-        </Button>
+          <IconButton disableTouchRipple disableRipple size="small">
+            <ArrowDropDownIcon />
+          </IconButton>
+        </Stack>
         <Menu
           id="basic-menu"
           anchorEl={anchorEl}

--- a/src/shell/components/global-tabs/components/Dropdown.tsx
+++ b/src/shell/components/global-tabs/components/Dropdown.tsx
@@ -1,5 +1,6 @@
 import { useState, FC } from "react";
 import { Link as Link } from "react-router-dom";
+import { useDispatch } from "react-redux";
 
 import { ConfirmDialog } from "@zesty-io/material";
 import PinIcon from "@mui/icons-material/PushPin";
@@ -18,7 +19,7 @@ import InputBase from "@mui/material/InputBase";
 import SvgIcon from "@mui/material/SvgIcon";
 import Typography from "@mui/material/Typography";
 
-import { Tab } from "../../../../shell/store/ui";
+import { Tab, updatePinnedTabs } from "../../../../shell/store/ui";
 
 export type Dropdown = {
   tabs: Tab[];
@@ -285,6 +286,8 @@ type DropdownItem = {
   remove: () => void;
 };
 const DropdownItem: FC<DropdownItem> = ({ tab, remove }) => {
+  const dispatch = useDispatch();
+
   return (
     <MenuItem
       disableRipple
@@ -321,6 +324,7 @@ const DropdownItem: FC<DropdownItem> = ({ tab, remove }) => {
       <MuiLink
         component={Link}
         to={tab.pathname + tab.search}
+        onClick={() => dispatch(updatePinnedTabs(tab))}
         underline="none"
         sx={{
           textDecoration: "none",

--- a/src/shell/components/global-tabs/components/Tab.tsx
+++ b/src/shell/components/global-tabs/components/Tab.tsx
@@ -2,14 +2,13 @@ import { FC, useEffect, useMemo, useState } from "react";
 import { useLocation, Link as Link } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import PinIcon from "@mui/icons-material/PushPin";
 import OutlinedPinIcon from "@mui/icons-material/PushPinOutlined";
 import { SxProps } from "@mui/system";
 
 import MuiLink from "@mui/material/Link";
 import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
+import SvgIcon from "@mui/material/SvgIcon";
 import Stack from "@mui/material/Stack";
 
 import {
@@ -39,9 +38,6 @@ type BaseTab = {
   sx?: SxProps;
   isDarkMode?: boolean;
   isActive?: boolean;
-  isAdjacentTabHovered?: boolean;
-  onMouseEnter?: () => void;
-  onMouseLeave?: () => void;
 };
 const BaseTab: FC<BaseTab> = ({
   tab,
@@ -51,9 +47,6 @@ const BaseTab: FC<BaseTab> = ({
   sx,
   isDarkMode = false,
   isActive = false,
-  isAdjacentTabHovered = false,
-  onMouseEnter,
-  onMouseLeave,
 }) => {
   const [styles, setStyles] = useState({
     backgroundColor: "grey.100",
@@ -87,9 +80,6 @@ const BaseTab: FC<BaseTab> = ({
   }, [isDarkMode, isActive]);
 
   const Pin = variant === "outline" ? OutlinedPinIcon : PinIcon;
-  // This removes the right border if the tab is to the left of a hovered tab
-  // or is an active tab
-  const isBorderHidden = isActive || isAdjacentTabHovered;
 
   return (
     <Box
@@ -101,8 +91,6 @@ const BaseTab: FC<BaseTab> = ({
       py={0.5}
       height={34}
       bgcolor={styles.backgroundColor}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
       flex="1 0 0"
       borderRadius="8px 8px 0px 0px"
       sx={{
@@ -134,10 +122,13 @@ const BaseTab: FC<BaseTab> = ({
           textOverflow="ellipsis"
           pl={1.5}
         >
-          <Box display="inline-block" mr={1.25} color={styles.iconColor}>
-            {tab.icon && (
-              <FontAwesomeIcon icon={tab.icon} style={{ fontSize: 16 }} />
-            )}
+          <Box
+            display="inline-block"
+            mr={1.25}
+            color={styles.iconColor}
+            fontSize={16}
+          >
+            {tab.icon && <SvgIcon component={tab.icon} fontSize="inherit" />}
           </Box>
           <MuiLink
             component={Link}
@@ -189,18 +180,13 @@ export type InactiveTabGroup = {
 };
 
 export const InactiveTabGroup: FC<InactiveTabGroup> = ({ tabs, tabWidth }) => {
-  const [hoveredTabIdx, setHoveredTabIdx] = useState(null);
-
   return (
     <>
       {tabs.map((tab, i) => (
         <InactiveTab
-          isAdjacentTabHovered={hoveredTabIdx - 1 === i}
           tab={tab}
           key={tab.pathname + tab.search}
           tabWidth={tabWidth}
-          onMouseEnter={() => setHoveredTabIdx(i)}
-          onMouseLeave={() => setHoveredTabIdx(null)}
           sx={{ zIndex: zIndex - i - 1 }}
         />
       ))}
@@ -212,19 +198,9 @@ export type InactiveTab = {
   tab: Tab;
   tabWidth: number;
   sx?: SxProps;
-  isAdjacentTabHovered: boolean;
-  onMouseEnter?: () => void;
-  onMouseLeave?: () => void;
 };
 
-export const InactiveTab: FC<InactiveTab> = ({
-  tab,
-  tabWidth,
-  sx,
-  isAdjacentTabHovered,
-  onMouseEnter,
-  onMouseLeave,
-}) => {
+export const InactiveTab: FC<InactiveTab> = ({ tab, tabWidth, sx }) => {
   const dispatch = useDispatch();
   const location = useLocation();
   const instanceId = useSelector((state: any) => state.instance.ID);
@@ -252,9 +228,6 @@ export const InactiveTab: FC<InactiveTab> = ({
       tab={tab}
       tabWidth={tabWidth}
       onClick={() => dispatch(unpinTab(tab, false, queryData))}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      isAdjacentTabHovered={isAdjacentTabHovered}
       sx={{
         "&:hover": {
           backgroundColor: "grey.50",

--- a/src/shell/components/global-tabs/components/Tab.tsx
+++ b/src/shell/components/global-tabs/components/Tab.tsx
@@ -44,7 +44,6 @@ const BaseTab: FC<BaseTab> = ({
   tabWidth,
   variant,
   onClick,
-  sx,
   isDarkMode = false,
   isActive = false,
 }) => {
@@ -228,14 +227,6 @@ export const InactiveTab: FC<InactiveTab> = ({ tab, tabWidth, sx }) => {
       tab={tab}
       tabWidth={tabWidth}
       onClick={() => dispatch(unpinTab(tab, false, queryData))}
-      sx={{
-        "&:hover": {
-          backgroundColor: "grey.50",
-          borderRadius: "8px 8px 0px 0px",
-          borderColor: "common.white",
-        },
-        ...sx,
-      }}
     />
   );
 };
@@ -286,11 +277,6 @@ export const ActiveTab: FC<ActiveTab> = ({ tabWidth }) => {
         } else {
           dispatch(pinTab(activeTab, queryData));
         }
-      }}
-      sx={{
-        borderRadius: "8px 8px 0px 0px",
-        border: "none",
-        zIndex,
       }}
     />
   );

--- a/src/shell/components/global-tabs/components/Tab.tsx
+++ b/src/shell/components/global-tabs/components/Tab.tsx
@@ -198,10 +198,8 @@ export type UnpinnedTopBarTab = {
   tabWidth: number;
 };
 export const UnpinnedTopBarTab: FC<UnpinnedTopBarTab> = ({ tabWidth }) => {
-  const dispatch = useDispatch();
   const instanceId = useSelector((state: any) => state.instance.ID);
   const ecoId = useSelector((state: any) => state.instance.ecoID);
-  const pinnedTabs = useSelector((state: AppState) => state.ui.pinnedTabs);
   const state = useSelector((state: AppState) => state);
   const location = useLocation();
   // RTK QUERY FOR HOOKING INTO ALL MEDIA BIN GROUPS
@@ -221,18 +219,15 @@ export const UnpinnedTopBarTab: FC<UnpinnedTopBarTab> = ({ tabWidth }) => {
     };
   }, [binGroups]);
 
-  const activeTab = createTab(state, parsePath(location), queryData);
-
-  const isPinned =
-    pinnedTabs.findIndex((t: Tab) => tabLocationEquality(t, activeTab)) >= 0;
+  const tab = createTab(state, parsePath(location), queryData);
 
   return (
     <TopBarTab
       isActive
       isPinned={false}
       tabWidth={tabWidth}
-      tab={activeTab}
-      isDarkMode={activeTab.app === "Code"}
+      tab={tab}
+      isDarkMode={tab.app === "Code"}
     />
   );
 };

--- a/src/shell/components/global-tabs/components/Tab.tsx
+++ b/src/shell/components/global-tabs/components/Tab.tsx
@@ -4,7 +4,6 @@ import { useDispatch, useSelector } from "react-redux";
 
 import PinIcon from "@mui/icons-material/PushPin";
 import OutlinedPinIcon from "@mui/icons-material/PushPinOutlined";
-import { SxProps } from "@mui/system";
 
 import MuiLink from "@mui/material/Link";
 import Box from "@mui/material/Box";
@@ -25,22 +24,24 @@ import {
   useGetBinsQuery,
 } from "../../../services/mediaManager";
 
-export type TopBarTab = {
+export type PinnedTopBarTab = {
   tab: Tab;
   tabWidth: number;
-  variant: "outline" | "fill";
-  onPinClick: () => void;
   isDarkMode?: boolean;
   isActive?: boolean;
+  isPinned?: boolean;
 };
-export const TopBarTab: FC<TopBarTab> = ({
+export const PinnedTopBarTab: FC<PinnedTopBarTab> = ({
   tab,
   tabWidth,
-  variant,
-  onPinClick,
   isDarkMode = false,
   isActive = false,
+  isPinned = false,
 }) => {
+  const dispatch = useDispatch();
+  const instanceId = useSelector((state: any) => state.instance.ID);
+  const ecoId = useSelector((state: any) => state.instance.ecoID);
+
   const [styles, setStyles] = useState({
     backgroundColor: "grey.100",
     fontColor: "text.secondary",
@@ -72,7 +73,33 @@ export const TopBarTab: FC<TopBarTab> = ({
     }
   }, [isDarkMode, isActive]);
 
-  const Pin = variant === "outline" ? OutlinedPinIcon : PinIcon;
+  // RTK QUERY FOR HOOKING INTO ALL MEDIA BIN GROUPS
+  const { data: bins } = useGetBinsQuery({ instanceId, ecoId });
+  const { data: binGroups } = useGetAllBinGroupsQuery(
+    bins?.map((bin) => bin.id),
+    {
+      skip: !bins?.length,
+    }
+  );
+  const queryData = useMemo(() => {
+    return {
+      mediaManager: {
+        bins,
+        binGroups: binGroups?.flat(),
+      },
+    };
+  }, [binGroups]);
+
+  const Pin = isPinned ? PinIcon : OutlinedPinIcon;
+
+  const handlePinClick = () => {
+    // force unpin because we don't want to show the modal on the active tab
+    if (isPinned) {
+      dispatch(unpinTab(tab, isActive, queryData));
+    } else {
+      dispatch(pinTab(tab, queryData));
+    }
+  };
 
   return (
     <Box
@@ -139,7 +166,7 @@ export const TopBarTab: FC<TopBarTab> = ({
         </Box>
         <Box
           component="div"
-          onClick={onPinClick}
+          onClick={handlePinClick}
           width={24}
           height={24}
           display="flex"
@@ -200,277 +227,12 @@ export const UnpinnedTopBarTab: FC<UnpinnedTopBarTab> = ({ tabWidth }) => {
     pinnedTabs.findIndex((t: Tab) => tabLocationEquality(t, activeTab)) >= 0;
 
   return (
-    <TopBarTab
+    <PinnedTopBarTab
       isActive
-      variant="outline"
+      isPinned={false}
       tabWidth={tabWidth}
       tab={activeTab}
       isDarkMode={activeTab.app === "Code"}
-      onPinClick={() => {
-        // force unpin because we don't want to show the modal on the active tab
-        if (isPinned) {
-          dispatch(unpinTab(activeTab, true, queryData));
-        } else {
-          dispatch(pinTab(activeTab, queryData));
-        }
-      }}
-    />
-  );
-};
-
-/*
-  we need a descending z-index to make the drop shadow render correctly
-*/
-const zIndex = 25;
-
-type BaseTab = {
-  tab: Tab;
-  tabWidth: number;
-  variant: "outline" | "fill";
-  onClick: () => void;
-  sx?: SxProps;
-  isDarkMode?: boolean;
-  isActive?: boolean;
-};
-const BaseTab: FC<BaseTab> = ({
-  tab,
-  tabWidth,
-  variant,
-  onClick,
-  isDarkMode = false,
-  isActive = false,
-}) => {
-  const [styles, setStyles] = useState({
-    backgroundColor: "grey.100",
-    fontColor: "text.secondary",
-    iconColor: "action.active",
-  });
-
-  useEffect(() => {
-    if (isActive) {
-      if (isDarkMode) {
-        setStyles({
-          backgroundColor: "#1e1e1e",
-          fontColor: "common.white",
-          iconColor: "grey.500",
-        });
-      } else {
-        setStyles({
-          backgroundColor: "common.white",
-          fontColor: "text.primary",
-          iconColor: "action.active",
-        });
-      }
-    } else {
-      // Revert to default style once unselected as active
-      setStyles({
-        backgroundColor: "grey.100",
-        fontColor: "text.secondary",
-        iconColor: "action.active",
-      });
-    }
-  }, [isDarkMode, isActive]);
-
-  const Pin = variant === "outline" ? OutlinedPinIcon : PinIcon;
-
-  return (
-    <Box
-      component="div"
-      className="tab-item"
-      data-cy="ActiveTab"
-      data-active={isActive}
-      width={`${tabWidth}px`}
-      py={0.5}
-      height={34}
-      bgcolor={styles.backgroundColor}
-      flex="1 0 0"
-      borderRadius="8px 8px 0px 0px"
-      sx={{
-        "&:hover": {
-          backgroundColor: isActive ? styles.backgroundColor : "grey.50",
-        },
-      }}
-    >
-      <Stack
-        component="div"
-        direction="row"
-        height={24}
-        alignItems="center"
-        justifyContent="space-between"
-        borderLeft={1}
-        borderColor={isActive ? "transparent" : "grey.300"}
-        sx={{
-          "&:hover": {
-            borderColor: "transparent",
-          },
-        }}
-      >
-        <Box
-          display="flex"
-          flex="1 0 0"
-          component="div"
-          whiteSpace="nowrap"
-          overflow="hidden"
-          textOverflow="ellipsis"
-          pl={1.5}
-        >
-          <Box
-            display="inline-block"
-            mr={1.25}
-            color={styles.iconColor}
-            fontSize={16}
-          >
-            {tab.icon && <SvgIcon component={tab.icon} fontSize="inherit" />}
-          </Box>
-          <MuiLink
-            component={Link}
-            to={tab.pathname + tab.search}
-            // @ts-expect-error missing body3 module augmentation
-            variant="body3"
-            color={styles.fontColor}
-            fontWeight={600}
-            underline="none"
-            flex="1 0 0"
-            noWrap
-          >
-            {tab.name ? tab.name : `${tab.pathname.slice(1)}`}
-          </MuiLink>
-        </Box>
-        <Box
-          component="div"
-          onClick={onClick}
-          width={24}
-          height={24}
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          pr={1}
-          pl={0.5}
-          color="action.active"
-          sx={{
-            cursor: "pointer",
-          }}
-        >
-          <Pin
-            fontSize="small"
-            sx={{
-              width: "16px",
-              height: "16px",
-              transform: "rotate(45deg)",
-              color: styles.iconColor,
-            }}
-          />
-        </Box>
-      </Stack>
-    </Box>
-  );
-};
-
-export type InactiveTabGroup = {
-  tabs: Tab[];
-  tabWidth: number;
-};
-
-export const InactiveTabGroup: FC<InactiveTabGroup> = ({ tabs, tabWidth }) => {
-  return (
-    <>
-      {tabs.map((tab, i) => (
-        <InactiveTab
-          tab={tab}
-          key={tab.pathname + tab.search}
-          tabWidth={tabWidth}
-          sx={{ zIndex: zIndex - i - 1 }}
-        />
-      ))}
-    </>
-  );
-};
-
-export type InactiveTab = {
-  tab: Tab;
-  tabWidth: number;
-  sx?: SxProps;
-};
-
-export const InactiveTab: FC<InactiveTab> = ({ tab, tabWidth, sx }) => {
-  const dispatch = useDispatch();
-  const location = useLocation();
-  const instanceId = useSelector((state: any) => state.instance.ID);
-  const ecoId = useSelector((state: any) => state.instance.ecoID);
-  // RTK QUERY FOR HOOKING INTO ALL MEDIA BIN GROUPS
-  const { data: bins } = useGetBinsQuery({ instanceId, ecoId });
-  const { data: binGroups } = useGetAllBinGroupsQuery(
-    bins?.map((bin) => bin.id),
-    {
-      skip: !bins?.length,
-    }
-  );
-  const queryData = useMemo(() => {
-    return {
-      mediaManager: {
-        bins,
-        binGroups: binGroups?.flat(),
-      },
-    };
-  }, [binGroups]);
-  if (tabLocationEquality(location, tab)) return null;
-  return (
-    <BaseTab
-      variant="fill"
-      tab={tab}
-      tabWidth={tabWidth}
-      onClick={() => dispatch(unpinTab(tab, false, queryData))}
-    />
-  );
-};
-
-export type ActiveTab = {
-  tabWidth: number;
-};
-export const ActiveTab: FC<ActiveTab> = ({ tabWidth }) => {
-  const dispatch = useDispatch();
-  const instanceId = useSelector((state: any) => state.instance.ID);
-  const ecoId = useSelector((state: any) => state.instance.ecoID);
-  const pinnedTabs = useSelector((state: AppState) => state.ui.pinnedTabs);
-  const state = useSelector((state: AppState) => state);
-  const location = useLocation();
-  // RTK QUERY FOR HOOKING INTO ALL MEDIA BIN GROUPS
-  const { data: bins } = useGetBinsQuery({ instanceId, ecoId });
-  const { data: binGroups } = useGetAllBinGroupsQuery(
-    bins?.map((bin) => bin.id),
-    {
-      skip: !bins?.length,
-    }
-  );
-  const queryData = useMemo(() => {
-    return {
-      mediaManager: {
-        bins,
-        binGroups: binGroups?.flat(),
-      },
-    };
-  }, [binGroups]);
-
-  const activeTab = createTab(state, parsePath(location), queryData);
-
-  const isPinned =
-    pinnedTabs.findIndex((t: Tab) => tabLocationEquality(t, activeTab)) >= 0;
-
-  return (
-    <BaseTab
-      isActive
-      variant={isPinned ? "fill" : "outline"}
-      tabWidth={tabWidth}
-      tab={activeTab}
-      isDarkMode={activeTab.app === "Code"}
-      onClick={() => {
-        // force unpin because we don't want to show the modal on the active tab
-        if (isPinned) {
-          dispatch(unpinTab(activeTab, true, queryData));
-        } else {
-          dispatch(pinTab(activeTab, queryData));
-        }
-      }}
     />
   );
 };

--- a/src/shell/components/global-tabs/components/Tab.tsx
+++ b/src/shell/components/global-tabs/components/Tab.tsx
@@ -25,6 +25,199 @@ import {
   useGetBinsQuery,
 } from "../../../services/mediaManager";
 
+export type TopBarTab = {
+  tab: Tab;
+  tabWidth: number;
+  variant: "outline" | "fill";
+  onPinClick: () => void;
+  isDarkMode?: boolean;
+  isActive?: boolean;
+};
+export const TopBarTab: FC<TopBarTab> = ({
+  tab,
+  tabWidth,
+  variant,
+  onPinClick,
+  isDarkMode = false,
+  isActive = false,
+}) => {
+  const [styles, setStyles] = useState({
+    backgroundColor: "grey.100",
+    fontColor: "text.secondary",
+    iconColor: "action.active",
+  });
+
+  useEffect(() => {
+    if (isActive) {
+      if (isDarkMode) {
+        setStyles({
+          backgroundColor: "#1e1e1e",
+          fontColor: "common.white",
+          iconColor: "grey.500",
+        });
+      } else {
+        setStyles({
+          backgroundColor: "common.white",
+          fontColor: "text.primary",
+          iconColor: "action.active",
+        });
+      }
+    } else {
+      // Revert to default style once unselected as active
+      setStyles({
+        backgroundColor: "grey.100",
+        fontColor: "text.secondary",
+        iconColor: "action.active",
+      });
+    }
+  }, [isDarkMode, isActive]);
+
+  const Pin = variant === "outline" ? OutlinedPinIcon : PinIcon;
+
+  return (
+    <Box
+      component="div"
+      className="tab-item"
+      data-cy="ActiveTab"
+      data-active={isActive}
+      width={`${tabWidth}px`}
+      py={0.5}
+      height={34}
+      bgcolor={styles.backgroundColor}
+      flex="1 0 0"
+      borderRadius="8px 8px 0px 0px"
+      sx={{
+        "&:hover": {
+          backgroundColor: isActive ? styles.backgroundColor : "grey.50",
+        },
+      }}
+    >
+      <Stack
+        component="div"
+        direction="row"
+        height={24}
+        alignItems="center"
+        justifyContent="space-between"
+        borderLeft={1}
+        borderColor={isActive ? "transparent" : "grey.300"}
+        sx={{
+          "&:hover": {
+            borderColor: "transparent",
+          },
+        }}
+      >
+        <Box
+          display="flex"
+          flex="1 0 0"
+          component="div"
+          whiteSpace="nowrap"
+          overflow="hidden"
+          textOverflow="ellipsis"
+          pl={1.5}
+        >
+          <Box
+            display="inline-block"
+            mr={1.25}
+            color={styles.iconColor}
+            fontSize={16}
+          >
+            {tab.icon && <SvgIcon component={tab.icon} fontSize="inherit" />}
+          </Box>
+          <MuiLink
+            component={Link}
+            to={tab.pathname + tab.search}
+            // @ts-expect-error missing body3 module augmentation
+            variant="body3"
+            color={styles.fontColor}
+            fontWeight={600}
+            underline="none"
+            flex="1 0 0"
+            noWrap
+          >
+            {tab.name ? tab.name : `${tab.pathname.slice(1)}`}
+          </MuiLink>
+        </Box>
+        <Box
+          component="div"
+          onClick={onPinClick}
+          width={24}
+          height={24}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          pr={1}
+          pl={0.5}
+          color="action.active"
+          sx={{
+            cursor: "pointer",
+          }}
+        >
+          <Pin
+            fontSize="small"
+            sx={{
+              width: "16px",
+              height: "16px",
+              transform: "rotate(45deg)",
+              color: styles.iconColor,
+            }}
+          />
+        </Box>
+      </Stack>
+    </Box>
+  );
+};
+
+export type UnpinnedTopBarTab = {
+  tabWidth: number;
+};
+export const UnpinnedTopBarTab: FC<UnpinnedTopBarTab> = ({ tabWidth }) => {
+  const dispatch = useDispatch();
+  const instanceId = useSelector((state: any) => state.instance.ID);
+  const ecoId = useSelector((state: any) => state.instance.ecoID);
+  const pinnedTabs = useSelector((state: AppState) => state.ui.pinnedTabs);
+  const state = useSelector((state: AppState) => state);
+  const location = useLocation();
+  // RTK QUERY FOR HOOKING INTO ALL MEDIA BIN GROUPS
+  const { data: bins } = useGetBinsQuery({ instanceId, ecoId });
+  const { data: binGroups } = useGetAllBinGroupsQuery(
+    bins?.map((bin) => bin.id),
+    {
+      skip: !bins?.length,
+    }
+  );
+  const queryData = useMemo(() => {
+    return {
+      mediaManager: {
+        bins,
+        binGroups: binGroups?.flat(),
+      },
+    };
+  }, [binGroups]);
+
+  const activeTab = createTab(state, parsePath(location), queryData);
+
+  const isPinned =
+    pinnedTabs.findIndex((t: Tab) => tabLocationEquality(t, activeTab)) >= 0;
+
+  return (
+    <TopBarTab
+      isActive
+      variant="outline"
+      tabWidth={tabWidth}
+      tab={activeTab}
+      isDarkMode={activeTab.app === "Code"}
+      onPinClick={() => {
+        // force unpin because we don't want to show the modal on the active tab
+        if (isPinned) {
+          dispatch(unpinTab(activeTab, true, queryData));
+        } else {
+          dispatch(pinTab(activeTab, queryData));
+        }
+      }}
+    />
+  );
+};
+
 /*
   we need a descending z-index to make the drop shadow render correctly
 */

--- a/src/shell/components/global-tabs/components/Tab.tsx
+++ b/src/shell/components/global-tabs/components/Tab.tsx
@@ -24,14 +24,14 @@ import {
   useGetBinsQuery,
 } from "../../../services/mediaManager";
 
-export type PinnedTopBarTab = {
+export type TopBarTab = {
   tab: Tab;
   tabWidth: number;
   isDarkMode?: boolean;
   isActive?: boolean;
   isPinned?: boolean;
 };
-export const PinnedTopBarTab: FC<PinnedTopBarTab> = ({
+export const TopBarTab: FC<TopBarTab> = ({
   tab,
   tabWidth,
   isDarkMode = false,
@@ -227,7 +227,7 @@ export const UnpinnedTopBarTab: FC<UnpinnedTopBarTab> = ({ tabWidth }) => {
     pinnedTabs.findIndex((t: Tab) => tabLocationEquality(t, activeTab)) >= 0;
 
   return (
-    <PinnedTopBarTab
+    <TopBarTab
       isActive
       isPinned={false}
       tabWidth={tabWidth}

--- a/src/shell/store/ui.ts
+++ b/src/shell/store/ui.ts
@@ -437,6 +437,19 @@ export function pinTab({ pathname, search }: TabLocation, queryData: any) {
   };
 }
 
+export function updatePinnedTabs(tab: Tab) {
+  return async (dispatch: Dispatch, getState: () => AppState) => {
+    const state = getState();
+    const { pinnedTabs } = state.ui;
+    const newTabs = pinnedTabs.filter((t) => t !== tab);
+
+    newTabs.unshift(tab);
+
+    dispatch(actions.setPinnedTabs(newTabs));
+    await idb.set(`${state.instance.ZUID}:pinned`, newTabs);
+  };
+}
+
 export function unpinTab(
   { pathname, search }: TabLocation,
   force = false,


### PR DESCRIPTION
This pull request includes the following:

- Retain a tab's position on the top bar when selected
- Updated sorting of items in the dropdown menu, when a tab from the menu is selected, it becomes the first active tab on the top bar and shifts all other tabs to the right
- Minor css changes

#### Screenshot
![tabs-position](https://user-images.githubusercontent.com/28705606/208578335-c5178ff6-34cb-4cc8-a259-a5a16c7aa678.png)