### PR TITLE
Fix: Last row in multi-page content item gets cut off

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemList/ItemList.less
+++ b/src/apps/content-editor/src/app/views/ItemList/ItemList.less
@@ -4,7 +4,7 @@
 
   .TableWrap {
     // Parents height minus total height of actions container
-    height: calc(100vh - 54px - 52px);
+    height: calc(100vh - 166px);
   }
   .Display {
     font-size: 32px;


### PR DESCRIPTION
Closes #2278 

### Preview
[height fix.webm](https://github.com/zesty-io/manager-ui/assets/28705606/6021a49d-376d-469a-9992-42e20fef930b)
