### PR TITLE
Schema: Markdown, Multiline Text, WYSIWYG creation/update & several other changes

### DIFF
--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/FieldFormInput.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/FieldFormInput.tsx
@@ -24,7 +24,13 @@ export interface InputField {
 interface Props {
   fieldConfig: InputField;
   errorMsg?: string;
-  onDataChange: ({ name, value }: { name: string; value: FormValue }) => void;
+  onDataChange: ({
+    inputName,
+    value,
+  }: {
+    inputName: string;
+    value: FormValue;
+  }) => void;
   prefillData?: FormValue;
 }
 export const FieldFormInput = ({
@@ -35,7 +41,6 @@ export const FieldFormInput = ({
 }: Props) => {
   return (
     <Box mb={2.5}>
-      {/* TODO: Pending confirmation from Zosh if name will autopopulate and have char limit */}
       {fieldConfig.type === "input" && (
         <>
           <Box mb={0.5}>
@@ -72,7 +77,7 @@ export const FieldFormInput = ({
             minRows={fieldConfig.multiline && 2}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               onDataChange({
-                name: fieldConfig.name,
+                inputName: fieldConfig.name,
                 value: e.target.value,
               });
             }}
@@ -95,7 +100,7 @@ export const FieldFormInput = ({
               required={fieldConfig.required}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 onDataChange({
-                  name: fieldConfig.name,
+                  inputName: fieldConfig.name,
                   value: e.target.checked,
                 });
               }}

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
@@ -81,15 +81,15 @@ const formConfig: { [key: string]: InputField[] } = {
   images: [],
   internal_link: [],
   link: [],
-  markdown: [],
+  markdown: [...commonFields],
   number: [],
   one_to_many: [],
   one_to_one: [],
   sort: [],
   text: [...commonFields],
-  textarea: [],
+  textarea: [...commonFields],
   uuid: [],
-  wysiwyg_basic: [],
+  wysiwyg_basic: [...commonFields],
   yes_no: [],
 };
 

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
@@ -13,14 +13,14 @@ import {
   CircularProgress,
 } from "@mui/material";
 import LoadingButton from "@mui/lab/LoadingButton";
-import { snakeCase, isEmpty } from "lodash";
+import { isEmpty } from "lodash";
 
 import CloseIcon from "@mui/icons-material/Close";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
 
 import { FieldIcon } from "../../Field/FieldIcon";
-import { stringStartsWithVowel } from "../../utils";
+import { stringStartsWithVowel, convertLabelValue } from "../../utils";
 import { InputField, FieldFormInput } from "../FieldFormInput";
 import {
   useCreateContentModelFieldMutation,
@@ -171,11 +171,54 @@ export const FieldForm = ({
   }, [type, fieldData]);
 
   useEffect(() => {
-    // TODO: Field creation flow is not yet completed, closing modal on success for now
     if (isFieldCreated || isFieldUpdated) {
       onFieldCreationSuccesssful();
     }
   }, [isFieldCreated, isFieldUpdated]);
+
+  useEffect(() => {
+    if (!Object.keys(formData).length) {
+      return;
+    }
+
+    const currFieldNames = fields.map((field) => field.name);
+    let newErrorsObj: Errors = {};
+
+    Object.keys(formData).map((inputName) => {
+      if (inputName in errors) {
+        // Special validation for "name"
+        if (inputName === "name") {
+          // Validate if "name" has a value
+          if (isEmpty(formData.name)) {
+            newErrorsObj.name = "This field is required";
+          } else {
+            if (isUpdateField) {
+              // Validate if "name" already exists during field update, but here it is ok to re-use its current name
+              newErrorsObj.name =
+                currFieldNames.includes(formData.name as string) &&
+                formData.name !== fieldData.name
+                  ? "Field name already exists"
+                  : "";
+            } else {
+              // Validate if "name" already exists during create new field
+              newErrorsObj.name = currFieldNames.includes(
+                formData.name as string
+              )
+                ? "Field name already exists"
+                : "";
+            }
+          }
+        } else {
+          // All other input validation
+          newErrorsObj[inputName] = isEmpty(formData[inputName])
+            ? "This field is required"
+            : "";
+        }
+      }
+    });
+
+    setErrors(newErrorsObj);
+  }, [formData]);
 
   const handleSubmitForm = () => {
     setIsSubmitClicked(true);
@@ -190,7 +233,7 @@ export const FieldForm = ({
       "ZUID" | "datatypeOptions" | "createdAt" | "updatedAt"
     > = {
       contentModelZUID: id,
-      name: snakeCase(formData.name as string),
+      name: formData.name as string,
       label: formData.label as string,
       description: formData.description as string,
       datatype: type,
@@ -218,38 +261,26 @@ export const FieldForm = ({
   };
 
   const handleFieldDataChange = ({
-    name,
+    inputName,
     value,
   }: {
-    name: string;
+    inputName: string;
     value: string | boolean;
   }) => {
+    const isAutoPopulateName = inputName === "label" && !isUpdateField;
+
+    // Form data update
     setFormData((prevData) => ({
       ...prevData,
-      [name]: value,
+      [inputName]:
+        inputName === "name" ? convertLabelValue(value as string) : value,
     }));
 
-    const currFieldNames = fields.map((field) => field.name);
-    let errorMsg = value ? "" : "This field is required";
-
-    if (value && name === "name") {
-      if (isUpdateField) {
-        // Re-using its original name is fine when updating a field
-        errorMsg =
-          currFieldNames.includes(value as string) && value !== fieldData.name
-            ? "Field name already exists"
-            : "";
-      } else {
-        errorMsg = currFieldNames.includes(value as string)
-          ? "Field name already exists"
-          : "";
-      }
-    }
-
-    if (name in errors) {
-      setErrors((prevData) => ({
+    // Auto populate "name" when "label" field changes
+    if (isAutoPopulateName) {
+      setFormData((prevData) => ({
         ...prevData,
-        [name]: errorMsg,
+        name: convertLabelValue(value as string),
       }));
     }
   };

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldSelection.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldSelection.tsx
@@ -178,7 +178,6 @@ const fields_config: { [key: string]: FieldData[] } = {
         "Lorem ipsum dolor sit amet consectetur adipisicing elit. Beatae, quas.",
     },
   ],
-  // TODO: Zosh to provide correct Group Header Text
   dateandtime: [
     {
       type: "date",
@@ -209,7 +208,6 @@ const fields_config: { [key: string]: FieldData[] } = {
       proTip: "If you want to only have a date then use the date field.",
     },
   ],
-  // TODO: Zosh to provide correct Group Header Text
   options: [
     {
       type: "yes_no",

--- a/src/apps/schema/src/appRevamp/components/Field/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/Field/index.tsx
@@ -234,12 +234,6 @@ export const Field = ({
             horizontal: "right",
           }}
         >
-          <MenuItem>
-            <ListItemIcon>
-              <ContentCopyRoundedIcon />
-            </ListItemIcon>
-            <ListItemText>Duplicate Field</ListItemText>
-          </MenuItem>
           <MenuItem
             onClick={() => history.push(`${location.pathname}/${field.ZUID}`)}
           >

--- a/src/apps/schema/src/appRevamp/components/utils.ts
+++ b/src/apps/schema/src/appRevamp/components/utils.ts
@@ -1,7 +1,15 @@
+import { replace } from "lodash";
+
 export const stringStartsWithVowel = (string: string): boolean => {
   if (!string) return;
 
   const firstLetter = string[0];
 
   return ["a", "e", "i", "o", "u"].includes(firstLetter.toLowerCase());
+};
+
+export const convertLabelValue = (string: string): string => {
+  if (!string) return;
+
+  return replace(string, /\W/g, "_");
 };


### PR DESCRIPTION
This pull request updates the ff:
- Added option to create/update markdown, multiline text and WYSIWYG fields
- Autofill parsley reference field when typing in a field label
- Auto replace spaces and special characters with underscores in parsley reference field
- Updated error validation logic
- Removed unneeded comments

#### Preview:
[Screencast from 2023-01-18 11-13-51.webm](https://user-images.githubusercontent.com/28705606/213075077-798f5968-1c91-4c85-aba9-9cb29f36b2bf.webm)
