### PR TITLE
Fix: add default return when invalidation is skipped

### DIFF
--- a/src/shell/services/instance.ts
+++ b/src/shell/services/instance.ts
@@ -205,6 +205,8 @@ export const instanceApi = createApi({
         if (!arg.skipInvalidation) {
           return [{ type: "ContentModelFields", id: arg.modelZUID }];
         }
+
+        return [];
       },
     }),
     updateContentModelField: builder.mutation<


### PR DESCRIPTION
Closes #1931 

RTK query encounters an error when no array is returned from `invalidatesTag`