### PR TITLE
Only dispatch FETCH_HEADERS_SUCCESS action on 200 response

### DIFF
--- a/src/apps/code-editor/src/store/headers.js
+++ b/src/apps/code-editor/src/store/headers.js
@@ -18,11 +18,19 @@ export function fetchHeaders() {
       type: "FETCH_RESOURCE",
       uri: `${CONFIG.API_INSTANCE}/web/headers`,
       handler: (res) => {
-        dispatch({
-          type: "FETCH_HEADERS_SUCCESS",
-          payload: res.data,
-        });
-
+        if (res.status === 200) {
+          dispatch({
+            type: "FETCH_HEADERS_SUCCESS",
+            payload: res.data,
+          });
+        } else {
+          dispatch(
+            notify({
+              kind: "warn",
+              message: `Failed to load headers. ${res.status}`,
+            })
+          );
+        }
         return res;
       },
     });


### PR DESCRIPTION
We should not be dispatching a success action when the response returns a non-200 status. 

Closes #1661 