### PR TITLE
Change in-app announcement image resolution

### DIFF
--- a/src/shell/components/InAppAnnouncement/index.tsx
+++ b/src/shell/components/InAppAnnouncement/index.tsx
@@ -109,7 +109,7 @@ export const InAppAnnouncement = () => {
               component="img"
               alt="announcement-banner-image"
               src={
-                `${latestAnnouncement?.feature_image?.data[0]?.url}?fit=cover&width=560&height=300` ??
+                `${latestAnnouncement?.feature_image?.data[0]?.url}?fit=cover&width=1280` ??
                 ""
               }
               maxWidth="100%"


### PR DESCRIPTION
Updated the image resolution from 560 to 1280
![image](https://github.com/zesty-io/manager-ui/assets/28705606/5bd0fb8e-ff44-483c-adf2-eb93f5e99502)


Closes #2373 