### PR TITLE
Feature: Sidebar parent model update

### DIFF
--- a/src/apps/schema/src/app/components/CreateModelDialogue.tsx
+++ b/src/apps/schema/src/app/components/CreateModelDialogue.tsx
@@ -367,6 +367,7 @@ export const CreateModelDialogue = ({ onClose, modelType = "" }: Props) => {
                     parentZUID: value,
                   })
                 }
+                tooltip="Selecting a parent affects default routing and content navigation in the UI"
               />
               <Box>
                 <InputLabel>

--- a/src/apps/schema/src/app/components/FieldsListRight.tsx
+++ b/src/apps/schema/src/app/components/FieldsListRight.tsx
@@ -79,7 +79,7 @@ export const FieldsListRight = ({ model }: Props) => {
       case "parentZUID":
         body = {
           ...body,
-          parentZUID: newParentZUID,
+          parentZUID: newParentZUID ?? "0",
         };
         break;
 

--- a/src/apps/schema/src/app/components/FieldsListRight.tsx
+++ b/src/apps/schema/src/app/components/FieldsListRight.tsx
@@ -36,13 +36,20 @@ export const FieldsListRight = ({ model }: Props) => {
     }
   }, [model]);
 
-  const [updateContentModel, { isLoading }] = useUpdateContentModelMutation();
+  const [updateContentModel, { isLoading, isSuccess }] =
+    useUpdateContentModelMutation();
 
   useEffect(() => {
     if (model?.description) {
       setDescription(model?.description || "");
     }
   }, [model]);
+
+  useEffect(() => {
+    if (isSuccess) {
+      setshowSaveParentModelButton(false);
+    }
+  }, [isSuccess]);
 
   const handleCopyClick = (data: string) => {
     navigator?.clipboard
@@ -58,11 +65,28 @@ export const FieldsListRight = ({ model }: Props) => {
       });
   };
 
