### PR TITLE
Fix: Updated char limit for meta keywords

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/MetaKeywords.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/MetaKeywords.js
@@ -27,7 +27,7 @@ export const MetaKeywords = memo(function MetaKeywords({
         }
         value={meta_keywords || ""}
         placeholder="comma, separated, keywords"
-        maxLength="250"
+        maxLength="255"
         rows={6}
         multiline
         onChange={(evt) => onChange(evt.target.value, "metaKeywords")}


### PR DESCRIPTION
- Changed char limit from 250 to 255
Closes #2020 

![Screenshot](https://github.com/zesty-io/manager-ui/assets/28705606/1fe3cdec-6716-48bb-95d8-bf37f04c9ad9)
