### PR TITLE
FIX: Disable open resource button when no url can be derived

### DIFF
--- a/src/apps/reports/src/app/views/ActivityLog/views/ResourceDetails.js
+++ b/src/apps/reports/src/app/views/ActivityLog/views/ResourceDetails.js
@@ -163,6 +163,7 @@ export const ResourceDetails = () => {
             startIcon={<OpenInNewIcon />}
             variant="outlined"
             size="small"
+            disabled={!actionsByZuid[0] || !actionsByZuid[0]?.meta}
             onClick={() => {
               if (actionsByZuid[0]?.resourceType === "code") {
                 history.push(


### PR DESCRIPTION
Closes #1733 

#### Preview
![Screenshot from 2023-01-30 03-57-57](https://user-images.githubusercontent.com/28705606/215352634-14cd3629-b91f-4371-9e8f-ba7b97468773.png)
