### PR TITLE
Fix: Unable to re-order child tree

### DIFF
--- a/src/apps/content-editor/src/app/components/ReorderNav/DragComponents/styles.less
+++ b/src/apps/content-editor/src/app/components/ReorderNav/DragComponents/styles.less
@@ -14,7 +14,6 @@
       display: flex;
       align-items: center;
       color: @zesty-blue;
-      pointer-events: none;
 
       &:hover,
       &:focus {


### PR DESCRIPTION
Removed `pointer-events: none` which prevents the element onClick

[reorder-fix.webm](https://github.com/zesty-io/manager-ui/assets/28705606/41c57092-7d3f-4506-86e7-a269c3e46ab1)
