### PR TITLE
Change ItemParent warning message to not access undefined variable

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
@@ -133,7 +133,7 @@ export const ItemParent = connect((state) => {
                 props.dispatch(
                   notify({
                     kind: "warn",
-                    message: `API failed to return response ${res.status}`,
+                    message: `API failed to return response when searching for ${parentZUID}`,
                   })
                 );
               }


### PR DESCRIPTION
This is another variation of the bug described in #1215

Duplicate requests are be resolved as `undefined` which causes issues when consumers assume they are objects.

This change needs to occur regardless because we are accessing the `status` property on `res` when `res` is guaranteed to be falsey (i.e. not an object)

Closes #1691 