### PR TITLE
Global Search: Save/remove recent searches

### DIFF
--- a/src/shell/components/ContentSearch/components/GlobalSearchItem.tsx
+++ b/src/shell/components/ContentSearch/components/GlobalSearchItem.tsx
@@ -1,0 +1,37 @@
+import { FC, HTMLAttributes } from "react";
+import { ListItem, ListItemIcon, ListItemText, SvgIcon } from "@mui/material";
+import { SvgIconComponent } from "@mui/icons-material";
+
+type GlobalSearchItemProps = HTMLAttributes<HTMLLIElement> & {
+  text: string;
+  icon: SvgIconComponent;
+};
+export const GlobalSearchItem: FC<GlobalSearchItemProps> = ({
+  text,
+  icon,
+  ...props
+}) => {
+  return (
+    <ListItem
+      {...props}
+      sx={{
+        "&.MuiAutocomplete-option": {
+          padding: "4px 16px 4px 16px",
+        },
+        minHeight: "36px",
+        "&.Mui-focused": {
+          borderLeft: (theme) => "4px solid " + theme.palette.primary.main,
+          padding: "4px 16px 4px 12px",
+        },
+      }}
+    >
+      <ListItemIcon sx={{ width: "32px", minWidth: "32px" }}>
+        <SvgIcon component={icon} fontSize="small" />
+      </ListItemIcon>
+      <ListItemText
+        primary={text}
+        primaryTypographyProps={{ variant: "body2", color: "text.secondary" }}
+      />
+    </ListItem>
+  );
+};

--- a/src/shell/components/ContentSearch/components/GlobalSearchItem.tsx
+++ b/src/shell/components/ContentSearch/components/GlobalSearchItem.tsx
@@ -1,14 +1,26 @@
 import { FC, HTMLAttributes } from "react";
-import { ListItem, ListItemIcon, ListItemText, SvgIcon } from "@mui/material";
+import {
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  SvgIcon,
+  ListItemSecondaryAction,
+  IconButton,
+} from "@mui/material";
 import { SvgIconComponent } from "@mui/icons-material";
