### PR TITLE
FIX:  Side nav favicon updates

### DIFF
--- a/cypress/e2e/schema/models.spec.js
+++ b/cypress/e2e/schema/models.spec.js
@@ -17,7 +17,7 @@ describe("Schema: Models", () => {
     cy.contains("Create Multi Page Model").should("be.visible");
     cy.get("body").type("{esc}");
     cy.getBySelector(`create-model-button-sidebar-dataset`).click();
-    cy.contains("Create Headless Dataset Model").should("be.visible");
+    cy.contains("Create Dataset Model").should("be.visible");
     cy.get("body").type("{esc}");
   });
   it("Creates model", () => {

--- a/src/shell/components/global-sidebar/components/InstanceAvatar.tsx
+++ b/src/shell/components/global-sidebar/components/InstanceAvatar.tsx
@@ -64,7 +64,7 @@ export const InstanceAvatar: FC<InstanceAvatar> = ({
         sx={{
           height: 32,
           width: 32,
-          backgroundColor: faviconURL ? "initial" : "info.main",
+          backgroundColor: faviconURL ? "white" : "info.main",
         }}
       >
         {(!faviconURL && instance?.name[0]?.toUpperCase()) || "A"}

--- a/src/shell/components/global-sidebar/components/InstanceAvatar.tsx
+++ b/src/shell/components/global-sidebar/components/InstanceAvatar.tsx
@@ -1,10 +1,23 @@
-import { useMemo } from "react";
-import { Avatar, Skeleton } from "@mui/material";
+import { FC, useMemo } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { Avatar, Skeleton, Box } from "@mui/material";
+import ImageRoundedIcon from "@mui/icons-material/ImageRounded";
 
 import { useGetHeadTagsQuery } from "../../../services/instance";
 import { useGetInstanceQuery } from "../../../services/accounts";
+import { AppState } from "../../../store/types";
+import { actions } from "../../../store/ui";
 
-export const InstanceAvatar = () => {
+interface InstanceAvatar {
+  canUpdateAvatar?: boolean;
+  onFaviconModalOpen?: () => void;
+}
+export const InstanceAvatar: FC<InstanceAvatar> = ({
+  canUpdateAvatar = true,
+  onFaviconModalOpen,
+}) => {
+  const ui = useSelector((state: AppState) => state.ui);
+  const dispatch = useDispatch();
   const { data: headTags, isLoading: isLoadingHeadTags } =
     useGetHeadTagsQuery();
   const { data: instance, isLoading: isLoadingInstance } =
@@ -37,16 +50,49 @@ export const InstanceAvatar = () => {
   }
 
   return (
-    <Avatar
-      src={faviconURL}
-      alt="favicon"
+    <Box
+      position="relative"
       sx={{
-        height: 32,
-        width: 32,
-        backgroundColor: faviconURL ? "initial" : "info.main",
+        "&:hover [data-cy='AvatarHoverOverlay']": {
+          display: "flex",
+        },
       }}
     >
-      {(!faviconURL && instance?.name[0]?.toUpperCase()) || "A"}
-    </Avatar>
+      <Avatar
+        src={faviconURL}
+        alt="favicon"
+        sx={{
+          height: 32,
+          width: 32,
+          backgroundColor: faviconURL ? "initial" : "info.main",
+        }}
+      >
+        {(!faviconURL && instance?.name[0]?.toUpperCase()) || "A"}
+      </Avatar>
+      {canUpdateAvatar && (
+        <Box
+          data-cy="AvatarHoverOverlay"
+          sx={{
+            backgroundColor: "#10182880",
+            borderRadius: "50%",
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            right: 0,
+            left: 0,
+            display: "none",
+            justifyContent: "center",
+            alignItems: "center",
+            cursor: "pointer",
+          }}
+          onClick={() => {
+            dispatch(actions.toggleUpdateFaviconModal(true));
+            onFaviconModalOpen && onFaviconModalOpen();
+          }}
+        >
+          <ImageRoundedIcon sx={{ width: 16, height: 16, fill: "white" }} />
+        </Box>
+      )}
+    </Box>
   );
 };

--- a/src/shell/components/global-sidebar/components/InstanceAvatar.tsx
+++ b/src/shell/components/global-sidebar/components/InstanceAvatar.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+import { Avatar, Skeleton } from "@mui/material";
+
+import { useGetHeadTagsQuery } from "../../../services/instance";
+import { useGetInstanceQuery } from "../../../services/accounts";
+
+export const InstanceAvatar = () => {
+  const { data: headTags, isLoading: isLoadingHeadTags } =
+    useGetHeadTagsQuery();
+  const { data: instance, isLoading: isLoadingInstance } =
+    useGetInstanceQuery();
+
+  const faviconURL = useMemo(() => {
+    if (headTags?.length) {
+      const allAttributes = headTags.map((tag) => tag.attributes);
+      const faviconTag = allAttributes.find((attr) => {
+        if ("href" in attr && "sizes" in attr && attr["sizes"] === "196x196") {
+          return attr;
+        }
+      });
+
+      return faviconTag?.href;
+    }
+
+    return "";
+  }, [headTags]);
+
+  if (isLoadingHeadTags || isLoadingInstance) {
+    return (
+      <Skeleton
+        variant="circular"
+        width={32}
+        height={32}
+        sx={{ bgcolor: "grey.500" }}
+      />
+    );
+  }
+
+  return (
+    <Avatar
+      src={faviconURL}
+      alt="favicon"
+      sx={{
+        height: 32,
+        width: 32,
+        backgroundColor: faviconURL ? "initial" : "info.main",
+      }}
+    >
+      {(!faviconURL && instance?.name[0]?.toUpperCase()) || "A"}
+    </Avatar>
+  );
+};

--- a/src/shell/components/global-sidebar/components/InstanceMenu/DropdownMenu.tsx
+++ b/src/shell/components/global-sidebar/components/InstanceMenu/DropdownMenu.tsx
@@ -9,13 +9,8 @@ export type View = "normal" | "instances" | "domains";
 interface DropdownMenuProps {
   anchorEl: HTMLElement;
   onClose: () => void;
-  faviconURL: string;
 }
-export const DropdownMenu: FC<DropdownMenuProps> = ({
-  anchorEl,
-  onClose,
-  faviconURL,
-}) => {
+export const DropdownMenu: FC<DropdownMenuProps> = ({ anchorEl, onClose }) => {
   const [view, setView] = useState<View>("normal");
 
   return (
@@ -42,7 +37,6 @@ export const DropdownMenu: FC<DropdownMenuProps> = ({
     >
       {view === "normal" && (
         <NormalMenu
-          faviconURL={faviconURL}
           onChangeView={(view) => setView(view)}
           onCloseDropdownMenu={onClose}
         />

--- a/src/shell/components/global-sidebar/components/InstanceMenu/index.tsx
+++ b/src/shell/components/global-sidebar/components/InstanceMenu/index.tsx
@@ -46,7 +46,7 @@ export const InstanceMenu: FC<InstanceMenuProps> = ({ openNav }) => {
           }
         >
           <Stack direction="row" gap={1} alignItems="center">
-            <InstanceAvatar />
+            <InstanceAvatar canUpdateAvatar={false} />
             {openNav && (
               <Typography
                 // @ts-ignore

--- a/src/shell/components/global-sidebar/components/InstanceMenu/index.tsx
+++ b/src/shell/components/global-sidebar/components/InstanceMenu/index.tsx
@@ -1,33 +1,18 @@
-import React, { FC, useMemo, useState, useRef } from "react";
-import { Avatar, Stack, Typography, ListItem, Box } from "@mui/material";
+import React, { FC, useState } from "react";
+import { Stack, Typography, ListItem, Skeleton } from "@mui/material";
 import ArrowDropDownRoundedIcon from "@mui/icons-material/ArrowDropDownRounded";
 
-import { useGetHeadTagsQuery } from "../../../../services/instance";
 import { useGetInstanceQuery } from "../../../../services/accounts";
 import { DropdownMenu } from "./DropdownMenu";
+import { InstanceAvatar } from "../InstanceAvatar";
 
 interface InstanceMenuProps {
   openNav: boolean;
 }
 export const InstanceMenu: FC<InstanceMenuProps> = ({ openNav }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const { data: headTags } = useGetHeadTagsQuery();
-  const { data: instance } = useGetInstanceQuery();
-
-  const faviconURL = useMemo(() => {
-    if (headTags?.length) {
-      const allAttributes = headTags.map((tag) => tag.attributes);
-      const faviconTag = allAttributes.find((attr) => {
-        if ("href" in attr && "sizes" in attr && attr["sizes"] === "196x196") {
-          return attr;
-        }
-      });
-
-      return faviconTag?.href;
-    }
-
-    return "";
-  }, [headTags]);
+  const { data: instance, isLoading: isLoadingInstance } =
+    useGetInstanceQuery();
 
   return (
     <>
@@ -61,11 +46,7 @@ export const InstanceMenu: FC<InstanceMenuProps> = ({ openNav }) => {
           }
         >
           <Stack direction="row" gap={1} alignItems="center">
-            <Avatar
-              src={faviconURL}
-              alt="favicon"
-              sx={{ height: 32, width: 32 }}
-            />
+            <InstanceAvatar />
             {openNav && (
               <Typography
                 // @ts-ignore
@@ -80,7 +61,11 @@ export const InstanceMenu: FC<InstanceMenuProps> = ({ openNav }) => {
                 }}
                 overflow="hidden"
               >
-                {instance?.name}
+                {isLoadingInstance ? (
+                  <Skeleton sx={{ bgcolor: "grey.500", width: 70 }} />
+                ) : (
+                  instance?.name
+                )}
               </Typography>
             )}
           </Stack>
@@ -88,11 +73,7 @@ export const InstanceMenu: FC<InstanceMenuProps> = ({ openNav }) => {
         </Stack>
       </ListItem>
       {Boolean(anchorEl) && (
-        <DropdownMenu
-          anchorEl={anchorEl}
-          faviconURL={faviconURL}
-          onClose={() => setAnchorEl(null)}
-        />
+        <DropdownMenu anchorEl={anchorEl} onClose={() => setAnchorEl(null)} />
       )}
     </>
   );

--- a/src/shell/components/global-sidebar/components/InstanceMenu/views/NormalMenu.tsx
+++ b/src/shell/components/global-sidebar/components/InstanceMenu/views/NormalMenu.tsx
@@ -116,7 +116,7 @@ export const NormalMenu: FC<NormalMenuProps> = ({
   return (
     <>
       <Stack direction="row" gap={1.5} p={2} alignItems="center">
-        <InstanceAvatar />
+        <InstanceAvatar onFaviconModalOpen={() => onCloseDropdownMenu()} />
         <Stack>
           <Typography variant="body2" fontWeight={600}>
             {instance?.name}

--- a/src/shell/components/global-sidebar/components/InstanceMenu/views/NormalMenu.tsx
+++ b/src/shell/components/global-sidebar/components/InstanceMenu/views/NormalMenu.tsx
@@ -35,6 +35,7 @@ import { actions } from "../../../../../store/ui";
 import { notify } from "../../../../../store/notifications";
 import { useRefreshCacheMutation } from "../../../../../services/cloudFunctions";
 import { useDomain } from "../../../../../hooks/use-domain";
+import { InstanceAvatar } from "../../InstanceAvatar";
 
 export const rotateAnimation = keyframes`
   from {
@@ -46,12 +47,10 @@ export const rotateAnimation = keyframes`
 `;
 
 interface NormalMenuProps {
-  faviconURL: string;
   onChangeView: (view: View) => void;
   onCloseDropdownMenu: () => void;
 }
 export const NormalMenu: FC<NormalMenuProps> = ({
-  faviconURL,
   onChangeView,
   onCloseDropdownMenu,
 }) => {
@@ -117,7 +116,7 @@ export const NormalMenu: FC<NormalMenuProps> = ({
   return (
     <>
       <Stack direction="row" gap={1.5} p={2} alignItems="center">
-        <Avatar src={faviconURL} alt="favicon" sx={{ height: 32, width: 32 }} />
+        <InstanceAvatar />
         <Stack>
           <Typography variant="body2" fontWeight={600}>
             {instance?.name}


### PR DESCRIPTION
- Added default favicon with instance initial when no favicon is uploaded
- Added function to update favicon when user hovers and clicks on the favicon at the dropdown menu
- Added a default white background for the favicon

![2023-04-24 08 09 36 8-f48cf3a682-7fthvk manager dev zesty io d8cb0a1ad840](https://user-images.githubusercontent.com/28705606/233891437-010ba501-e59b-4d8c-a20f-2dc4210f41ab.jpg)
![Screenshot from 2023-04-24 11-05-45](https://user-images.githubusercontent.com/28705606/233891592-b3e5936e-a1ce-447c-87f4-bc41dc20e779.png)
![2023-04-24 11 05 10 8-f48cf3a682-7fthvk manager dev zesty io f8f38f6e0ae8](https://user-images.githubusercontent.com/28705606/233891601-c6fab088-695a-482c-8034-801398efee38.jpg)

Closes #1997 
Closes #2001 
Closes #2006 
