### PR TITLE
Fix: Incorrect url in preview site generator api

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/MoreMenu.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/MoreMenu.tsx
@@ -68,7 +68,7 @@ export const MoreMenu = () => {
 
   const apiTypeEndpointMap: Partial<Record<ApiType, string>> = {
     "quick-access": `/-/instant/${itemZUID}.json`,
-    "site-generators": item ? `/${item?.web?.pathPart}/?toJSON` : "/?toJSON",
+    "site-generators": item ? `/${item?.web?.path}/?toJSON` : "/?toJSON",
   };
 
   const liveDomain = domains?.find((domain) => domain.branch == "live");


### PR DESCRIPTION
Closes #2271 
Closes #2280 

### Preview
[site-generator.webm](https://github.com/zesty-io/manager-ui/assets/28705606/287cbad8-9328-4954-b042-342749e0f458)
