### PR TITLE
FIX: Incorrect zuid copied

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/ContentInfo/index.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/ContentInfo/index.js
@@ -109,9 +109,9 @@ export const ContentInfo = (props) => {
                   <InputAdornment position="end">
                     <IconButton
                       size="small"
-                      onClick={() => handleCopyClick(props.modelZUID)}
+                      onClick={() => handleCopyClick(props.itemZUID || "")}
                     >
-                      {isCopied === props.modelZUID ? (
+                      {isCopied === props.itemZUID ? (
                         <CheckIcon color="action" />
                       ) : (
                         <ContentCopyRoundedIcon color="action" />


### PR DESCRIPTION
Fixes model zuid being copied instead of the content zuid
Closes #1996 

![chrome-capture-2023-4-11](https://github.com/zesty-io/manager-ui/assets/28705606/eb5fd874-5c8d-4c27-85d6-3adfb3d5c4bd)
