### PR TITLE
Remove custom dirty state handling

### DIFF
--- a/src/shell/components/FieldTypeTinyMCE/index.tsx
+++ b/src/shell/components/FieldTypeTinyMCE/index.tsx
@@ -74,7 +74,6 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE({
   // NOTE: controlled component
   const [initialValue, setInitialValue] = useState(value);
   const [isSkinLoaded, setIsSkinLoaded] = useState(false);
-  const [isDirty, setIsDirty] = useState(false);
 
   // NOTE: update if version changes
   useEffect(() => {
@@ -115,16 +114,13 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE({
           onFocusOut={onBlur}
           initialValue={initialValue}
           onEditorChange={(content, editor) => {
-            if (isDirty) {
-              onChange(content, name, datatype);
+            onChange(content, name, datatype);
 
-              const charCount =
-                editor.plugins?.wordcount?.body?.getCharacterCount() ?? 0;
+            const charCount =
+              editor.plugins?.wordcount?.body?.getCharacterCount() ?? 0;
 
-              onCharacterCountChange(charCount);
-            }
+            onCharacterCountChange(charCount);
           }}
-          onDirty={() => setIsDirty(true)}
           onInit={(_, editor) => {
             const charCount =
               editor.plugins?.wordcount?.body?.getCharacterCount() ?? 0;


### PR DESCRIPTION
This removes the addition of a quick 'fix' of an erroneous understanding of why the tinymce error would trigger an onChange event on mount and by making use of a deferred variable that provides false positives.

Upon investigation tinyMCE editor does NOT auto trigger a change event on mount and in the cases where it DID are cases where the previous html did not conform to the new tinyMCE version html format and thus a slight format change was triggered (mostly removal of extra whitespace) however upon saving the newly formatted html this change event on mount no longer occurs due to correct formatting being saved.

