### PR TITLE
Move nav icon set to the buildTree method to avoid inserting component into IDB

### DIFF
--- a/src/apps/content-editor/src/store/navContent.js
+++ b/src/apps/content-editor/src/store/navContent.js
@@ -123,13 +123,6 @@ export function fetchNav() {
               } else {
                 node.path = `/content/${node.ZUID}`;
               }
-
-              // Set Icon
-              if (node.label.toLowerCase() === "homepage") {
-                node.icon = ICONS["homepage"];
-              } else {
-                node.icon = ICONS[node.type];
-              }
             });
 
             dispatch({
@@ -236,7 +229,13 @@ function buildTree(nodes) {
       return acc;
     }
 
-    acc[node.ZUID] = { ...node };
+    //Set Icon
+    const icon =
+      node.label.toLowerCase() === "homepage"
+        ? ICONS["homepage"]
+        : ICONS[node.type];
+
+    acc[node.ZUID] = { ...node, icon };
 
     // Setup container for children nodes
     acc[node.ZUID].children = [];


### PR DESCRIPTION
The error in question

DOMException: Failed to execute 'put' on 'IDBObjectStore': Symbol(react.element) could not be cloned.

Occurs if we attempt to store a JavaScript Symbol value (in this case, a React element) into IndexedDB. This attempt occurs when setting the navContent into indexDB because we are adding an icon component. 

This error was introduced was navContent icons were swapped to mui icons since mui icons are react components and font-awesome icons were not.

The solution is to not append the icon component to the raw nav response when storing it to idb and to infer the icon required afterwards.  


Note: This will no longer be utilized with new content nav