### PR TITLE
Remove Atom video as it is no longer supported

### DIFF
--- a/src/apps/code-editor/src/app/components/Workspace/components/GettingStarted/GettingStarted.js
+++ b/src/apps/code-editor/src/app/components/Workspace/components/GettingStarted/GettingStarted.js
@@ -64,19 +64,6 @@ export function GettingStarted(props) {
               .
             </p>
           </div>
-          <div className={styles.Topic}>
-            <h2 className={styles.subheadline}>
-              Using the Atom IDE With Zesty.io
-            </h2>
-            <iframe
-              height="480px"
-              width="100%"
-              src="https://www.youtube-nocookie.com/embed/s98dR1M2u8E?rel=0"
-              frameBorder="0"
-              allow="encrypted-media;"
-              allowFullScreen
-            ></iframe>
-          </div>
         </div>
 
         <div className={styles.Column}>


### PR DESCRIPTION
Remove Atom video. Please see screenshot to see what the Code app looks like without it.

@ardeay This is acceptable? Or do you want something (e.g. another video) to take it's place?

![Screen Shot 2023-01-25 at 8 03 09 PM](https://user-images.githubusercontent.com/16678143/214731957-cbecf2fe-6785-4508-b50f-17bf90201894.png)

Closes #1701 