### PR TITLE
Focus done button after file selection and add spacing to Selected text

### DIFF
--- a/src/apps/media/src/app/components/DnDProvider.tsx
+++ b/src/apps/media/src/app/components/DnDProvider.tsx
@@ -73,7 +73,10 @@ export const DnDProvider = ({
         outline: "none",
         ...sx,
       }}
-      {...getRootProps({ onClick: (evt) => evt.stopPropagation() })}
+      {...getRootProps({
+        onClick: (evt) => evt.stopPropagation(),
+        onKeyDown: (evt) => evt.stopPropagation(),
+      })}
     >
       <input {...getInputProps()} />
       {isDragActive ? (

--- a/src/apps/media/src/app/components/Header.tsx
+++ b/src/apps/media/src/app/components/Header.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useEffect, useState } from "react";
+import { MouseEvent, useEffect, useRef, useState } from "react";
 import {
   Box,
   Button,
@@ -66,6 +66,7 @@ export const Header = ({
   addImagesCallback,
   showBackButton,
 }: Props) => {
+  const doneButtonRef = useRef<HTMLButtonElement>(null);
   const [openDialog, setOpenDialog] = useState<Dialogs>(null);
   const [anchorEl, setAnchorEl] = useState(null);
   const history = useHistory();
@@ -154,6 +155,13 @@ export const Header = ({
     }
   };
 
+  // Focus done button after selecting files
+  useEffect(() => {
+    if (selectedFiles?.length > 0) {
+      doneButtonRef.current?.focus();
+    }
+  }, [selectedFiles]);
+
   return (
     <>
       {/* Move File Dialog */}
@@ -211,7 +219,9 @@ export const Header = ({
               </IconButton>
               <Typography variant="h4" fontWeight={600}>
                 {selectedFiles?.length}{" "}
-                {isSelectDialog && limitSelected ? `/${limitSelected}` : null}
+                {isSelectDialog && limitSelected
+                  ? ` / ${limitSelected} `
+                  : null}
                 Selected
               </Typography>
             </Stack>
@@ -267,6 +277,7 @@ export const Header = ({
                   color="primary"
                   onClick={() => addImagesCallback(selectedFiles)}
                   startIcon={<CheckIcon fontSize="small" />}
+                  ref={doneButtonRef}
                 >
                   Done
                 </Button>


### PR DESCRIPTION
Closes https://github.com/zesty-io/manager-ui/issues/2189

Supports hitting enter key to trigger Done button after selecting media files and fixes text pacing