### PR TITLE
In-app announcement timezone

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
@@ -901,7 +901,6 @@ export const Field = ({
         },
         [onChange]
       );
-
       return (
         <FieldShell settings={fieldData} errors={errors}>
           <Box maxWidth={360}>

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
@@ -902,9 +902,6 @@ export const Field = ({
         [onChange]
       );
 
-      // Convert the UCT+0 date and time value to local date and time
-      const localDateTime = value ? moment.utc(value).local().toDate() : null;
-
       return (
         <FieldShell settings={fieldData} errors={errors}>
           <Box maxWidth={360}>

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
@@ -897,17 +897,30 @@ export const Field = ({
     case "datetime":
       const onDateTimeChange = useCallback(
         (value, name, datatype) => {
-          onChange(moment(value).format("YYYY-MM-DD HH:mm:ss"), name, datatype);
+          const utc0DateTime = moment.utc(value).format("YYYY-MM-DD HH:mm:ss");
+
+          console.log("utc 0", utc0DateTime);
+          console.log(
+            "utc 0 to local time",
+            moment.utc(utc0DateTime).local().format("YYYY-MM-DD HH:mm:ss")
+          );
+
+          // Date and time values converted to UTC+0
+          onChange(utc0DateTime, name, datatype);
         },
         [onChange]
       );
+
+      // Convert the UCT+0 date and time value to local date and time
+      const localDateTime = value ? moment.utc(value).local().toDate() : null;
+
       return (
         <FieldShell settings={fieldData} errors={errors}>
           <Box maxWidth={360}>
             <FieldTypeDateTime
               name={name}
               required={required}
-              value={value ? new Date(value) : null}
+              value={localDateTime}
               inputFormat="yyyy-MM-dd HH:mm:ss.SSSSSS"
               onChange={(date) => onDateTimeChange(date, name, datatype)}
               error={errors && Object.values(errors)?.some((error) => !!error)}

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
@@ -897,16 +897,7 @@ export const Field = ({
     case "datetime":
       const onDateTimeChange = useCallback(
         (value, name, datatype) => {
-          const utc0DateTime = moment.utc(value).format("YYYY-MM-DD HH:mm:ss");
-
-          console.log("utc 0", utc0DateTime);
-          console.log(
-            "utc 0 to local time",
-            moment.utc(utc0DateTime).local().format("YYYY-MM-DD HH:mm:ss")
-          );
-
-          // Date and time values converted to UTC+0
-          onChange(utc0DateTime, name, datatype);
+          onChange(moment(value).format("YYYY-MM-DD HH:mm:ss"), name, datatype);
         },
         [onChange]
       );
@@ -920,7 +911,7 @@ export const Field = ({
             <FieldTypeDateTime
               name={name}
               required={required}
-              value={localDateTime}
+              value={value ? new Date(value) : null}
               inputFormat="yyyy-MM-dd HH:mm:ss.SSSSSS"
               onChange={(date) => onDateTimeChange(date, name, datatype)}
               error={errors && Object.values(errors)?.some((error) => !!error)}

--- a/src/shell/components/InAppAnnouncement/index.tsx
+++ b/src/shell/components/InAppAnnouncement/index.tsx
@@ -47,6 +47,7 @@ export const InAppAnnouncement = () => {
         moment(b.created_at).diff(moment(a.created_at))
       )?.[0];
 
+      // TODO: Convert all moment values below to UTC+0
       if (
         moment().isBetween(
           moment(latest?.start_date_and_time),

--- a/src/shell/components/InAppAnnouncement/index.tsx
+++ b/src/shell/components/InAppAnnouncement/index.tsx
@@ -47,12 +47,13 @@ export const InAppAnnouncement = () => {
         moment(b.created_at).diff(moment(a.created_at))
       )?.[0];
 
-      // TODO: Convert all moment values below to UTC+0
       if (
-        moment().isBetween(
-          moment(latest?.start_date_and_time),
-          moment(latest?.end_date_and_time)
-        )
+        moment
+          .utc()
+          .isBetween(
+            moment.utc(latest?.start_date_and_time),
+            moment.utc(latest?.end_date_and_time)
+          )
       ) {
         return latest;
       }


### PR DESCRIPTION
Closes #2370 

Makes sure that all times are being converted to utc+0 to determine when to show/hide in-app announcements