### PR TITLE
Schema: In-between field creation

### DIFF
--- a/src/apps/schema/src/appRevamp/components/AddFieldDivider.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldDivider.tsx
@@ -4,10 +4,15 @@ import AddRoundedIcon from "@mui/icons-material/AddRounded";
 interface Props {
   indexToInsert: number;
   disabled: boolean;
+  onDividerClick: () => void;
 }
 
 // TODO: On component click the new field dialog should open and upon completion the rest of the fields should be re-ordered to reflect the new field that was inserted.
-export const AddFieldDivider = ({ indexToInsert, disabled }: Props) => {
+export const AddFieldDivider = ({
+  indexToInsert,
+  disabled,
+  onDividerClick,
+}: Props) => {
   const styles = !disabled
     ? {
         cursor: "pointer",
@@ -21,7 +26,13 @@ export const AddFieldDivider = ({ indexToInsert, disabled }: Props) => {
     : {};
 
   return (
-    <Box py="3px" display="flex" alignItems={"center"} sx={styles}>
+    <Box
+      py="3px"
+      display="flex"
+      alignItems={"center"}
+      sx={styles}
+      onClick={onDividerClick}
+    >
       <IconButton
         sx={{
           visibility: "hidden",

--- a/src/apps/schema/src/appRevamp/components/AddFieldDivider.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldDivider.tsx
@@ -7,7 +7,6 @@ interface Props {
   onDividerClick: () => void;
 }
 
-// TODO: On component click the new field dialog should open and upon completion the rest of the fields should be re-ordered to reflect the new field that was inserted.
 export const AddFieldDivider = ({
   indexToInsert,
   disabled,

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
@@ -92,6 +92,7 @@ export const AddFieldModal = ({ onModalClose, mode, sortIndex }: Props) => {
           name={fieldData?.label}
           onModalClose={onModalClose}
           fieldData={fieldData}
+          sortIndex={null}
         />
       )}
     </Dialog>

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
@@ -14,8 +14,9 @@ export type ViewMode = "fields_list" | "new_field" | "update_field";
 interface Props {
   onModalClose: Dispatch<SetStateAction<boolean>>;
   mode: ViewMode;
+  sortIndex?: number | null;
 }
-export const AddFieldModal = ({ onModalClose, mode }: Props) => {
+export const AddFieldModal = ({ onModalClose, mode, sortIndex }: Props) => {
   const [viewMode, setViewMode] = useState<ViewMode>(mode);
   const [selectedField, setSelectedField] = useState({
     fieldType: "",
@@ -67,6 +68,7 @@ export const AddFieldModal = ({ onModalClose, mode }: Props) => {
           onModalClose={() => onModalClose(false)}
           onBackClick={() => setViewMode("fields_list")}
           onFieldCreationSuccesssful={() => onModalClose(false)}
+          sortIndex={sortIndex}
         />
       )}
       {viewMode === "update_field" && (

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useParams } from "react-router";
 import { Dialog } from "@mui/material";
 
@@ -30,7 +30,13 @@ export const AddFieldModal = ({
   });
   const params = useParams<Params>();
   const { id, fieldId } = params;
+  const [localSortIndex, setLocalSortIndex] = useState<number | null>(null);
   const { data: fields } = useGetContentModelFieldsQuery(id);
+
+  useEffect(() => {
+    // Local copy is incremented when user clicks "add another field"
+    setLocalSortIndex(sortIndex);
+  }, [sortIndex]);
 
   const fieldData = useMemo(() => {
     return fields?.find((field) => field.ZUID === fieldId);
@@ -39,6 +45,14 @@ export const AddFieldModal = ({
   const handleFieldClick = (fieldType: string, fieldName: string) => {
     setViewMode("new_field");
     setSelectedField({ fieldType, fieldName });
+  };
+
+  const handleCreateAnotherField = () => {
+    setViewMode("fields_list");
+
+    if (localSortIndex !== null) {
+      setLocalSortIndex((prevData) => prevData + 1);
+    }
   };
 
   return (
@@ -73,8 +87,9 @@ export const AddFieldModal = ({
           name={selectedField?.fieldName}
           onModalClose={onModalClose}
           onBackClick={() => setViewMode("fields_list")}
-          sortIndex={sortIndex}
+          sortIndex={localSortIndex}
           onBulkUpdateDone={onBulkUpdateDone}
+          onCreateAnotherField={handleCreateAnotherField}
         />
       )}
       {viewMode === "update_field" && (

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
@@ -15,8 +15,14 @@ interface Props {
   onModalClose: Dispatch<SetStateAction<boolean>>;
   mode: ViewMode;
   sortIndex?: number | null;
+  onBulkUpdateDone?: () => void;
 }
-export const AddFieldModal = ({ onModalClose, mode, sortIndex }: Props) => {
+export const AddFieldModal = ({
+  onModalClose,
+  mode,
+  sortIndex,
+  onBulkUpdateDone,
+}: Props) => {
   const [viewMode, setViewMode] = useState<ViewMode>(mode);
   const [selectedField, setSelectedField] = useState({
     fieldType: "",
@@ -24,11 +30,7 @@ export const AddFieldModal = ({ onModalClose, mode, sortIndex }: Props) => {
   });
   const params = useParams<Params>();
   const { id, fieldId } = params;
-  const {
-    data: fields,
-    isLoading: isFieldsLoading,
-    isSuccess: isFieldsLoaded,
-  } = useGetContentModelFieldsQuery(id);
+  const { data: fields } = useGetContentModelFieldsQuery(id);
 
   const fieldData = useMemo(() => {
     return fields?.find((field) => field.ZUID === fieldId);
@@ -72,7 +74,7 @@ export const AddFieldModal = ({ onModalClose, mode, sortIndex }: Props) => {
           onModalClose={() => onModalClose(false)}
           onBackClick={() => setViewMode("fields_list")}
           sortIndex={sortIndex}
-          isFieldsLoaded={isFieldsLoaded && !isFieldsLoading}
+          onBulkUpdateDone={onBulkUpdateDone}
         />
       )}
       {viewMode === "update_field" && (

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { useParams } from "react-router";
 import { Dialog } from "@mui/material";
 
@@ -12,7 +12,7 @@ type Params = {
 };
 export type ViewMode = "fields_list" | "new_field" | "update_field";
 interface Props {
-  onModalClose: Dispatch<SetStateAction<boolean>>;
+  onModalClose: () => void;
   mode: ViewMode;
   sortIndex?: number | null;
   onBulkUpdateDone?: () => void;
@@ -44,7 +44,7 @@ export const AddFieldModal = ({
   return (
     <Dialog
       open
-      onClose={() => onModalClose(false)}
+      onClose={onModalClose}
       fullScreen
       sx={{
         "& .MuiDialog-container": {
@@ -62,7 +62,7 @@ export const AddFieldModal = ({
     >
       {viewMode === "fields_list" && (
         <FieldSelection
-          onModalClose={() => onModalClose(false)}
+          onModalClose={onModalClose}
           onFieldClick={handleFieldClick}
         />
       )}
@@ -71,7 +71,7 @@ export const AddFieldModal = ({
           fields={fields}
           type={selectedField?.fieldType}
           name={selectedField?.fieldName}
-          onModalClose={() => onModalClose(false)}
+          onModalClose={onModalClose}
           onBackClick={() => setViewMode("fields_list")}
           sortIndex={sortIndex}
           onBulkUpdateDone={onBulkUpdateDone}
@@ -82,7 +82,7 @@ export const AddFieldModal = ({
           fields={fields}
           type={fieldData?.datatype}
           name={fieldData?.label}
-          onModalClose={() => onModalClose(false)}
+          onModalClose={onModalClose}
           fieldData={fieldData}
         />
       )}

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
@@ -24,7 +24,11 @@ export const AddFieldModal = ({ onModalClose, mode, sortIndex }: Props) => {
   });
   const params = useParams<Params>();
   const { id, fieldId } = params;
-  const { data: fields } = useGetContentModelFieldsQuery(id);
+  const {
+    data: fields,
+    isLoading: isFieldsLoading,
+    isSuccess: isFieldsLoaded,
+  } = useGetContentModelFieldsQuery(id);
 
   const fieldData = useMemo(() => {
     return fields?.find((field) => field.ZUID === fieldId);
@@ -69,6 +73,7 @@ export const AddFieldModal = ({ onModalClose, mode, sortIndex }: Props) => {
           onBackClick={() => setViewMode("fields_list")}
           onFieldCreationSuccesssful={() => onModalClose(false)}
           sortIndex={sortIndex}
+          isFieldsLoaded={isFieldsLoaded && !isFieldsLoading}
         />
       )}
       {viewMode === "update_field" && (

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/index.tsx
@@ -15,14 +15,8 @@ interface Props {
   onModalClose: () => void;
   mode: ViewMode;
   sortIndex?: number | null;
-  onBulkUpdateDone?: () => void;
 }
-export const AddFieldModal = ({
-  onModalClose,
-  mode,
-  sortIndex,
-  onBulkUpdateDone,
-}: Props) => {
+export const AddFieldModal = ({ onModalClose, mode, sortIndex }: Props) => {
   const [viewMode, setViewMode] = useState<ViewMode>(mode);
   const [selectedField, setSelectedField] = useState({
     fieldType: "",
@@ -88,7 +82,6 @@ export const AddFieldModal = ({
           onModalClose={onModalClose}
           onBackClick={() => setViewMode("fields_list")}
           sortIndex={localSortIndex}
-          onBulkUpdateDone={onBulkUpdateDone}
           onCreateAnotherField={handleCreateAnotherField}
         />
       )}

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
@@ -26,7 +26,6 @@ import {
   useCreateContentModelFieldMutation,
   useUpdateContentModelFieldMutation,
   useBulkUpdateContentModelFieldMutation,
-  useGetContentModelFieldsQuery,
 } from "../../../../../../../shell/services/instance";
 import {
   ContentModelField,

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
@@ -112,6 +112,7 @@ interface Props {
   fields: ContentModelField[];
   onFieldCreationSuccesssful: () => void;
   fieldData?: ContentModelField;
+  sortIndex?: number | null;
 }
 export const FieldForm = ({
   type,
@@ -121,6 +122,7 @@ export const FieldForm = ({
   fields,
   onFieldCreationSuccesssful,
   fieldData,
+  sortIndex,
 }: Props) => {
   const [activeTab, setActiveTab] = useState<ActiveTab>("details");
   const [isSubmitClicked, setIsSubmitClicked] = useState(false);
@@ -223,6 +225,7 @@ export const FieldForm = ({
   const handleSubmitForm = () => {
     setIsSubmitClicked(true);
     const hasErrors = Object.values(errors).some((error) => error.length);
+    const sort = sortIndex === null ? fields?.length : sortIndex;
 
     if (hasErrors) {
       return;
@@ -241,7 +244,7 @@ export const FieldForm = ({
       settings: {
         list: formData.list as boolean,
       },
-      sort: isUpdateField ? fieldData.sort : fields?.length, // Just use the length since sort starts at 0
+      sort: isUpdateField ? fieldData.sort : sort, // Just use the length since sort starts at 0
     };
 
     if (isUpdateField) {

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
@@ -114,7 +114,7 @@ interface Props {
   fields: ContentModelField[];
   fieldData?: ContentModelField;
   sortIndex?: number | null;
-  isFieldsLoaded?: boolean;
+  onBulkUpdateDone?: () => void;
 }
 export const FieldForm = ({
   type,
@@ -124,7 +124,7 @@ export const FieldForm = ({
   fields,
   fieldData,
   sortIndex,
-  isFieldsLoaded,
+  onBulkUpdateDone,
 }: Props) => {
   const [activeTab, setActiveTab] = useState<ActiveTab>("details");
   const [isSubmitClicked, setIsSubmitClicked] = useState(false);
@@ -181,16 +181,15 @@ export const FieldForm = ({
   }, [type, fieldData]);
 
   useEffect(() => {
-    if (isBulkUpdated && isFieldsLoaded) {
-      // TODO: Only close once fields have been reloaded with proper sorting
+    if (isBulkUpdated) {
       onModalClose();
+      onBulkUpdateDone();
     }
   }, [isBulkUpdated]);
 
   useEffect(() => {
     if (isFieldCreated && sortIndex !== null) {
       // Bulk update field sort
-      console.log(fields, sortIndex);
       const fieldsToUpdate = fields.slice(sortIndex).map((field) => ({
         ...field,
         sort: field.sort + 1,
@@ -199,7 +198,7 @@ export const FieldForm = ({
       bulkUpdateContentModelField({ modelZUID: id, fields: fieldsToUpdate });
     }
 
-    if (isFieldCreated || (isFieldUpdated && sortIndex === null)) {
+    if ((isFieldCreated || isFieldUpdated) && sortIndex === null) {
       if (isAddAnotherFieldClicked) {
         // When field is successfully created, re-route the user back to the field selection screen
         setIsAddAnotherFieldClicked(false);

--- a/src/apps/schema/src/appRevamp/components/FieldList.tsx
+++ b/src/apps/schema/src/appRevamp/components/FieldList.tsx
@@ -26,7 +26,7 @@ type Params = {
 };
 
 interface Props {
-  onNewFieldModalClick: () => void;
+  onNewFieldModalClick: (sortIndex: number | null) => void;
 }
 export const FieldList = ({ onNewFieldModalClick }: Props) => {
   const params = useParams<Params>();
@@ -184,6 +184,7 @@ export const FieldList = ({ onNewFieldModalClick }: Props) => {
                     <AddFieldDivider
                       indexToInsert={index}
                       disabled={!!search}
+                      onDividerClick={() => onNewFieldModalClick(index)}
                     />
                   )}
                   <Box sx={{ pl: 3 }}>
@@ -209,7 +210,7 @@ export const FieldList = ({ onNewFieldModalClick }: Props) => {
                 variant="outlined"
                 startIcon={<AddRoundedIcon />}
                 fullWidth
-                onClick={onNewFieldModalClick}
+                onClick={() => onNewFieldModalClick(null)}
               >
                 Add Another Field to {model?.label}
               </Button>

--- a/src/apps/schema/src/appRevamp/components/FieldList.tsx
+++ b/src/apps/schema/src/appRevamp/components/FieldList.tsx
@@ -8,6 +8,8 @@ import {
   Typography,
 } from "@mui/material";
 import { useParams } from "react-router";
+import { isEqual } from "lodash";
+
 import {
   useBulkUpdateContentModelFieldMutation,
   useGetContentModelFieldsQuery,
@@ -51,7 +53,7 @@ export const FieldList = ({ onNewFieldModalClick }: Props) => {
   );
 
   useEffect(() => {
-    if (fields && localFields?.length !== fields.length) {
+    if (fields?.length && !isEqual(localFields, fields)) {
       setLocalFields([...fields]);
     }
   }, [fields]);

--- a/src/apps/schema/src/appRevamp/components/FieldList.tsx
+++ b/src/apps/schema/src/appRevamp/components/FieldList.tsx
@@ -51,8 +51,8 @@ export const FieldList = ({ onNewFieldModalClick }: Props) => {
   );
 
   useEffect(() => {
-    if (fields && localFields?.length !== fields.length) {
-      setLocalFields([...fields]);
+    if (fields?.length) {
+      setLocalFields(fields);
     }
   }, [fields]);
 

--- a/src/apps/schema/src/appRevamp/components/FieldList.tsx
+++ b/src/apps/schema/src/appRevamp/components/FieldList.tsx
@@ -27,8 +27,12 @@ type Params = {
 
 interface Props {
   onNewFieldModalClick: (sortIndex: number | null) => void;
+  isDeferFieldFetch?: boolean;
 }
-export const FieldList = ({ onNewFieldModalClick }: Props) => {
+export const FieldList = ({
+  onNewFieldModalClick,
+  isDeferFieldFetch,
+}: Props) => {
   const params = useParams<Params>();
   const { id } = params;
   const [search, setSearch] = useState("");
@@ -37,7 +41,7 @@ export const FieldList = ({ onNewFieldModalClick }: Props) => {
     data: fields,
     isLoading: isFieldsLoading,
     isFetching: isFieldsFetching,
-  } = useGetContentModelFieldsQuery(id);
+  } = useGetContentModelFieldsQuery(id, { skip: isDeferFieldFetch });
   const [bulkUpdateContentModelField, { isLoading: isBulkFieldsUpdating }] =
     useBulkUpdateContentModelFieldMutation();
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
@@ -51,8 +55,8 @@ export const FieldList = ({ onNewFieldModalClick }: Props) => {
   );
 
   useEffect(() => {
-    if (fields?.length) {
-      setLocalFields(fields);
+    if (fields && localFields?.length !== fields.length) {
+      setLocalFields([...fields]);
     }
   }, [fields]);
 

--- a/src/apps/schema/src/appRevamp/components/FieldList.tsx
+++ b/src/apps/schema/src/appRevamp/components/FieldList.tsx
@@ -27,12 +27,8 @@ type Params = {
 
 interface Props {
   onNewFieldModalClick: (sortIndex: number | null) => void;
-  isDeferFieldFetch?: boolean;
 }
-export const FieldList = ({
-  onNewFieldModalClick,
-  isDeferFieldFetch,
-}: Props) => {
+export const FieldList = ({ onNewFieldModalClick }: Props) => {
   const params = useParams<Params>();
   const { id } = params;
   const [search, setSearch] = useState("");
@@ -41,7 +37,7 @@ export const FieldList = ({
     data: fields,
     isLoading: isFieldsLoading,
     isFetching: isFieldsFetching,
-  } = useGetContentModelFieldsQuery(id, { skip: isDeferFieldFetch });
+  } = useGetContentModelFieldsQuery(id);
   const [bulkUpdateContentModelField, { isLoading: isBulkFieldsUpdating }] =
     useBulkUpdateContentModelFieldMutation();
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);

--- a/src/apps/schema/src/appRevamp/components/ModelHeader/index.tsx
+++ b/src/apps/schema/src/appRevamp/components/ModelHeader/index.tsx
@@ -22,7 +22,7 @@ const modelTypeName = {
 };
 
 interface Props {
-  onNewFieldModalClick: () => void;
+  onNewFieldModalClick: (sortIndex: number | null) => void;
 }
 export const ModelHeader = ({ onNewFieldModalClick }: Props) => {
   const params = useParams<Params>();
@@ -58,7 +58,7 @@ export const ModelHeader = ({ onNewFieldModalClick }: Props) => {
                 size="small"
                 variant="contained"
                 startIcon={<AddRoundedIcon />}
-                onClick={onNewFieldModalClick}
+                onClick={() => onNewFieldModalClick(null)}
                 disabled={!isFieldsLoaded}
               >
                 Add Field

--- a/src/apps/schema/src/appRevamp/views/Model.tsx
+++ b/src/apps/schema/src/appRevamp/views/Model.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Box } from "@mui/material";
 import { Redirect, Route, Switch, useParams, useHistory } from "react-router";
-import { useGetContentModelsQuery } from "../../../../../shell/services/instance";
 import { FieldList } from "../components/FieldList";
 import { ModelHeader } from "../components/ModelHeader";
 import { AddFieldModal } from "../components/AddFieldModal";

--- a/src/apps/schema/src/appRevamp/views/Model.tsx
+++ b/src/apps/schema/src/appRevamp/views/Model.tsx
@@ -29,7 +29,10 @@ export const Model = () => {
           exact
           path="/schema/:id/fields"
           render={() => (
-            <FieldList onNewFieldModalClick={handleNewFieldModalClick} />
+            <FieldList
+              onNewFieldModalClick={handleNewFieldModalClick}
+              isDeferFieldFetch={Boolean(sortIndex !== null)}
+            />
           )}
         />
         <Route
@@ -54,6 +57,7 @@ export const Model = () => {
           mode="fields_list"
           onModalClose={setAddFieldModalOpen}
           sortIndex={sortIndex}
+          onBulkUpdateDone={() => setSortIndex(null)}
         />
       )}
     </Box>

--- a/src/apps/schema/src/appRevamp/views/Model.tsx
+++ b/src/apps/schema/src/appRevamp/views/Model.tsx
@@ -21,6 +21,11 @@ export const Model = () => {
     setSortIndex(sortIndex);
   };
 
+  const handleModalClosed = () => {
+    setAddFieldModalOpen(false);
+    setSortIndex(null);
+  };
+
   return (
     <Box flex="1" display="flex" height="100%" flexDirection="column">
       <ModelHeader onNewFieldModalClick={handleNewFieldModalClick} />
@@ -55,7 +60,7 @@ export const Model = () => {
       {isAddFieldModalOpen && (
         <AddFieldModal
           mode="fields_list"
-          onModalClose={setAddFieldModalOpen}
+          onModalClose={handleModalClosed}
           sortIndex={sortIndex}
           onBulkUpdateDone={() => setSortIndex(null)}
         />

--- a/src/apps/schema/src/appRevamp/views/Model.tsx
+++ b/src/apps/schema/src/appRevamp/views/Model.tsx
@@ -11,21 +11,25 @@ type Params = {
 };
 export const Model = () => {
   const [isAddFieldModalOpen, setAddFieldModalOpen] = useState(false);
+  const [sortIndex, setSortIndex] = useState<number | null>(null);
   const history = useHistory();
   const params = useParams<Params>();
   const { id } = params;
 
+  const handleNewFieldModalClick = (sortIndex: number | null) => {
+    setAddFieldModalOpen(true);
+    setSortIndex(sortIndex);
+  };
+
   return (
     <Box flex="1" display="flex" height="100%" flexDirection="column">
-      <ModelHeader onNewFieldModalClick={() => setAddFieldModalOpen(true)} />
+      <ModelHeader onNewFieldModalClick={handleNewFieldModalClick} />
       <Switch>
         <Route
           exact
           path="/schema/:id/fields"
           render={() => (
-            <FieldList
-              onNewFieldModalClick={() => setAddFieldModalOpen(true)}
-            />
+            <FieldList onNewFieldModalClick={handleNewFieldModalClick} />
           )}
         />
         <Route
@@ -46,7 +50,11 @@ export const Model = () => {
         <Redirect to="/schema/:id/fields" />
       </Switch>
       {isAddFieldModalOpen && (
-        <AddFieldModal mode="fields_list" onModalClose={setAddFieldModalOpen} />
+        <AddFieldModal
+          mode="fields_list"
+          onModalClose={setAddFieldModalOpen}
+          sortIndex={sortIndex}
+        />
       )}
     </Box>
   );

--- a/src/apps/schema/src/appRevamp/views/Model.tsx
+++ b/src/apps/schema/src/appRevamp/views/Model.tsx
@@ -33,10 +33,7 @@ export const Model = () => {
           exact
           path="/schema/:id/fields"
           render={() => (
-            <FieldList
-              onNewFieldModalClick={handleNewFieldModalClick}
-              isDeferFieldFetch={Boolean(sortIndex !== null)}
-            />
+            <FieldList onNewFieldModalClick={handleNewFieldModalClick} />
           )}
         />
         <Route
@@ -61,7 +58,6 @@ export const Model = () => {
           mode="fields_list"
           onModalClose={handleModalClosed}
           sortIndex={sortIndex}
-          onBulkUpdateDone={() => setSortIndex(null)}
         />
       )}
     </Box>

--- a/src/shell/services/instance.ts
+++ b/src/shell/services/instance.ts
@@ -166,6 +166,7 @@ export const instanceApi = createApi({
           ContentModelField,
           "ZUID" | "datatypeOptions" | "createdAt" | "updatedAt"
         >;
+        skipInvalidation?: boolean;
       }
     >({
       query: ({ modelZUID, body }) => ({
@@ -173,9 +174,11 @@ export const instanceApi = createApi({
         method: "POST",
         body,
       }),
-      invalidatesTags: (result, error, arg) => [
-        { type: "ContentModelFields", id: arg.modelZUID },
-      ],
+      invalidatesTags: (result, error, arg) => {
+        if (!arg.skipInvalidation) {
+          return [{ type: "ContentModelFields", id: arg.modelZUID }];
+        }
+      },
     }),
     updateContentModelField: builder.mutation<
       any,


### PR DESCRIPTION
- In-between field creation functionality
- When "Done" button is clicked, it uses the passed in sort index
- When "Add another field" button is clicked, passed in sort index gets incremented'
- Bulk update to update sort of fields below the inserted field
- Added a skipInvalidation flag to the create field rtk query, to skip cache invalidation when creating an in-between field, leaving the cache invalidation to the bulk sorting rtk query instead. Ensures FieldsList always shows the updated field data with proper sorting
- Fixed a bug where FieldsList **does not** re-render with updated fields after a field has been updated

#### Preview
[Screencast from 2023-01-24 17-02-41.webm](https://user-images.githubusercontent.com/28705606/214251655-ddcfa680-6794-46ad-9022-2bce1d404bbc.webm)
