### PR TITLE
Make read announcements cookie permanent

### DIFF
--- a/src/shell/components/InAppAnnouncement/index.tsx
+++ b/src/shell/components/InAppAnnouncement/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { ThemeProvider } from "@mui/material";
 import { theme } from "@zesty-io/material";
 import moment from "moment";
@@ -23,6 +23,19 @@ export const InAppAnnouncement = () => {
   const [readAnnouncementsCookie, updateReadAnnouncementsCookie] = useCookie(
     "READ_ANNOUNCEMENTS_ZUID"
   );
+  const cookieOptions = {
+    // @ts-ignore
+    domain: __CONFIG__.COOKIE_DOMAIN,
+    expires: moment().add(1, "year").toDate(),
+  };
+
+  useEffect(() => {
+    // Initializes and keeps on bumping the read announcements cookie to permanently keep it on the browser
+    updateReadAnnouncementsCookie(
+      JSON.stringify(readAnnouncements ?? []),
+      cookieOptions
+    );
+  }, []);
 
   const latestAnnouncement = useMemo(() => {
     if (announcements?.length) {
@@ -49,10 +62,7 @@ export const InAppAnnouncement = () => {
     if (!readAnnouncements?.includes(zuid)) {
       updateReadAnnouncementsCookie(
         JSON.stringify([...readAnnouncements, zuid]),
-        {
-          // @ts-ignore
-          domain: __CONFIG__.COOKIE_DOMAIN,
-        }
+        cookieOptions
       );
     }
   };

--- a/src/shell/components/InAppAnnouncement/index.tsx
+++ b/src/shell/components/InAppAnnouncement/index.tsx
@@ -31,8 +31,12 @@ export const InAppAnnouncement = () => {
 
   useEffect(() => {
     // Initializes and keeps on bumping the read announcements cookie to permanently keep it on the browser
+    const parsedAnnouncementZuids = readAnnouncementsCookie
+      ? JSON.parse(readAnnouncementsCookie)
+      : [];
+
     updateReadAnnouncementsCookie(
-      JSON.stringify(readAnnouncements ?? []),
+      JSON.stringify(parsedAnnouncementZuids),
       cookieOptions
     );
   }, []);


### PR DESCRIPTION
Add a cookie expiration to 1 year to prevent cookies from being cleared when browser is closed

Closes #2347
