### PR TITLE
Prevent verify from invalidating stores

### DIFF
--- a/src/shell/components/GlobalAccountMenu/index.tsx
+++ b/src/shell/components/GlobalAccountMenu/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from "react";
+import { FC, useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import {
@@ -36,6 +36,7 @@ export const GlobalAccountMenu: FC<GlobalAccountMenuProps> = ({
   onShowDocsMenu,
 }) => {
   const user: User = useSelector((state: AppState) => state.user);
+  const auth = useSelector((state: AppState) => state.auth);
   const { data: roles, isLoading: isLoadingRoles } = useGetUsersRolesQuery();
 
   const userRole = useMemo(() => {
@@ -43,6 +44,12 @@ export const GlobalAccountMenu: FC<GlobalAccountMenuProps> = ({
   }, [roles]);
 
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!auth.valid) {
+      onClose();
+    }
+  }, [auth.valid]);
 
   const handleClickAction = ([action, location]: ClickAction) => {
     switch (action) {

--- a/src/shell/components/load-instance/index.js
+++ b/src/shell/components/load-instance/index.js
@@ -71,7 +71,7 @@ export default connect((state) => {
       props.dispatch(fetchFiles("views"));
       props.dispatch(fetchFiles("stylesheets"));
       props.dispatch(fetchFiles("scripts"));
-    }, [props.auth]);
+    }, [props.auth.valid]);
 
     useEffect(() => {
       if (

--- a/src/shell/store/types.ts
+++ b/src/shell/store/types.ts
@@ -16,7 +16,11 @@ export type AppState = {
     frames: any;
     installed: InstalledApp[];
   };
-  auth: any;
+  auth: {
+    checking: boolean;
+    valid: boolean;
+    sessionEnding: boolean;
+  };
   user: any;
   users: any;
   releases: any;


### PR DESCRIPTION
[verify-fix.webm](https://github.com/zesty-io/manager-ui/assets/28705606/f2bcb168-bb9b-4d22-8bf5-78004d427da4)


- Closes #2559 
- Also fixes an issue where the login input fields are not clickable when user session expires due to the accounts menu remaining open in the background