### PR TITLE
In-app announcement popup enhancements

### DIFF
--- a/cypress/e2e/content/analyticsDashboard.spec.js
+++ b/cypress/e2e/content/analyticsDashboard.spec.js
@@ -1,7 +1,6 @@
 describe("Analytics dashboard", () => {
   before(() => {
     cy.waitOn("*getPropertyList*", () => {
-      cy.blockAnnouncements();
       cy.visit("/content");
     });
   });

--- a/cypress/e2e/content/content.spec.js
+++ b/cypress/e2e/content/content.spec.js
@@ -3,7 +3,6 @@ describe("Content Specs", () => {
 
   describe("content drawer", () => {
     before(() => {
-      cy.blockAnnouncements();
       cy.waitOn("/v1/content/models*", () => {
         cy.visit("/content/6-556370-8sh47g/7-b939a4-457q19");
       });
@@ -56,7 +55,6 @@ describe("Content Specs", () => {
 
   describe("editing content", () => {
     before(() => {
-      cy.blockAnnouncements();
       cy.waitOn("/v1/content/models*", () => {
         cy.visit("/content/6-556370-8sh47g/7-b939a4-457q19");
       });

--- a/cypress/e2e/content/list.spec.js
+++ b/cypress/e2e/content/list.spec.js
@@ -1,6 +1,5 @@
 describe("Content List", () => {
   before(() => {
-    cy.blockAnnouncements();
     cy.waitOn("/v1/content/models*", () => {
       cy.visit("/content/6-0c960c-d1n0kx");
     });

--- a/cypress/e2e/content/navigation.spec.js
+++ b/cypress/e2e/content/navigation.spec.js
@@ -1,6 +1,5 @@
 describe("Navigation through content editor", () => {
   before(() => {
-    cy.blockAnnouncements();
     cy.waitOn("/v1/env/nav", () => {
       cy.visit("/content");
     });

--- a/cypress/e2e/content/singlePageAnalytics.spec.js
+++ b/cypress/e2e/content/singlePageAnalytics.spec.js
@@ -1,6 +1,5 @@
 describe("Single Page Analytics", () => {
   before(() => {
-    cy.blockAnnouncements();
     cy.waitOn("*getPropertyList*", () => {
       cy.visit("/content/6-a1a600-k0b6f0/7-a1be38-1b42ht/analytics");
     });

--- a/cypress/e2e/media/folders.spec.js
+++ b/cypress/e2e/media/folders.spec.js
@@ -1,6 +1,5 @@
 describe("Media Folders", () => {
   before(() => {
-    cy.blockAnnouncements();
     cy.waitOn("*groups*", () => {
       cy.visit("/media");
     });

--- a/cypress/e2e/reports/activity-log/activity-log.spec.js
+++ b/cypress/e2e/reports/activity-log/activity-log.spec.js
@@ -138,7 +138,6 @@ describe("Reports > Activity Log > Home", () => {
 
   describe("Resources View", () => {
     before(() => {
-      cy.blockAnnouncements();
       cy.waitOn("/v1/env/audits*", () => {
         cy.visit(
           "/reports/activity-log/resources?from=2022-07-14&to=2022-07-16"

--- a/cypress/e2e/schema/field.spec.js
+++ b/cypress/e2e/schema/field.spec.js
@@ -53,7 +53,6 @@ describe("Schema: Fields", () => {
   const timestamp = Date.now();
 
   before(() => {
-    cy.blockAnnouncements();
     cy.waitOn(
       "/v1/content/models/6-ce80dbfe90-ptjpm6/fields?showDeleted=true",
       () => {

--- a/cypress/e2e/schema/models.spec.js
+++ b/cypress/e2e/schema/models.spec.js
@@ -1,7 +1,6 @@
 const SEARCH_TERM = `cypress ${Date.now()}`;
 describe("Schema: Models", () => {
   before(() => {
-    cy.blockAnnouncements();
     cy.waitOn("/v1/content/models", () => {
       cy.visit("/schema");
     });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,6 +27,7 @@ Cypress.Commands.add("blockLock", () => {
 
 Cypress.Commands.add("waitOn", (path, cb) => {
   cy.intercept(path).as("waitingOn");
+  cy.blockAnnouncements();
   cb();
   cy.wait("@waitingOn", {
     timeout: 30000,
@@ -46,10 +47,7 @@ Cypress.Commands.add("getBySelector", (selector, ...args) => {
 });
 
 Cypress.Commands.add("blockAnnouncements", () => {
-  cy.intercept(
-    "https://www.zesty.io/-/instant/6-90fbdcadfc-4lc0s5.json",
-    (req) => {
-      req.reply({});
-    }
-  );
+  cy.intercept("/-/instant/6-90fbdcadfc-4lc0s5.json", (req) => {
+    req.reply({});
+  });
 });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -42,6 +42,9 @@ before(() => {
   // throw undefined errors. To ensure these are caught during testing we always drop
   // indexdb before starting tests
   indexedDB.deleteDatabase("zesty");
+
+  // Blocks the api call to render the announcement popup
+  cy.blockAnnouncements();
 });
 
 // Before each test in spec

--- a/src/shell/app.config.js
+++ b/src/shell/app.config.js
@@ -44,6 +44,9 @@ module.exports = {
 
     TIME_DISPLAY_FORMAT: "MMMM Do YYYY, [at] h:mm a",
     TIME_UTC_FORMAT: "YYYY-MM-DD HH:mm:ss",
+
+    MARKETING_INSTANCE_DOMAIN: "https://www.zesty.io/",
+    MARKETING_ANNOUNCEMENT_MODEL_ZUID: "6-90fbdcadfc-4lc0s5",
   },
   stage: {
     VERSION: pkg.version,
@@ -86,6 +89,9 @@ module.exports = {
 
     TIME_DISPLAY_FORMAT: "MMMM Do YYYY, [at] h:mm a",
     TIME_UTC_FORMAT: "YYYY-MM-DD HH:mm:ss",
+
+    MARKETING_INSTANCE_DOMAIN: "https://kfg6bckb-dev.preview.stage.zesty.io/",
+    MARKETING_ANNOUNCEMENT_MODEL_ZUID: "6-90fbdcadfc-4lc0s5",
   },
   development: {
     VERSION: pkg.version,
@@ -130,6 +136,9 @@ module.exports = {
 
     TIME_DISPLAY_FORMAT: "MMMM Do YYYY, [at] h:mm a",
     TIME_UTC_FORMAT: "YYYY-MM-DD HH:mm:ss",
+
+    MARKETING_INSTANCE_DOMAIN: "https://kfg6bckb-dev.preview.stage.zesty.io/",
+    MARKETING_ANNOUNCEMENT_MODEL_ZUID: "6-90fbdcadfc-4lc0s5",
   },
   local: {
     VERSION: pkg.version,
@@ -170,5 +179,8 @@ module.exports = {
 
     TIME_DISPLAY_FORMAT: "MMMM Do YYYY, [at] h:mm a",
     TIME_UTC_FORMAT: "YYYY-MM-DD HH:mm:ss",
+
+    MARKETING_INSTANCE_DOMAIN: "https://kfg6bckb-dev.preview.stage.zesty.io/",
+    MARKETING_ANNOUNCEMENT_MODEL_ZUID: "6-90fbdcadfc-4lc0s5",
   },
 };

--- a/src/shell/components/InAppAnnouncement/index.tsx
+++ b/src/shell/components/InAppAnnouncement/index.tsx
@@ -66,6 +66,9 @@ export const InAppAnnouncement = () => {
         >
           <DialogContent sx={{ p: 0 }}>
             <Stack
+              component="a"
+              href={announcementData?.announcement_link}
+              target="_blank"
               m={2.5}
               p={2.5}
               width={600}
@@ -86,14 +89,6 @@ export const InAppAnnouncement = () => {
                 }
                 maxWidth="100%"
                 maxHeight="100%"
-                sx={{
-                  cursor: "pointer",
-                }}
-                onClick={() => {
-                  if (announcementData?.announcement_link) {
-                    window.open(announcementData?.announcement_link, "_blank");
-                  }
-                }}
               />
             </Stack>
             <Stack gap={1} px={2.5} pb={2.5}>
@@ -119,9 +114,8 @@ export const InAppAnnouncement = () => {
                 variant="outlined"
                 startIcon={<OpenInNewRoundedIcon />}
                 disabled={!announcementData?.announcement_link}
-                onClick={() =>
-                  window.open(announcementData?.announcement_link, "_blank")
-                }
+                href={announcementData?.announcement_link}
+                target="_blank"
               >
                 Read Announcement
               </Button>
@@ -130,9 +124,8 @@ export const InAppAnnouncement = () => {
                   <Button
                     variant="contained"
                     startIcon={<PlayArrowRoundedIcon />}
-                    onClick={() =>
-                      window.open(announcementData?.video_link, "_blank")
-                    }
+                    href={announcementData?.video_link}
+                    target="_blank"
                   >
                     Show Video
                   </Button>
@@ -142,9 +135,8 @@ export const InAppAnnouncement = () => {
                   <Button
                     variant="contained"
                     startIcon={<ScheduledRoundedIcon />}
-                    onClick={() =>
-                      window.open(announcementData?.training_link, "_blank")
-                    }
+                    href={announcementData?.training_link}
+                    target="_blank"
                   >
                     Schedule Training
                   </Button>

--- a/src/shell/components/InAppAnnouncement/index.tsx
+++ b/src/shell/components/InAppAnnouncement/index.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { ThemeProvider } from "@mui/material";
 import { theme } from "@zesty-io/material";
 import moment from "moment";
-import { useLocalStorage } from "react-use";
 import {
   Dialog,
   DialogContent,
@@ -15,15 +14,15 @@ import {
 import OpenInNewRoundedIcon from "@mui/icons-material/OpenInNewRounded";
 import ScheduledRoundedIcon from "@mui/icons-material/ScheduleRounded";
 import PlayArrowRoundedIcon from "@mui/icons-material/PlayArrowRounded";
+import { useCookie } from "react-use";
 
 import { useGetAnnouncementsQuery } from "../../services/marketing";
 
 export const InAppAnnouncement = () => {
-  const [readAnnouncements, setReadAnnouncements] = useLocalStorage(
-    "zesty:readAnnouncements",
-    []
-  );
   const { data: announcements } = useGetAnnouncementsQuery();
+  const [readAnnouncementsCookie, updateReadAnnouncementsCookie] = useCookie(
+    "READ_ANNOUNCEMENTS_ZUID"
+  );
 
   const latestAnnouncement = useMemo(() => {
     if (announcements?.length) {
@@ -33,9 +32,19 @@ export const InAppAnnouncement = () => {
     }
   }, [announcements]);
 
+  const readAnnouncements = useMemo(() => {
+    return readAnnouncementsCookie ? JSON.parse(readAnnouncementsCookie) : [];
+  }, [readAnnouncementsCookie]);
+
   const onIgnoreAnnouncement = (zuid: string) => {
-    if (!readAnnouncements.includes(zuid)) {
-      setReadAnnouncements([...readAnnouncements, zuid]);
+    if (!readAnnouncements?.includes(zuid)) {
+      updateReadAnnouncementsCookie(
+        JSON.stringify([...readAnnouncements, zuid]),
+        {
+          // @ts-ignore
+          domain: __CONFIG__.COOKIE_DOMAIN,
+        }
+      );
     }
   };
 

--- a/src/shell/components/InAppAnnouncement/index.tsx
+++ b/src/shell/components/InAppAnnouncement/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
 import { ThemeProvider } from "@mui/material";
 import { theme } from "@zesty-io/material";
 import moment from "moment";
@@ -19,132 +19,122 @@ import PlayArrowRoundedIcon from "@mui/icons-material/PlayArrowRounded";
 import { useGetAnnouncementsQuery } from "../../services/marketing";
 
 export const InAppAnnouncement = () => {
-  const [activeAnnouncementIndex, setActiveAnnouncementIndex] = useState(0);
   const [readAnnouncements, setReadAnnouncements] = useLocalStorage(
     "zesty:readAnnouncements",
     []
   );
   const { data: announcements } = useGetAnnouncementsQuery();
 
-  const unreadAnnouncements = useMemo(() => {
+  const latestAnnouncement = useMemo(() => {
     if (announcements?.length) {
-      return announcements
-        .filter((announcement) => {
-          const isInPublishRange = moment().isBetween(
-            moment(announcement?.start_date_and_time),
-            moment(announcement?.end_date_and_time)
-          );
-
-          return (
-            isInPublishRange && !readAnnouncements.includes(announcement?.zuid)
-          );
-        })
-        ?.sort((a, b) => moment(b.created_at).diff(a.created_at));
+      return [...announcements].sort((a, b) =>
+        moment(b.created_at).diff(moment(a.created_at))
+      )?.[0];
     }
   }, [announcements]);
 
   const onIgnoreAnnouncement = (zuid: string) => {
     if (!readAnnouncements.includes(zuid)) {
       setReadAnnouncements([...readAnnouncements, zuid]);
-      setActiveAnnouncementIndex(activeAnnouncementIndex + 1);
     }
   };
 
-  const announcementData = unreadAnnouncements
-    ? unreadAnnouncements[activeAnnouncementIndex]
-    : null;
+  if (
+    !latestAnnouncement ||
+    readAnnouncements.includes(latestAnnouncement.zuid)
+  ) {
+    return <></>;
+  }
 
   return (
     <ThemeProvider theme={theme}>
-      {announcementData && (
-        <Dialog
-          open
-          onClose={() => onIgnoreAnnouncement(announcementData?.zuid)}
-          maxWidth="md"
-          PaperProps={{ sx: { width: 640 } }}
-          data-cy="AnnouncementPopup"
-        >
-          <DialogContent sx={{ p: 0 }}>
-            <Stack
-              component="a"
-              href={announcementData?.announcement_link}
-              target="_blank"
-              m={2.5}
-              p={2.5}
-              width={600}
-              height={340}
-              sx={{
-                background: "linear-gradient(90deg, #EC4A0A 0%, #FD853A 100%)",
-              }}
-              alignItems="center"
-              justifyContent="center"
-              boxSizing="border-box"
-            >
-              <Box
-                component="img"
-                alt="announcement-banner-image"
-                src={
-                  `${announcementData?.feature_image?.data[0]?.url}?fit=cover&width=560&height=300` ??
-                  ""
-                }
-                maxWidth="100%"
-                maxHeight="100%"
-              />
-            </Stack>
-            <Stack gap={1} px={2.5} pb={2.5}>
-              <Typography variant="h4" fontWeight={700}>
-                {announcementData?.title}
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                {announcementData?.description}
-              </Typography>
-            </Stack>
-          </DialogContent>
-          <DialogActions sx={{ justifyContent: "space-between" }}>
+      <Dialog
+        open
+        onClose={() => onIgnoreAnnouncement(latestAnnouncement?.zuid)}
+        maxWidth="md"
+        PaperProps={{ sx: { width: 640 } }}
+        data-cy="AnnouncementPopup"
+      >
+        <DialogContent sx={{ p: 0 }}>
+          <Stack
+            component="a"
+            href={latestAnnouncement?.announcement_link}
+            target="_blank"
+            m={2.5}
+            p={2.5}
+            width={600}
+            height={340}
+            sx={{
+              background: "linear-gradient(90deg, #EC4A0A 0%, #FD853A 100%)",
+            }}
+            alignItems="center"
+            justifyContent="center"
+            boxSizing="border-box"
+          >
+            <Box
+              component="img"
+              alt="announcement-banner-image"
+              src={
+                `${latestAnnouncement?.feature_image?.data[0]?.url}?fit=cover&width=560&height=300` ??
+                ""
+              }
+              maxWidth="100%"
+              maxHeight="100%"
+            />
+          </Stack>
+          <Stack gap={1} px={2.5} pb={2.5}>
+            <Typography variant="h4" fontWeight={700}>
+              {latestAnnouncement?.title}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {latestAnnouncement?.description}
+            </Typography>
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ justifyContent: "space-between" }}>
+          <Button
+            variant="text"
+            color="inherit"
+            onClick={() => onIgnoreAnnouncement(latestAnnouncement?.zuid)}
+            data-cy="IgnoreAnnouncementButton"
+          >
+            Ignore
+          </Button>
+          <Stack direction="row" gap={1}>
             <Button
-              variant="text"
-              color="inherit"
-              onClick={() => onIgnoreAnnouncement(announcementData?.zuid)}
-              data-cy="IgnoreAnnouncementButton"
+              variant="outlined"
+              startIcon={<OpenInNewRoundedIcon />}
+              disabled={!latestAnnouncement?.announcement_link}
+              href={latestAnnouncement?.announcement_link}
+              target="_blank"
             >
-              Ignore
+              Read Announcement
             </Button>
-            <Stack direction="row" gap={1}>
-              <Button
-                variant="outlined"
-                startIcon={<OpenInNewRoundedIcon />}
-                disabled={!announcementData?.announcement_link}
-                href={announcementData?.announcement_link}
-                target="_blank"
-              >
-                Read Announcement
-              </Button>
-              {announcementData?.cta_type === "play_video" &&
-                announcementData?.video_link && (
-                  <Button
-                    variant="contained"
-                    startIcon={<PlayArrowRoundedIcon />}
-                    href={announcementData?.video_link}
-                    target="_blank"
-                  >
-                    Show Video
-                  </Button>
-                )}
-              {announcementData?.cta_type === "schedule_training" &&
-                announcementData?.training_link && (
-                  <Button
-                    variant="contained"
-                    startIcon={<ScheduledRoundedIcon />}
-                    href={announcementData?.training_link}
-                    target="_blank"
-                  >
-                    Schedule Training
-                  </Button>
-                )}
-            </Stack>
-          </DialogActions>
-        </Dialog>
-      )}
+            {latestAnnouncement?.cta_type === "play_video" &&
+              latestAnnouncement?.video_link && (
+                <Button
+                  variant="contained"
+                  startIcon={<PlayArrowRoundedIcon />}
+                  href={latestAnnouncement?.video_link}
+                  target="_blank"
+                >
+                  Show Video
+                </Button>
+              )}
+            {latestAnnouncement?.cta_type === "schedule_training" &&
+              latestAnnouncement?.training_link && (
+                <Button
+                  variant="contained"
+                  startIcon={<ScheduledRoundedIcon />}
+                  href={latestAnnouncement?.training_link}
+                  target="_blank"
+                >
+                  Schedule Training
+                </Button>
+              )}
+          </Stack>
+        </DialogActions>
+      </Dialog>
     </ThemeProvider>
   );
 };

--- a/src/shell/components/InAppAnnouncement/index.tsx
+++ b/src/shell/components/InAppAnnouncement/index.tsx
@@ -67,7 +67,7 @@ export const InAppAnnouncement = () => {
           <DialogContent sx={{ p: 0 }}>
             <Stack
               m={2.5}
-              p={3}
+              p={2.5}
               width={600}
               height={340}
               sx={{
@@ -80,7 +80,10 @@ export const InAppAnnouncement = () => {
               <Box
                 component="img"
                 alt="announcement-banner-image"
-                src={announcementData?.feature_image?.data[0]?.url ?? ""}
+                src={
+                  `${announcementData?.feature_image?.data[0]?.url}?fit=cover&width=560&height=300` ??
+                  ""
+                }
                 maxWidth="100%"
                 maxHeight="100%"
                 sx={{

--- a/src/shell/services/marketing.ts
+++ b/src/shell/services/marketing.ts
@@ -4,11 +4,16 @@ import { Announcement } from "./types";
 
 export const marketingApi = createApi({
   reducerPath: "marketingApi",
-  baseQuery: fetchBaseQuery({ baseUrl: "https://www.zesty.io/" }),
+  baseQuery: fetchBaseQuery({
+    // @ts-ignore
+    baseUrl: `${__CONFIG__.MARKETING_INSTANCE_DOMAIN}`,
+  }),
   endpoints: (builder) => ({
     // Get announcements via instant api from the marketing instance
     getAnnouncements: builder.query<Announcement[], void>({
-      query: () => "/-/instant/6-90fbdcadfc-4lc0s5.json",
+      query: () =>
+        // @ts-ignore
+        `/-/instant/${__CONFIG__.MARKETING_ANNOUNCEMENT_MODEL_ZUID}.json`,
       transformResponse: (response: { data: any[] }) => {
         // Filter out other languages if exists, this makes sure that announcements don't get repeatedly shown per language
         return response?.data?.reduce((accu, currVal) => {


### PR DESCRIPTION
- Add href to mui buttons so they function as links
- Set env variables for the marketing instant api url
- Set width and height to image source url
- Only show most recent announcement created
- Store announcement read preferences via cookies
- Update cypress tests so that the announcement api call is blocked by default for each test

### Preview
![announcement](https://github.com/zesty-io/manager-ui/assets/28705606/77e38800-dc52-41ce-8442-f6c3d5ebff58)
