### PR TITLE
Fix: Copy the meta description when content item is duplicated

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
@@ -54,6 +54,7 @@ export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
           parentZUID: item.web.parentZUID,
           metaLinkText: item.web.metaLinkText + " (copy)",
           metaTitle: item.web.metaTitle + " (copy)",
+          metaDescription: item.web.metaDescription + " (copy)",
           pathPart: item.web.pathPart
             ? item.web.pathPart + `-${new Date().toISOString()}`
             : undefined,


### PR DESCRIPTION
Closes https://github.com/zesty-io/manager-ui/issues/2475


https://github.com/zesty-io/manager-ui/assets/61284357/292d605e-5995-454b-8a5e-39b96ab03155

