### PR TITLE
Cypress test runner use old chrome headless

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -13,6 +13,20 @@ module.exports = defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     setupNodeEvents(on, config) {
+      on("before:browser:launch", (browser, launchOptions) => {
+        if (browser.name === "chrome" && browser.isHeadless) {
+          launchOptions.args = launchOptions.args.map((arg) => {
+            if (arg === "--headless") {
+              return "--headless=old";
+            }
+
+            return arg;
+          });
+        }
+
+        return launchOptions;
+      });
+
       return require("./cypress/plugins/index.js")(on, config);
     },
     baseUrl: "http://8-f48cf3a682-7fthvk.manager.dev.zesty.io:8080/",

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -15,13 +15,7 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       on("before:browser:launch", (browser, launchOptions) => {
         if (browser.name === "chrome" && browser.isHeadless) {
-          launchOptions.args = launchOptions.args.map((arg) => {
-            if (arg === "--headless") {
-              return "--headless=old";
-            }
-
-            return arg;
-          });
+          launchOptions.args.push("--headless=old");
         }
 
         return launchOptions;


### PR DESCRIPTION
The recent chrome headless v120 is causing the test runner to freeze and eventually get cancelled after several hours of trying to run the test. This was still working fine prior to v120.

A workaround is to pass `--headless=old` to chrome for it to use the old headless chrome.
Ref: https://github.com/cypress-io/cypress/issues/27264