### PR TITLE
Fix undefined title on custom apps

### DIFF
--- a/src/shell/store/ui.ts
+++ b/src/shell/store/ui.ts
@@ -453,14 +453,19 @@ export function setDocumentTitle(location: TabLocation, queryData: any) {
 
     const { pathname, search } = location;
     const parsedPath = parsePath({ pathname, search });
-    const t = createTab(state, parsedPath, queryData);
-    const { app } = t;
-    const item = t.name || t.pathname;
-    const titleElements = [app, item, "Zesty.io", instanceName, "Manager"]
-      .filter((elem) => Boolean(elem) && Boolean(elem.toString))
-      .map((elem) => elem.toString());
-    const title = titleElements.join(" - ");
-    // set the title
+    const tab = createTab(state, parsedPath, queryData);
+    const { app } = tab;
+    let item = tab.name || tab.pathname;
+
+    // Don't repeat the sub-app name
+    if (app === item) {
+      item = "";
+    }
+
+    const title = [app, item, "Zesty.io", instanceName, "Manager"]
+      .filter((elem) => elem)
+      .join(" - ");
+
     document.title = title;
   };
 }

--- a/src/shell/store/ui.ts
+++ b/src/shell/store/ui.ts
@@ -456,7 +456,10 @@ export function setDocumentTitle(location: TabLocation, queryData: any) {
     const t = createTab(state, parsedPath, queryData);
     const { app } = t;
     const item = t.name || t.pathname;
-    const title = `${app} - ${item} - Zesty.io - ${instanceName} - Manager`;
+    const titleElements = [app, item, "Zesty.io", instanceName, "Manager"]
+      .filter((elem) => Boolean(elem) && Boolean(elem.toString))
+      .map((elem) => elem.toString());
+    const title = titleElements.join(" - ");
     // set the title
     document.title = title;
   };


### PR DESCRIPTION
This fixes the 'undefined' in the title of an Custom App page.

This fix also prevents 'undefined' from being part of any document title. Only valid strings are used to construct the title.

![image](https://user-images.githubusercontent.com/16678143/208958577-28431b84-5f2e-4f4c-a619-31cd1c5843db.png)
