### PR TITLE
Do not throw an exception when a duplicate request occurs on ItemEdit.js

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -130,6 +130,12 @@ export default function ItemEdit() {
     try {
       const itemResponse = await dispatch(fetchItem(modelZUID, itemZUID));
 
+      // Likely due to a duplicate request which causes middleware to return undefined
+      // Return early will show loading screen until the request is resolved
+      if (!itemResponse) {
+        return;
+      }
+
       if (itemResponse.status === 404 || itemResponse.status === 400) {
         setNotFound(itemResponse.message || itemResponse.error);
       }
@@ -154,13 +160,15 @@ export default function ItemEdit() {
           dispatch(fetchItemPublishing(modelZUID, itemZUID)),
         ]);
       }
-    } catch (err) {
-      console.error("ItemEdit:load:error", err);
-      throw err;
-    } finally {
       if (isMounted.current) {
         setLoading(false);
       }
+    } catch (err) {
+      console.error("ItemEdit:load:error", err);
+      if (isMounted.current) {
+        setLoading(false);
+      }
+      throw err;
     }
   }
 


### PR DESCRIPTION
If a user switches between items too fast, a duplicate request will be triggered for an item. As described in #1215 the request middleware will simply return `undefined` for the duplicate request. This causes an exception and therefore a Sentry error, but it **does not** break the user experience.

The solution is to simply return early if the middleware returns `undefined` -- this will prevent an error from being sent to Sentry & keep the loading component displayed until the request is resolved.

Closes #1617 