### PR TITLE
FIX: Prevent unnecessary api call when uploading in all media

### DIFF
--- a/src/apps/media/src/app/components/DnDProvider.tsx
+++ b/src/apps/media/src/app/components/DnDProvider.tsx
@@ -34,7 +34,9 @@ export const DnDProvider = ({
 }: Props) => {
   const dispatch = useDispatch();
   const { data: currentGroup, isFetching: groupIsFetching } =
-    useGetGroupDataQuery(currentGroupId, { skip: !currentGroupId });
+    useGetGroupDataQuery(currentGroupId, {
+      skip: !currentGroupId || currentGroupId === currentBinId,
+    });
   const { data: binData, isFetching: binIsFetching } = useGetBinQuery(
     currentBinId,
     { skip: !currentBinId }

--- a/src/apps/media/src/app/components/UploadButton.tsx
+++ b/src/apps/media/src/app/components/UploadButton.tsx
@@ -30,7 +30,9 @@ export const UploadButton: FC<UploadButton> = ({
   const [params] = useParams();
   const triggerUpload = (params as URLSearchParams).get("triggerUpload");
   const { data: currentGroup, isFetching: groupIsFetching } =
-    useGetGroupDataQuery(currentGroupId, { skip: !currentGroupId });
+    useGetGroupDataQuery(currentGroupId, {
+      skip: !currentGroupId || currentGroupId === currentBinId,
+    });
   const { data: binData, isFetching: binIsFetching } = useGetBinQuery(
     currentBinId,
     { skip: !currentBinId }


### PR DESCRIPTION
Prevents the api call to get the group data when the group id === bin id in all media

Closes #2036 