### PR TITLE
Schema: Autofocus related model field & prevent referencing own model

### DIFF
--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/FieldFormInput.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/FieldFormInput.tsx
@@ -63,6 +63,7 @@ export interface InputField {
   tooltip?: string;
   validate?: Validation[];
   inputType?: InputType;
+  autoFocus?: boolean;
 }
 export interface DropdownOptions {
   label: string;
@@ -175,7 +176,7 @@ export const FieldFormInput = ({
             )}
           </Box>
           <InputTextField
-            autoFocus={fieldConfig.name === "label"}
+            autoFocus={fieldConfig.autoFocus}
             data-cy={`FieldFormInput_${fieldConfig.name}`}
             name={fieldConfig.name}
             required={fieldConfig.required}
@@ -297,6 +298,7 @@ export const FieldFormInput = ({
                 {...params}
                 placeholder={fieldConfig.placeholder}
                 hiddenLabel
+                autoFocus={fieldConfig.autoFocus}
               />
             )}
             isOptionEqualToValue={(option, value) =>

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useParams } from "react-router";
 import { useDispatch } from "react-redux";
 import {
@@ -126,16 +126,25 @@ export const FieldForm = ({
 
   const isUpdateField = !isEmpty(fieldData);
   const isInbetweenField = sortIndex !== null;
-  const modelsOptions: DropdownOptions[] = allModels?.map((model) => ({
-    label: model.label,
-    value: model.ZUID,
-  }));
-  const fieldsOptions: DropdownOptions[] = selectedModelFields?.map(
-    (field) => ({
+  const modelsOptions: DropdownOptions[] = useMemo(() => {
+    // Remove the model that the field is from
+    const _filteredModels = allModels?.filter((model) => model.ZUID !== id);
+
+    return _filteredModels?.map((model) => {
+      if (model.ZUID !== id) {
+        return {
+          label: model.label,
+          value: model.ZUID,
+        };
+      }
+    });
+  }, [allModels]);
+  const fieldsOptions: DropdownOptions[] = useMemo(() => {
+    return selectedModelFields?.map((field) => ({
       label: field.label,
       value: field.ZUID,
-    })
-  );
+    }));
+  }, [selectedModelFields]);
   const [
     deleteContentModelField,
     { isLoading: isDeletingField, isSuccess: isFieldDeleted },

--- a/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/appRevamp/components/AddFieldModal/views/FieldForm.tsx
@@ -199,7 +199,8 @@ export const FieldForm = ({
         }
       } else {
         if (field.type === "checkbox") {
-          formFields[field.name] = true;
+          // Only "list" checkbox will be checked by default
+          formFields[field.name] = field.name === "list";
         } else if (field.type === "options") {
           formFields[field.name] = [{ "": "" }];
         } else if (field.type === "toggle_options") {

--- a/src/apps/schema/src/appRevamp/components/configs.ts
+++ b/src/apps/schema/src/appRevamp/components/configs.ts
@@ -341,6 +341,7 @@ const COMMON_FIELDS: InputField[] = [
     gridSize: 12,
     tooltip: "The display name of the field seen in Schema.",
     validate: ["required", "length"],
+    autoFocus: true,
   },
   {
     name: "name",
@@ -483,6 +484,7 @@ const FORM_CONFIG: { [key: string]: FormConfig } = {
         required: false,
         gridSize: 6,
         placeholder: "Select a model",
+        autoFocus: true,
       },
       {
         name: "relatedFieldZUID",
@@ -492,7 +494,11 @@ const FORM_CONFIG: { [key: string]: FormConfig } = {
         gridSize: 6,
         placeholder: "Select a field",
       },
-      ...COMMON_FIELDS,
+      {
+        ...COMMON_FIELDS[0],
+        autoFocus: false,
+      },
+      ...COMMON_FIELDS.slice(1),
     ],
     rules: [],
   },
@@ -505,6 +511,7 @@ const FORM_CONFIG: { [key: string]: FormConfig } = {
         required: false,
         gridSize: 6,
         placeholder: "Select a model",
+        autoFocus: true,
       },
       {
         name: "relatedFieldZUID",
@@ -514,7 +521,11 @@ const FORM_CONFIG: { [key: string]: FormConfig } = {
         gridSize: 6,
         placeholder: "Select a field",
       },
-      ...COMMON_FIELDS,
+      {
+        ...COMMON_FIELDS[0],
+        autoFocus: false,
+      },
+      ...COMMON_FIELDS.slice(1),
     ],
     rules: [],
   },


### PR DESCRIPTION
- Autofocus the related model dropdown when creating one-to-one and one-to-many fields
- Prevent a one-to-one and one-to-many field from referencing the model which it is from

Closes #1905 
Closes #1902 