-  const handleSave = () => {
-    const body = {
-      ...model,
-      description,
-    };
+  const handleSave = (type: "description" | "parentZUID") => {
+    let body = { ...model };
+
+    switch (type) {
+      case "description":
+        body = {
+          ...body,
+          description,
+        };
+        break;
+
+      case "parentZUID":
+        body = {
+          ...body,
+          parentZUID: newParentZUID,
+        };
+        break;
+
+      default:
+        break;
+    }
+
     updateContentModel({
       ZUID: model.ZUID,
       body,
@@ -166,9 +190,8 @@ export const FieldsListRight = ({ model }: Props) => {
           <LoadingButton
             color="primary"
             loading={isLoading}
-            loadingPosition="start"
             variant="contained"
-            onClick={handleSave}
+            onClick={() => handleSave("parentZUID")}
             sx={{ mt: 1.5 }}
           >
             Save
@@ -202,7 +225,7 @@ export const FieldsListRight = ({ model }: Props) => {
           startIcon={<SaveRoundedIcon />}
           loadingPosition="start"
           variant="contained"
-          onClick={handleSave}
+          onClick={() => handleSave("description")}
           sx={{ mt: 1.5 }}
         >
           Save

--- a/src/apps/schema/src/app/components/FieldsListRight.tsx
+++ b/src/apps/schema/src/app/components/FieldsListRight.tsx
@@ -183,7 +183,6 @@ export const FieldsListRight = ({ model }: Props) => {
             setshowSaveParentModelButton(value !== model?.parentZUID);
             setNewParentZUID(value);
           }}
-          withTooltip={false}
           label="Model Parent"
         />
         {showSaveParentModelButton && (

--- a/src/apps/schema/src/app/components/FieldsListRight.tsx
+++ b/src/apps/schema/src/app/components/FieldsListRight.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
   Link,
   Tooltip,
+  Select,
 } from "@mui/material";
 import SaveRoundedIcon from "@mui/icons-material/SaveRounded";
 import LoadingButton from "@mui/lab/LoadingButton";
@@ -16,6 +17,7 @@ import CheckIcon from "@mui/icons-material/Check";
 import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
 import { ContentModel } from "../../../../../shell/services/types";
 import { useUpdateContentModelMutation } from "../../../../../shell/services/instance";
+import { SelectModelParentInput } from "./SelectModelParentInput";
 
 interface Props {
   model: ContentModel;
@@ -24,6 +26,15 @@ interface Props {
 export const FieldsListRight = ({ model }: Props) => {
   const [description, setDescription] = useState("");
   const [isCopied, setIsCopied] = useState(null);
+  const [newParentZUID, setNewParentZUID] = useState(null);
+  const [showSaveParentModelButton, setshowSaveParentModelButton] =
+    useState(false);
+
+  useEffect(() => {
+    if (model?.parentZUID) {
+      setNewParentZUID(model.parentZUID === "0" ? null : model.parentZUID);
+    }
+  }, [model]);
 
   const [updateContentModel, { isLoading }] = useUpdateContentModelMutation();
 
@@ -140,6 +151,31 @@ export const FieldsListRight = ({ model }: Props) => {
           ),
         }}
       />
+      <Box mt={3}>
+        <SelectModelParentInput
+          modelType={model?.type}
+          value={newParentZUID}
+          onChange={(value) => {
+            setshowSaveParentModelButton(value !== model?.parentZUID);
+            setNewParentZUID(value);
+          }}
+          withTooltip={false}
+          label="Model Parent"
+        />
+        {showSaveParentModelButton && (
+          <LoadingButton
+            color="primary"
+            loading={isLoading}
+            loadingPosition="start"
+            variant="contained"
+            onClick={handleSave}
+            sx={{ mt: 1.5 }}
+          >
+            Save
+          </LoadingButton>
+        )}
+      </Box>
+
       <InputLabel sx={{ mt: 3 }}>
         Description
         <Tooltip

--- a/src/apps/schema/src/app/components/SelectModelParentInput.tsx
+++ b/src/apps/schema/src/app/components/SelectModelParentInput.tsx
@@ -14,12 +14,16 @@ type SelectModelParentInputProps = {
   value: string;
   onChange: (value: string) => void;
   modelType: ModelType;
+  label?: string;
+  withTooltip?: boolean;
 };
 
 export const SelectModelParentInput = ({
   value,
   onChange,
   modelType,
+  label = "Select Model Parent",
+  withTooltip = true,
 }: SelectModelParentInputProps) => {
   const { data: navItems } = useGetContentNavItemsQuery();
 
@@ -43,16 +47,18 @@ export const SelectModelParentInput = ({
   return (
     <Box>
       <InputLabel>
-        Select Model Parent
-        <Tooltip
-          placement="top"
-          title="Selecting a parent affects default routing and content navigation in the UI"
-        >
-          <InfoRoundedIcon
-            sx={{ ml: 1, width: "10px", height: "10px" }}
-            color="action"
-          />
-        </Tooltip>
+        {label}
+        {withTooltip && (
+          <Tooltip
+            placement="top"
+            title="Selecting a parent affects default routing and content navigation in the UI"
+          >
+            <InfoRoundedIcon
+              sx={{ ml: 1, width: "10px", height: "10px" }}
+              color="action"
+            />
+          </Tooltip>
+        )}
       </InputLabel>
       <Autocomplete
         fullWidth

--- a/src/apps/schema/src/app/components/SelectModelParentInput.tsx
+++ b/src/apps/schema/src/app/components/SelectModelParentInput.tsx
@@ -15,7 +15,7 @@ type SelectModelParentInputProps = {
   onChange: (value: string) => void;
   modelType: ModelType;
   label?: string;
-  withTooltip?: boolean;
+  tooltip?: string;
 };
 
 export const SelectModelParentInput = ({
@@ -23,7 +23,7 @@ export const SelectModelParentInput = ({
   onChange,
   modelType,
   label = "Select Model Parent",
-  withTooltip = true,
+  tooltip = "",
 }: SelectModelParentInputProps) => {
   const { data: navItems } = useGetContentNavItemsQuery();
 
@@ -48,11 +48,8 @@ export const SelectModelParentInput = ({
     <Box>
       <InputLabel>
         {label}
-        {withTooltip && (
-          <Tooltip
-            placement="top"
-            title="Selecting a parent affects default routing and content navigation in the UI"
-          >
+        {tooltip && (
+          <Tooltip placement="top" title={tooltip}>
             <InfoRoundedIcon
               sx={{ ml: 1, width: "10px", height: "10px" }}
               color="action"

--- a/src/apps/schema/src/app/components/UpdateParentModelDialogue.tsx
+++ b/src/apps/schema/src/app/components/UpdateParentModelDialogue.tsx
@@ -81,6 +81,7 @@ export const UpdateParentModelDialogue = ({ onClose, model }: Props) => {
           modelType={model.type}
           value={newParentZUID}
           onChange={(value) => setNewParentZUID(value)}
+          tooltip="Selecting a parent affects default routing and content navigation in the UI"
         />
       </DialogContent>
       <DialogActions>


### PR DESCRIPTION
Allows users to update the model parent via the right sidebar
Closes #2188 

### Preview
[parent model.webm](https://github.com/zesty-io/manager-ui/assets/28705606/7ed1bbf5-13d3-42e3-9ada-51438f214cb6)
