### PR TITLE
Schema: Field reference copy

### DIFF
--- a/src/apps/schema/src/appRevamp/components/Field/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/Field/index.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { Box, IconButton, Typography } from "@mui/material";
+import { Box, IconButton, Typography, Button } from "@mui/material";
 import { ContentModelField } from "../../../../../../shell/services/types";
 import DragIndicatorRoundedIcon from "@mui/icons-material/DragIndicatorRounded";
 import MoreHorizRoundedIcon from "@mui/icons-material/MoreHorizRounded";
@@ -85,6 +85,16 @@ export const Field = ({
     }
   };
 
+  const handleCopyFieldName = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    try {
+      await navigator.clipboard.writeText(field?.name);
+    } catch (error) {
+      console.error("Failed to copy ZUID", error);
+    }
+  };
+
   const style = {
     opacity: isDragging ? 0.5 : 1,
   };
@@ -138,26 +148,22 @@ export const Field = ({
           {typeText[field.datatype]}
         </Typography>
       </Box>
+      {/* TODO: Need confirmation from Zosh on how to let the user know that the field name was copied */}
       <Box display="flex" alignItems="center">
-        <Typography
-          component="span"
-          bgcolor="grey.100"
-          border="1px solid"
-          borderColor="grey.100"
-          boxSizing="border-box"
-          borderRadius={1}
-          px={1.25}
-          py={0.5}
-          mr={1}
-          fontFamily="Roboto Mono"
-          fontWeight="400"
-          fontSize="12px"
-          lineHeight="20px"
-          letterSpacing="0.46px"
-          color="text.secondary"
+        <Button
+          size="small"
+          variant="contained"
+          sx={{
+            bgcolor: "grey.100",
+            color: "text.secondary",
+            "&:hover": {
+              bgcolor: "grey.200",
+            },
+          }}
+          onClick={handleCopyFieldName}
         >
           {field.name}
-        </Typography>
+        </Button>
         {/* TODO: More button click action handler, still pending confirmation from zosh on what will happen */}
         <IconButton>
           <MoreHorizRoundedIcon />

--- a/src/apps/schema/src/appRevamp/components/Field/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/Field/index.tsx
@@ -1,8 +1,9 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { Box, IconButton, Typography, Button } from "@mui/material";
 import { ContentModelField } from "../../../../../../shell/services/types";
 import DragIndicatorRoundedIcon from "@mui/icons-material/DragIndicatorRounded";
 import MoreHorizRoundedIcon from "@mui/icons-material/MoreHorizRounded";
+import CheckIcon from "@mui/icons-material/Check";
 
 import { FieldIcon } from "./FieldIcon";
 
@@ -51,6 +52,20 @@ export const Field = ({
   const ref = useRef(null);
   const [isDragging, setIsDragging] = useState(false);
   const [isDraggable, setIsDraggable] = useState(false);
+  const [isFieldNameCopied, setIsFieldNameCopied] = useState(false);
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout;
+
+    if (isFieldNameCopied) {
+      timeoutId = setTimeout(() => setIsFieldNameCopied(false), 3000);
+    }
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [isFieldNameCopied]);
+
   const handleDragStart = (e: React.DragEvent) => {
     // TODO: Test on other browsers
     // console.log('testing', e, e.target, e.currentTarget);
@@ -90,6 +105,8 @@ export const Field = ({
 
     try {
       await navigator.clipboard.writeText(field?.name);
+
+      setIsFieldNameCopied(true);
     } catch (error) {
       console.error("Failed to copy ZUID", error);
     }
@@ -137,7 +154,15 @@ export const Field = ({
           <DragIndicatorRoundedIcon />
         </IconButton>
         <FieldIcon type={field.datatype} />
-        <Typography px={1.5} variant="body2" fontWeight="700">
+        <Typography
+          px={1.5}
+          variant="body2"
+          fontWeight="700"
+          maxWidth="200px"
+          textOverflow="ellipsis"
+          overflow="hidden"
+          whiteSpace="nowrap"
+        >
           {field.label}
         </Typography>
         <Typography
@@ -149,20 +174,27 @@ export const Field = ({
         </Typography>
       </Box>
       {/* TODO: Need confirmation from Zosh on how to let the user know that the field name was copied */}
-      <Box display="flex" alignItems="center">
+      <Box display="flex" alignItems="center" maxWidth="200px">
         <Button
           size="small"
           variant="contained"
+          color="inherit"
+          startIcon={isFieldNameCopied && <CheckIcon />}
           sx={{
-            bgcolor: "grey.100",
-            color: "text.secondary",
             "&:hover": {
               bgcolor: "grey.200",
             },
           }}
           onClick={handleCopyFieldName}
         >
-          {field.name}
+          <Box
+            component="span"
+            textOverflow="ellipsis"
+            overflow="hidden"
+            whiteSpace="nowrap"
+          >
+            {isFieldNameCopied ? "Copied" : field.name}
+          </Box>
         </Button>
         {/* TODO: More button click action handler, still pending confirmation from zosh on what will happen */}
         <IconButton>

--- a/src/apps/schema/src/appRevamp/components/Field/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/Field/index.tsx
@@ -154,15 +154,7 @@ export const Field = ({
           <DragIndicatorRoundedIcon />
         </IconButton>
         <FieldIcon type={field.datatype} />
-        <Typography
-          px={1.5}
-          variant="body2"
-          fontWeight="700"
-          maxWidth="20vw"
-          textOverflow="ellipsis"
-          overflow="hidden"
-          whiteSpace="nowrap"
-        >
+        <Typography px={1.5} variant="body2" fontWeight="700" noWrap>
           {field.label}
         </Typography>
         <Typography

--- a/src/apps/schema/src/appRevamp/components/Field/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/Field/index.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from "react";
-import { Box, IconButton, Typography, Button } from "@mui/material";
+import { Box, IconButton, Typography, Button, Tooltip } from "@mui/material";
 import { ContentModelField } from "../../../../../../shell/services/types";
 import DragIndicatorRoundedIcon from "@mui/icons-material/DragIndicatorRounded";
 import MoreHorizRoundedIcon from "@mui/icons-material/MoreHorizRounded";
@@ -140,8 +140,13 @@ export const Field = ({
       justifyContent="space-between"
       pr={1}
       pl={0.5}
+      gap={1}
     >
-      <Box display="flex" alignItems="center">
+      <Box
+        display="grid"
+        gridTemplateColumns="28px 24px minmax(auto, min-content) 90px"
+        alignItems="center"
+      >
         <IconButton
           className="drag-handle"
           size="small"
@@ -154,9 +159,11 @@ export const Field = ({
           <DragIndicatorRoundedIcon />
         </IconButton>
         <FieldIcon type={field.datatype} />
-        <Typography px={1.5} variant="body2" fontWeight="700" noWrap>
-          {field.label}
-        </Typography>
+        <Tooltip title={field.label} enterDelay={3000}>
+          <Typography px={1.5} variant="body2" fontWeight="700" noWrap>
+            {field.label}
+          </Typography>
+        </Tooltip>
         <Typography
           // @ts-expect-error missing body3 module augmentation
           variant="body3"
@@ -165,7 +172,7 @@ export const Field = ({
           {typeText[field.datatype]}
         </Typography>
       </Box>
-      <Box display="flex" alignItems="center" maxWidth="200px">
+      <Box display="flex" alignItems="center" maxWidth="180px">
         <Button
           size="small"
           variant="contained"
@@ -178,14 +185,9 @@ export const Field = ({
           }}
           onClick={handleCopyFieldName}
         >
-          <Box
-            component="span"
-            textOverflow="ellipsis"
-            overflow="hidden"
-            whiteSpace="nowrap"
-          >
+          <Typography component="span" variant="caption" noWrap>
             {isFieldNameCopied ? "Copied" : field.name}
-          </Box>
+          </Typography>
         </Button>
         {/* TODO: More button click action handler, still pending confirmation from zosh on what will happen */}
         <IconButton>

--- a/src/apps/schema/src/appRevamp/components/Field/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/Field/index.tsx
@@ -158,7 +158,7 @@ export const Field = ({
           px={1.5}
           variant="body2"
           fontWeight="700"
-          maxWidth="200px"
+          maxWidth="20vw"
           textOverflow="ellipsis"
           overflow="hidden"
           whiteSpace="nowrap"
@@ -173,7 +173,6 @@ export const Field = ({
           {typeText[field.datatype]}
         </Typography>
       </Box>
-      {/* TODO: Need confirmation from Zosh on how to let the user know that the field name was copied */}
       <Box display="flex" alignItems="center" maxWidth="200px">
         <Button
           size="small"


### PR DESCRIPTION
This pull request contains the ff changes:
- Add a field reference copy button functionality
- Set a max width for the field name and field action buttons to prevent overlap on small screens

#### Screenshot
![Screenshot from 2023-01-12 10-02-59](https://user-images.githubusercontent.com/28705606/211958279-1f5cc138-49be-416b-b701-b39d9aaf3a9c.png)
![Screenshot from 2023-01-12 10-02-54](https://user-images.githubusercontent.com/28705606/211958284-946e34f1-8786-4dbb-a071-99ba5c59b3dd.png)
![Screenshot from 2023-01-12 10-02-45](https://user-images.githubusercontent.com/28705606/211958286-ff95382d-6ca9-41f2-9bc0-0bb5d673b3f2.png)