+import CloseIcon from "@mui/icons-material/Close";
 
 type GlobalSearchItemProps = HTMLAttributes<HTMLLIElement> & {
   text: string;
   icon: SvgIconComponent;
+  isRemovable?: boolean;
+  onRemove?: (keyword: string) => void;
 };
 export const GlobalSearchItem: FC<GlobalSearchItemProps> = ({
   text,
   icon,
+  isRemovable = false,
+  onRemove,
   ...props
 }) => {
   return (
@@ -26,6 +38,12 @@ export const GlobalSearchItem: FC<GlobalSearchItemProps> = ({
           pr: 2,
           pl: 1.5,
         },
+        "& + .MuiListItemSecondaryAction-root": {
+          display: "none",
+        },
+        "&.Mui-focused + .MuiListItemSecondaryAction-root": {
+          display: "block",
+        },
       }}
     >
       <ListItemIcon sx={{ width: "32px", minWidth: "32px" }}>
@@ -35,6 +53,13 @@ export const GlobalSearchItem: FC<GlobalSearchItemProps> = ({
         primary={text}
         primaryTypographyProps={{ variant: "body2", color: "text.secondary" }}
       />
+      {isRemovable && (
+        <ListItemSecondaryAction>
+          <IconButton size="small" onClick={() => onRemove && onRemove(text)}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </ListItemSecondaryAction>
+      )}
     </ListItem>
   );
 };

--- a/src/shell/components/ContentSearch/components/GlobalSearchItem.tsx
+++ b/src/shell/components/ContentSearch/components/GlobalSearchItem.tsx
@@ -16,12 +16,15 @@ export const GlobalSearchItem: FC<GlobalSearchItemProps> = ({
       {...props}
       sx={{
         "&.MuiAutocomplete-option": {
-          padding: "4px 16px 4px 16px",
+          px: 2,
+          py: 0.5,
         },
         minHeight: "36px",
         "&.Mui-focused": {
           borderLeft: (theme) => "4px solid " + theme.palette.primary.main,
-          padding: "4px 16px 4px 12px",
+          py: 0.5,
+          pr: 2,
+          pl: 1.5,
         },
       }}
     >

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -15,15 +15,17 @@ import {
   IconButton,
 } from "@mui/material";
 import PencilIcon from "@mui/icons-material/Create";
+import { useHistory, useLocation } from "react-router";
+import { useDispatch, useSelector } from "react-redux";
+import { useTheme } from "@mui/material/styles";
+import TuneRoundedIcon from "@mui/icons-material/TuneRounded";
+
 import { useMetaKey } from "../../../shell/hooks/useMetaKey";
 import { useSearchContentQuery } from "../../services/instance";
 import { ContentItem } from "../../services/types";
-import { useHistory, useLocation } from "react-router";
-import { useDispatch, useSelector } from "react-redux";
 import { notify } from "../../store/notifications";
-import { useTheme } from "@mui/material/styles";
-import TuneRoundedIcon from "@mui/icons-material/TuneRounded";
 import { AdvancedSearch } from "./components/AdvancedSearch";
+import { useRecentSearches } from "../../hooks/useRecentSearches";
 
 // The order here matters as this is how it will be rendered as well
 const AdditionalDropdownOptions = ["RecentSearches", "AdvancedSearchButton"];
@@ -31,6 +33,7 @@ const AdditionalDropdownOptions = ["RecentSearches", "AdvancedSearchButton"];
 const ContentSearch: FC = () => {
   const [value, setValue] = useState("");
   const [isAdvancedSearchOpen, setIsAdvancedSearchOpen] = useState(false);
+  const [recentSearches, updateRecentSearches] = useRecentSearches();
   const history = useHistory();
   const location = useLocation();
   const dispatch = useDispatch();
@@ -56,6 +59,8 @@ const ContentSearch: FC = () => {
 
   const goToSearchPage = (queryTerm: string) => {
     const isOnSearchPage = location.pathname === "/search";
+
+    updateRecentSearches(queryTerm);
 
     // Only add the search page on the history stack during initial page visit
     // Makes sure clicking close on the search page brings the user back to the previous page

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -23,7 +23,7 @@ import { useSearchContentQuery } from "../../services/instance";
 import { ContentItem } from "../../services/types";
 import { notify } from "../../store/notifications";
 import { AdvancedSearch } from "./components/AdvancedSearch";
-import { useRecentSearches } from "../../hooks/useRecentSearches";
+import useRecentSearches from "../../hooks/useRecentSearches";
 import { GlobalSearchItem } from "./components/GlobalSearchItem";
 
 const AdditionalDropdownOptions = ["RecentSearches", "AdvancedSearchButton"];
@@ -32,7 +32,7 @@ const ElementId = "global-search-autocomplete";
 const ContentSearch: FC = () => {
   const [value, setValue] = useState("");
   const [isAdvancedSearchOpen, setIsAdvancedSearchOpen] = useState(false);
-  const [recentSearches, updateRecentSearches] = useRecentSearches();
+  const [recentSearches, addSearchTerm, deleteSearchTerm] = useRecentSearches();
   const history = useHistory();
   const location = useLocation();
   const dispatch = useDispatch();
@@ -65,7 +65,7 @@ const ContentSearch: FC = () => {
     const isOnSearchPage = location.pathname === "/search";
 
     setOpen(false);
-    updateRecentSearches(queryTerm);
+    addSearchTerm(queryTerm);
     textfieldRef.current?.querySelector("input").blur();
 
     if (queryTerm !== value) {
@@ -210,6 +210,8 @@ const ContentSearch: FC = () => {
                     icon={isSearchTerm ? SearchRounded : ScheduleRounded}
                     onClick={() => goToSearchPage(option)}
                     text={option}
+                    isRemovable={!isSearchTerm}
+                    onRemove={deleteSearchTerm}
                   />
                 );
               }

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -48,7 +48,8 @@ const ContentSearch: FC = () => {
       recentSearches?.length && !value
         ? ["RecentSearches", ...recentSearches.slice(0, 5)]
         : [];
-    const _suggestions = suggestions?.length ? suggestions?.slice(0, 5) : [];
+    const _suggestions =
+      suggestions?.length && value ? suggestions?.slice(0, 5) : [];
 
     return [value, ..._suggestions, ..._recentSearches, "AdvancedSearchButton"];
   }, [suggestions, recentSearches, value]);

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -1,11 +1,8 @@
 import { FC, useState, useRef, useMemo } from "react";
 import SearchIcon from "@mui/icons-material/SearchRounded";
 import InputAdornment from "@mui/material/InputAdornment";
-import { HTMLAttributes } from "react";
 import {
   ListItem,
-  ListItemIcon,
-  ListItemText,
   Button,
   TextField,
   Autocomplete,
@@ -14,19 +11,12 @@ import {
   Collapse,
   IconButton,
   ListSubheader,
-  SvgIcon,
 } from "@mui/material";
-import PencilIcon from "@mui/icons-material/Create";
 import { useHistory, useLocation } from "react-router";
 import { useDispatch, useSelector } from "react-redux";
 import { useTheme } from "@mui/material/styles";
 import TuneRoundedIcon from "@mui/icons-material/TuneRounded";
-import {
-  ScheduleRounded,
-  SearchRounded,
-  Create,
-  SvgIconComponent,
-} from "@mui/icons-material";
+import { ScheduleRounded, SearchRounded, Create } from "@mui/icons-material";
 
 import { useMetaKey } from "../../../shell/hooks/useMetaKey";
 import { useSearchContentQuery } from "../../services/instance";

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -59,8 +59,6 @@ const ContentSearch: FC = () => {
       ? ["RecentSearches", ...recentSearches]
       : [];
 
-    console.log(_recentSearches);
-
     if (suggestions && value) {
       return [
         value,
@@ -234,7 +232,22 @@ const ContentSearch: FC = () => {
 
               // Renders the recent searches component
               if (option === "RecentSearches") {
-                return <ListSubheader>Recent Searches</ListSubheader>;
+                return (
+                  <ListSubheader
+                    sx={{
+                      px: 1.5,
+                      pb: 0.5,
+                      pt: 0,
+                      mt: 1,
+                      fontSize: "12px",
+                      fontWeight: 600,
+                      lineHeight: "18px",
+                      letterSpacing: "0.15px",
+                    }}
+                  >
+                    Recent Searches
+                  </ListSubheader>
+                );
               }
 
               // Renders the advanced search button

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -48,17 +48,9 @@ const ContentSearch: FC = () => {
     const _recentSearches = recentSearches?.length
       ? ["RecentSearches", ...recentSearches]
       : [];
+    const _suggestions = suggestions?.length ? suggestions?.slice(0, 5) : [];
 
-    if (suggestions && value) {
-      return [
-        value,
-        ...suggestions.slice(0, 5),
-        ..._recentSearches,
-        "AdvancedSearchButton",
-      ];
-    }
-
-    return [..._recentSearches, "AdvancedSearchButton"];
+    return [value, ..._suggestions, ..._recentSearches, "AdvancedSearchButton"];
   }, [suggestions, recentSearches, value]);
 
   //@ts-ignore TODO fix typing for useMetaKey
@@ -204,14 +196,10 @@ const ContentSearch: FC = () => {
           renderOption={(props, option) => {
             if (typeof option === "string") {
               if (!AdditionalDropdownOptions.includes(option)) {
-                let icon;
+                const isSearchTerm = props.id === `${ElementId}-option-0`;
 
-                if (props.id === `${ElementId}-option-0`) {
-                  // First option is the user input term
-                  icon = SearchRounded;
-                } else {
-                  // These represent the recent search terms
-                  icon = ScheduleRounded;
+                if (isSearchTerm && !value) {
+                  return;
                 }
 
                 return (
@@ -219,8 +207,8 @@ const ContentSearch: FC = () => {
                     {...props}
                     // Hacky: aria-selected is required for accessibility but the underlying component is not setting it correctly for the top row
                     aria-selected={false}
-                    key={"global-search-term"}
-                    icon={icon}
+                    key={isSearchTerm ? "global-search-term" : option}
+                    icon={isSearchTerm ? SearchRounded : ScheduleRounded}
                     onClick={() => goToSearchPage(option)}
                     text={option}
                   />
@@ -241,6 +229,7 @@ const ContentSearch: FC = () => {
                       lineHeight: "18px",
                       letterSpacing: "0.15px",
                     }}
+                    key={option}
                   >
                     Recent Searches
                   </ListSubheader>

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -26,7 +26,6 @@ import { AdvancedSearch } from "./components/AdvancedSearch";
 import { useRecentSearches } from "../../hooks/useRecentSearches";
 import { GlobalSearchItem } from "./components/GlobalSearchItem";
 
-// The order here matters as this is how it will be rendered as well
 const AdditionalDropdownOptions = ["RecentSearches", "AdvancedSearchButton"];
 const ElementId = "global-search-autocomplete";
 

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -43,10 +43,11 @@ const ContentSearch: FC = () => {
 
   const suggestions = res.data;
   const options = useMemo(() => {
-    // Hides the recent searches if there's none, otherwise show first 5
-    const _recentSearches = recentSearches?.length
-      ? ["RecentSearches", ...recentSearches.slice(0, 5)]
-      : [];
+    // Only show the first 5 recent searches when user has not typed in a query
+    const _recentSearches =
+      recentSearches?.length && !value
+        ? ["RecentSearches", ...recentSearches.slice(0, 5)]
+        : [];
     const _suggestions = suggestions?.length ? suggestions?.slice(0, 5) : [];
 
     return [value, ..._suggestions, ..._recentSearches, "AdvancedSearchButton"];
@@ -193,8 +194,14 @@ const ContentSearch: FC = () => {
           renderOption={(props, option) => {
             if (typeof option === "string") {
               if (!AdditionalDropdownOptions.includes(option)) {
+                // Means that this option is the top row global search term typed by the userf
                 const isSearchTerm = props.id === `${ElementId}-option-0`;
 
+                // Determines if the user-typed top row global search term already exists in the recent searches
+                const searchTermInRecentSearches =
+                  isSearchTerm && recentSearches.includes(option);
+
+                // Hides the top row global search term if no value is present
                 if (isSearchTerm && !value) {
                   return;
                 }
@@ -205,10 +212,14 @@ const ContentSearch: FC = () => {
                     // Hacky: aria-selected is required for accessibility but the underlying component is not setting it correctly for the top row
                     aria-selected={false}
                     key={isSearchTerm ? "global-search-term" : option}
-                    icon={isSearchTerm ? SearchRounded : ScheduleRounded}
+                    icon={
+                      searchTermInRecentSearches
+                        ? ScheduleRounded
+                        : SearchRounded
+                    }
                     onClick={() => goToSearchPage(option)}
                     text={option}
-                    isRemovable={!isSearchTerm}
+                    isRemovable={!isSearchTerm || searchTermInRecentSearches}
                     onRemove={deleteSearchTerm}
                   />
                 );

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -214,7 +214,7 @@ const ContentSearch: FC = () => {
                     aria-selected={false}
                     key={isSearchTerm ? "global-search-term" : option}
                     icon={
-                      searchTermInRecentSearches
+                      !isSearchTerm || searchTermInRecentSearches
                         ? ScheduleRounded
                         : SearchRounded
                     }

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -73,7 +73,14 @@ const ContentSearch: FC = () => {
   const goToSearchPage = (queryTerm: string) => {
     const isOnSearchPage = location.pathname === "/search";
 
+    setOpen(false);
     updateRecentSearches(queryTerm);
+    textfieldRef.current?.querySelector("input").blur();
+
+    if (queryTerm !== value) {
+      // Makes sure that the textfield value gets updated if the user has clicked on a recent search item
+      setValue(queryTerm);
+    }
 
     // Only add the search page on the history stack during initial page visit
     // Makes sure clicking close on the search page brings the user back to the previous page

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -34,6 +34,7 @@ import { ContentItem } from "../../services/types";
 import { notify } from "../../store/notifications";
 import { AdvancedSearch } from "./components/AdvancedSearch";
 import { useRecentSearches } from "../../hooks/useRecentSearches";
+import { GlobalSearchItem } from "./components/GlobalSearchItem";
 
 // The order here matters as this is how it will be rendered as well
 const AdditionalDropdownOptions = ["RecentSearches", "AdvancedSearchButton"];
@@ -219,7 +220,7 @@ const ContentSearch: FC = () => {
                 }
 
                 return (
-                  <Suggestion
+                  <GlobalSearchItem
                     {...props}
                     // Hacky: aria-selected is required for accessibility but the underlying component is not setting it correctly for the top row
                     aria-selected={false}
@@ -267,7 +268,7 @@ const ContentSearch: FC = () => {
                 return langDisplay ? `${langDisplay}${title}` : title;
               };
               return (
-                <Suggestion
+                <GlobalSearchItem
                   {...props}
                   key={option.meta.ZUID}
                   icon={Create}
@@ -376,35 +377,3 @@ const ContentSearch: FC = () => {
 };
 
 export default ContentSearch;
-
-type SuggestionProps = HTMLAttributes<HTMLLIElement> & {
-  text: string;
-  icon: SvgIconComponent;
-};
-const Suggestion: FC<SuggestionProps> = ({ text, icon, ...props }) => {
-  // const Icon = icon === "search" ? SearchIcon : PencilIcon;
-
-  return (
-    <ListItem
-      {...props}
-      sx={{
-        "&.MuiAutocomplete-option": {
-          padding: "4px 16px 4px 16px",
-        },
-        minHeight: "36px",
-        "&.Mui-focused": {
-          borderLeft: (theme) => "4px solid " + theme.palette.primary.main,
-          padding: "4px 16px 4px 12px",
-        },
-      }}
-    >
-      <ListItemIcon sx={{ width: "32px", minWidth: "32px" }}>
-        <SvgIcon component={icon} fontSize="small" />
-      </ListItemIcon>
-      <ListItemText
-        primary={text}
-        primaryTypographyProps={{ variant: "body2", color: "text.secondary" }}
-      />
-    </ListItem>
-  );
-};

--- a/src/shell/components/ContentSearch/index.tsx
+++ b/src/shell/components/ContentSearch/index.tsx
@@ -42,10 +42,10 @@ const ContentSearch: FC = () => {
   const res = useSearchContentQuery({ query: value }, { skip: !value });
 
   const suggestions = res.data;
-  const topSuggestions = useMemo(() => {
-    // Hides the recent searches if there's none
+  const options = useMemo(() => {
+    // Hides the recent searches if there's none, otherwise show first 5
     const _recentSearches = recentSearches?.length
-      ? ["RecentSearches", ...recentSearches]
+      ? ["RecentSearches", ...recentSearches.slice(0, 5)]
       : [];
     const _suggestions = suggestions?.length ? suggestions?.slice(0, 5) : [];
 
@@ -113,9 +113,7 @@ const ContentSearch: FC = () => {
                 elevation={0}
                 sx={{
                   borderStyle: "solid",
-                  borderWidth: topSuggestions?.length
-                    ? "0px 1px 1px 1px"
-                    : "0px",
+                  borderWidth: options?.length ? "0px 1px 1px 1px" : "0px",
                   borderColor: "border",
                   borderRadius: "0px 0px 4px 4px",
 
@@ -144,7 +142,7 @@ const ContentSearch: FC = () => {
           clearOnBlur
           handleHomeEndKeys
           blurOnSelect
-          options={topSuggestions}
+          options={options}
           filterOptions={(x) => x}
           sx={{
             height: "40px",

--- a/src/shell/hooks/useRecentSearches.ts
+++ b/src/shell/hooks/useRecentSearches.ts
@@ -1,6 +1,4 @@
-import { useMemo } from "react";
 import { useLocalStorage } from "react-use";
-import { cloneDeep } from "lodash";
 
 const MaxSavedKeywords = 50;
 
@@ -20,27 +18,18 @@ const useRecentSearches: () => UseRecentSearches = () => {
       return;
     }
 
-    let keywords = cloneDeep(recentSearches);
-
-    // Remove the keyword if it was already saved
-    if (keywords.includes(keyword)) {
-      keywords = keywords.filter((term) => term !== keyword);
-    }
+    // Remove the keyword if it was already saved previously
+    let keywords = recentSearches.filter((term) => term !== keyword);
 
     // Add the keyword at the beginning
     keywords.unshift(keyword);
 
     // Limit the number of keywords saved
-    keywords = keywords.slice(0, MaxSavedKeywords);
-
-    setRecentSearches(keywords);
+    setRecentSearches(keywords.slice(0, MaxSavedKeywords));
   };
 
   const deleteSearchTerm = (keyword: string) => {
-    let keywords = cloneDeep(recentSearches);
-    keywords = keywords.filter((term) => term !== keyword);
-
-    setRecentSearches(keywords);
+    setRecentSearches(recentSearches.filter((term) => term !== keyword));
   };
 
   return [recentSearches, addSearchTerm, deleteSearchTerm];

--- a/src/shell/hooks/useRecentSearches.ts
+++ b/src/shell/hooks/useRecentSearches.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+import { useLocalStorage } from "react-use";
+import { cloneDeep } from "lodash";
+
+const MaxSavedKeywords = 5;
+
+type UseRecentSearches = [string[], (keyword: string) => void];
+export const useRecentSearches: () => UseRecentSearches = () => {
+  const [recentSearches, setRecentSearches] = useLocalStorage(
+    "zesty:globalSearch:recentSearches",
+    "[]"
+  );
+
+  const recentSearchesArray: string[] = useMemo(() => {
+    return JSON.parse(recentSearches || "[]");
+  }, [recentSearches]);
+
+  const updateRecentSearches = (keyword: string) => {
+    if (!Array.isArray(recentSearchesArray)) {
+      return;
+    }
+
+    let keywords = cloneDeep(recentSearchesArray);
+
+    // Remove the keyword if it was already saved
+    if (keywords.includes(keyword)) {
+      keywords = keywords.filter((term) => term !== keyword);
+    }
+
+    // Add the keyword at the beginning
+    keywords.unshift(keyword);
+
+    // Make sure only 5 keywords are saved
+    keywords = keywords.slice(0, MaxSavedKeywords);
+
+    setRecentSearches(JSON.stringify(keywords));
+  };
+
+  return [recentSearchesArray, updateRecentSearches];
+};

--- a/src/shell/hooks/useRecentSearches.ts
+++ b/src/shell/hooks/useRecentSearches.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useLocalStorage } from "react-use";
 import { cloneDeep } from "lodash";
 
-const MaxSavedKeywords = 5;
+const MaxSavedKeywords = 50;
 
 type UseRecentSearches = [
   string[],
@@ -34,7 +34,7 @@ const useRecentSearches: () => UseRecentSearches = () => {
     // Add the keyword at the beginning
     keywords.unshift(keyword);
 
-    // Make sure only 5 keywords are saved
+    // Limit the number of keywords saved
     keywords = keywords.slice(0, MaxSavedKeywords);
 
     setRecentSearches(JSON.stringify(keywords));

--- a/src/shell/hooks/useRecentSearches.ts
+++ b/src/shell/hooks/useRecentSearches.ts
@@ -12,19 +12,15 @@ type UseRecentSearches = [
 const useRecentSearches: () => UseRecentSearches = () => {
   const [recentSearches, setRecentSearches] = useLocalStorage(
     "zesty:globalSearch:recentSearches",
-    "[]"
+    []
   );
 
-  const recentSearchesArray: string[] = useMemo(() => {
-    return JSON.parse(recentSearches || "[]");
-  }, [recentSearches]);
-
   const addSearchTerm = (keyword: string) => {
-    if (!Array.isArray(recentSearchesArray)) {
+    if (!Array.isArray(recentSearches)) {
       return;
     }
 
-    let keywords = cloneDeep(recentSearchesArray);
+    let keywords = cloneDeep(recentSearches);
 
     // Remove the keyword if it was already saved
     if (keywords.includes(keyword)) {
@@ -37,17 +33,17 @@ const useRecentSearches: () => UseRecentSearches = () => {
     // Limit the number of keywords saved
     keywords = keywords.slice(0, MaxSavedKeywords);
 
-    setRecentSearches(JSON.stringify(keywords));
+    setRecentSearches(keywords);
   };
 
   const deleteSearchTerm = (keyword: string) => {
-    let keywords = cloneDeep(recentSearchesArray);
+    let keywords = cloneDeep(recentSearches);
     keywords = keywords.filter((term) => term !== keyword);
 
-    setRecentSearches(JSON.stringify(keywords));
+    setRecentSearches(keywords);
   };
 
-  return [recentSearchesArray, addSearchTerm, deleteSearchTerm];
+  return [recentSearches, addSearchTerm, deleteSearchTerm];
 };
 
 export default useRecentSearches;

--- a/src/shell/hooks/useRecentSearches.ts
+++ b/src/shell/hooks/useRecentSearches.ts
@@ -4,8 +4,12 @@ import { cloneDeep } from "lodash";
 
 const MaxSavedKeywords = 5;
 
-type UseRecentSearches = [string[], (keyword: string) => void];
-export const useRecentSearches: () => UseRecentSearches = () => {
+type UseRecentSearches = [
+  string[],
+  (keyword: string) => void,
+  (keyword: string) => void
+];
+const useRecentSearches: () => UseRecentSearches = () => {
   const [recentSearches, setRecentSearches] = useLocalStorage(
     "zesty:globalSearch:recentSearches",
     "[]"
@@ -15,7 +19,7 @@ export const useRecentSearches: () => UseRecentSearches = () => {
     return JSON.parse(recentSearches || "[]");
   }, [recentSearches]);
 
-  const updateRecentSearches = (keyword: string) => {
+  const addSearchTerm = (keyword: string) => {
     if (!Array.isArray(recentSearchesArray)) {
       return;
     }
@@ -36,5 +40,14 @@ export const useRecentSearches: () => UseRecentSearches = () => {
     setRecentSearches(JSON.stringify(keywords));
   };
 
-  return [recentSearchesArray, updateRecentSearches];
+  const deleteSearchTerm = (keyword: string) => {
+    let keywords = cloneDeep(recentSearchesArray);
+    keywords = keywords.filter((term) => term !== keyword);
+
+    setRecentSearches(JSON.stringify(keywords));
+  };
+
+  return [recentSearchesArray, addSearchTerm, deleteSearchTerm];
 };
+
+export default useRecentSearches;


### PR DESCRIPTION
- Added ability to save 50 recent searches
- Show top 5 recent searches on the global search dropdown
- Remove a recent search keyword
- If user-typed keyword exists as a recent search, show it as a recent search item

![image](https://user-images.githubusercontent.com/28705606/236116759-006da0f5-ddb6-420a-be0b-8e7652c9eb26.png)
![image](https://user-images.githubusercontent.com/28705606/236116793-821c1dfb-3be5-425e-88ed-74bcba1a6505.png)
