### PR TITLE
Schema: Tooltip fields support

### DIFF
--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/FieldFormInput.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/FieldFormInput.tsx
@@ -38,7 +38,8 @@ export type FieldNames =
   | "relatedModelZUID"
   | "relatedFieldZUID"
   | "group_id"
-  | "limit";
+  | "limit"
+  | "tooltip";
 type FieldType =
   | "input"
   | "checkbox"

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
@@ -178,6 +178,8 @@ export const FieldForm = ({
             }
           );
           formFields.options = options;
+        } else if (field.name === "tooltip") {
+          formFields["tooltip"] = fieldData.settings.tooltip || "";
         } else {
           formFields[field.name] = fieldData[field.name] as FormValue;
         }
@@ -242,6 +244,7 @@ export const FieldForm = ({
     }
   }, [isFieldCreated, isFieldUpdated]);
 
+  /** Error setting */
   useEffect(() => {
     if (!Object.keys(formData).length) {
       return;
@@ -366,6 +369,9 @@ export const FieldForm = ({
         list: formData.list as boolean,
         limit: formData.limit as number,
         group_id: formData.group_id as string,
+        ...((formData.tooltip as string)?.length && {
+          tooltip: formData.tooltip as string,
+        }),
       },
       sort: isUpdateField ? fieldData.sort : sort, // Just use the length since sort starts at 0
     };
@@ -539,6 +545,13 @@ export const FieldForm = ({
         {activeTab === "details" && (
           <Grid container spacing={2.5} maxWidth="480px">
             {FORM_CONFIG[type]?.details?.map((fieldConfig, index) => {
+              // Only show tooltip field when updating a field that already has a tooltip value
+              const hideTooltipField =
+                fieldConfig.name === "tooltip" &&
+                (!isUpdateField || !(formData["tooltip"] as string)?.length);
+
+              if (hideTooltipField) return;
+
               let dropdownOptions: DropdownOptions[];
               let disabled = false;
 

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
@@ -548,7 +548,7 @@ export const FieldForm = ({
               // Only show tooltip field when updating a field that already has a tooltip value
               const hideTooltipField =
                 fieldConfig.name === "tooltip" &&
-                (!isUpdateField || !(formData["tooltip"] as string)?.length);
+                (!isUpdateField || !fieldData.settings.tooltip?.length);
 
               if (hideTooltipField) return;
 

--- a/src/apps/schema/src/appRevamp/components/configs.ts
+++ b/src/apps/schema/src/appRevamp/components/configs.ts
@@ -354,6 +354,17 @@ const COMMON_FIELDS: InputField[] = [
     validate: ["length", "required", "unique"],
   },
   {
+    name: "tooltip",
+    type: "input",
+    label: "Tooltip",
+    required: false,
+    fullWidth: true,
+    maxLength: 250,
+    gridSize: 12,
+    tooltip: "Tool tip displayed to content editors.",
+    validate: ["length"],
+  },
+  {
     name: "description",
     type: "input",
     label: "Description",


### PR DESCRIPTION
Allow users to update the tooltip for a field, only if the tooltip exists already

#### Preview
[Screencast from 2023-02-22 08-54-17.webm](https://user-images.githubusercontent.com/28705606/220493585-45dd8d21-daf2-4a66-83be-23b663e160ec.webm)
