### PR TITLE
Prevent infinite loop if a model's parent is itself

### DIFF
--- a/cypress/e2e/schema/models.spec.js
+++ b/cypress/e2e/schema/models.spec.js
@@ -75,4 +75,21 @@ describe("Schema: Models", () => {
     cy.getBySelector("breadcrumbs").find(".MuiBreadcrumbs-li").first().click();
     cy.location("pathname").should("eq", "/schema");
   });
+  it("Cannot set it's model parent to be itself", () => {
+    cy.waitOn(
+      "/v1/content/models/6-ce80dbfe90-ptjpm6/fields?showDeleted=true",
+      () => {
+        cy.waitOn("/bin/1-6c9618c-r26pt/groups", () => {
+          cy.waitOn("/v1/content/models", () => {
+            cy.visit("/schema/6-ce80dbfe90-ptjpm6/fields");
+          });
+        });
+      }
+    );
+
+    cy.getBySelector("ModelParentSelector")
+      .find("input")
+      .type("Schema Fields Cypress Test DO NOT DELETE");
+    cy.get(".MuiAutocomplete-noOptions").contains("No options");
+  });
 });

--- a/cypress/e2e/schema/models.spec.js
+++ b/cypress/e2e/schema/models.spec.js
@@ -75,7 +75,7 @@ describe("Schema: Models", () => {
     cy.getBySelector("breadcrumbs").find(".MuiBreadcrumbs-li").first().click();
     cy.location("pathname").should("eq", "/schema");
   });
-  it("Cannot set it's model parent to be itself", () => {
+  it("Cannot set its model parent to be itself", () => {
     cy.waitOn(
       "/v1/content/models/6-ce80dbfe90-ptjpm6/fields?showDeleted=true",
       () => {
@@ -91,5 +91,22 @@ describe("Schema: Models", () => {
       .find("input")
       .type("Schema Fields Cypress Test DO NOT DELETE");
     cy.get(".MuiAutocomplete-noOptions").contains("No options");
+  });
+  it("Can render a model that has parented itself", () => {
+    cy.waitOn(
+      "/v1/content/models/6-96e0f1a7fe-vkjt20/fields?showDeleted=true",
+      () => {
+        cy.waitOn("/bin/1-6c9618c-r26pt/groups", () => {
+          cy.waitOn("/v1/content/models", () => {
+            cy.visit("/schema/6-96e0f1a7fe-vkjt20/fields");
+          });
+        });
+      }
+    );
+
+    cy.getBySelector("breadcrumbs")
+      .find(".MuiBreadcrumbs-li")
+      .eq(1)
+      .contains("Model parenting itself");
   });
 });

--- a/src/apps/schema/src/app/components/ModelBreadcrumbs.tsx
+++ b/src/apps/schema/src/app/components/ModelBreadcrumbs.tsx
@@ -42,7 +42,11 @@ export const ModelBreadcrumbs: FC<Props> = ({ modelZUID }) => {
               history.push(`/schema/${parentNavData.contentModelZUID}/fields`),
           });
 
-          parentNavZUID = parentContentModel?.parentZUID;
+          // Prevent infinite loop if the model's parent is itself
+          parentNavZUID =
+            parentContentModel?.parentZUID !== parentNavZUID
+              ? parentContentModel?.parentZUID
+              : null;
         } else {
           parentNavZUID = null;
         }

--- a/src/apps/schema/src/app/components/SelectModelParentInput.tsx
+++ b/src/apps/schema/src/app/components/SelectModelParentInput.tsx
@@ -6,6 +6,7 @@ import {
   Autocomplete,
 } from "@mui/material";
 import { useMemo } from "react";
+import { useParams } from "react-router";
 import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
 import { useGetContentNavItemsQuery } from "../../../../../shell/services/instance";
 import { ContentNavItem, ModelType } from "../../../../../shell/services/types";
@@ -25,6 +26,7 @@ export const SelectModelParentInput = ({
   label = "Select Model Parent",
   tooltip = "",
 }: SelectModelParentInputProps) => {
+  const { id } = useParams<{ id: string }>();
   const { data: navItems } = useGetContentNavItemsQuery();
 
   const parents = useMemo(() => {
@@ -39,7 +41,9 @@ export const SelectModelParentInput = ({
         );
       }
 
-      return _navItems?.sort((a, b) => a.label.localeCompare(b.label));
+      return _navItems
+        ?.filter((item) => item.contentModelZUID !== id)
+        ?.sort((a, b) => a.label.localeCompare(b.label));
     }
 
     return [];

--- a/src/apps/schema/src/app/components/SelectModelParentInput.tsx
+++ b/src/apps/schema/src/app/components/SelectModelParentInput.tsx
@@ -62,6 +62,7 @@ export const SelectModelParentInput = ({
         )}
       </InputLabel>
       <Autocomplete
+        data-cy="ModelParentSelector"
         fullWidth
         renderInput={(params) => <TextField {...params} placeholder="None" />}
         value={navItems?.find((m) => m.ZUID === value) || null}


### PR DESCRIPTION
Context: https://zesty-io.slack.com/archives/C050120G5/p1698191024727889

Prevent the model breadcrumbs component from going on an infinite loop if a model's parent is itself.

### Preview
[breadcrumb-infinite-loop-fix.webm](https://github.com/zesty-io/manager-ui/assets/28705606/b67cf463-a210-4b0f-b13a-407337a676c9)
