### PR TITLE
Group network errors by a custom fingerprint on sentry

### DIFF
--- a/src/utility/request.js
+++ b/src/utility/request.js
@@ -1,7 +1,8 @@
 import Cookies from "js-cookie";
 import { rest } from "lodash";
 import { Sentry } from "./sentry";
-// import { store } from "shell/store";
+import { store } from "shell/store";
+import { notify } from "../shell/store/notifications";
 // import { endSession } from "shell/store/auth";
 
 export function request(url, opts = {}) {
@@ -99,7 +100,9 @@ export function request(url, opts = {}) {
         );
         throw err;
       } else {
+        store.dispatch(notify({ message: err.message, kind: "warn" }));
         Sentry.captureException(err, { fingerprint: ["network_error"] });
+        return Promise.reject(err);
       }
     });
 }

--- a/src/utility/request.js
+++ b/src/utility/request.js
@@ -1,5 +1,6 @@
 import Cookies from "js-cookie";
 import { rest } from "lodash";
+import { Sentry } from "./sentry";
 // import { store } from "shell/store";
 // import { endSession } from "shell/store/auth";
 
@@ -98,7 +99,7 @@ export function request(url, opts = {}) {
         );
         throw err;
       } else {
-        throw err;
+        Sentry.captureException(err, { fingerprint: ["network_error"] });
       }
     });
 }


### PR DESCRIPTION
Due to stack traces differing when triggering a network error exception, Sentry is not grouping them properly. This change captures the error with a custom fingerprint so they get aggreagted.

This has been tested and confirmed on Sentry
![Screen Shot 2023-01-23 at 9 07 31 PM](https://user-images.githubusercontent.com/10054410/214216427-14dbc558-1b9b-4d4a-b279-af447c61bab7.png)
