### PR TITLE
Various WYSIWYG enhancements

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/Field/FieldShell.tsx
+++ b/src/apps/content-editor/src/app/components/Editor/Field/FieldShell.tsx
@@ -144,7 +144,11 @@ export const FieldShell = ({
         </Stack>
       </Stack>
       {settings?.description && (
-        <Typography variant="body2" color="text.secondary">
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ overflowWrap: "break-word" }}
+        >
           {settings?.description}
         </Typography>
       )}

--- a/src/shell/components/FieldTypeTinyMCE/FieldTypeTinyMCE.js
+++ b/src/shell/components/FieldTypeTinyMCE/FieldTypeTinyMCE.js
@@ -128,7 +128,7 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE(props) {
             // loading the default which is not available
             content_css: [
               props.contentCSS,
-              "https://fonts.googleapis.com/css?family=Mulish",
+              "https://fonts.googleapis.com/css?family=Mulish:wght@400;500;600;700",
             ],
 
             content_style:

--- a/src/shell/components/FieldTypeTinyMCE/FieldTypeTinyMCE.js
+++ b/src/shell/components/FieldTypeTinyMCE/FieldTypeTinyMCE.js
@@ -128,7 +128,7 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE(props) {
             // loading the default which is not available
             content_css: [
               props.contentCSS,
-              "https://fonts.googleapis.com/css?family=Mulish:wght@400;500;600;700",
+              "https://fonts.googleapis.com/css2?family=Mulish:wght@400;500;600;700",
             ],
 
             content_style:

--- a/src/shell/components/FieldTypeTinyMCE/FieldTypeTinyMCE.js
+++ b/src/shell/components/FieldTypeTinyMCE/FieldTypeTinyMCE.js
@@ -132,7 +132,7 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE(props) {
             ],
 
             content_style:
-              "body { font-family: 'Mulish', Arial, sans-serif;  } img { max-width: 100%; } h1, h2, h3, h4, h5, h6, strong { font-weight: 700; }",
+              "body { font-family: 'Mulish', Arial, sans-serif;  } img { width: 100%; } h1, h2, h3, h4, h5, h6, strong { font-weight: 700; }",
 
             // Customize editor buttons and actions
             setup: function (editor) {

--- a/src/shell/components/FieldTypeTinyMCE/FieldTypeTinyMCE.js
+++ b/src/shell/components/FieldTypeTinyMCE/FieldTypeTinyMCE.js
@@ -131,7 +131,8 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE(props) {
               "https://fonts.googleapis.com/css?family=Mulish",
             ],
 
-            content_style: "body { font-family: 'Mulish', Arial, sans-serif  }",
+            content_style:
+              "body { font-family: 'Mulish', Arial, sans-serif;  } img { max-width: 100%; } h1, h2, h3, h4, h5, h6, strong { font-weight: 700; }",
 
             // Customize editor buttons and actions
             setup: function (editor) {

--- a/src/shell/components/FieldTypeTinyMCE/FieldTypeTinyMCE.js
+++ b/src/shell/components/FieldTypeTinyMCE/FieldTypeTinyMCE.js
@@ -107,7 +107,7 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE(props) {
             // editor settings
             branding: false,
             menubar: false,
-            object_resizing: true,
+            object_resizing: "table",
 
             // Allows for embeds with script tags
             // extended_valid_elements: "script[src|async|defer|type|charset]",


### PR DESCRIPTION
- Update font-weights for heading and bold texts in the wysiwyg editor
- Fit images to editor width
- Wrap overflowing field description text

NOTE: The changes here will be for the old/current wysiwyg we have on prod

![wysiwyg](https://github.com/zesty-io/manager-ui/assets/28705606/df8b00bd-1314-4994-9ca6-f02d8c5c1eaa)

Closes #2371 
Closes #2367 
Closes #2348 