### PR TITLE
Fallback to created by user data if audit info not available

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
@@ -90,7 +90,9 @@ export const ItemEditHeaderActions = ({
     useCreateItemPublishingMutation();
   const [deleteItemPublishing, { isLoading: unpublishing }] =
     useDeleteItemPublishingMutation();
-  const lastItemUpdateAudit = itemAudit?.find((audit) => audit.action === 2);
+  const lastItemUpdateAudit = itemAudit?.find(
+    (audit) => audit.action === 2 || audit.action === 1
+  );
   const { data: itemPublishings, isFetching } = useGetItemPublishingsQuery({
     modelZUID,
     itemZUID,
@@ -206,8 +208,15 @@ export const ItemEditHeaderActions = ({
             <div>
               v{item?.meta?.version} saved on <br />
               {formatDate(item?.meta?.updatedAt)} <br />
-              by {lastItemUpdateAudit?.firstName}{" "}
-              {lastItemUpdateAudit?.lastName}
+              by{" "}
+              {lastItemUpdateAudit?.firstName ||
+                users?.find(
+                  (user) => user.ZUID === item?.meta?.createdByUserZUID
+                )?.firstName}{" "}
+              {lastItemUpdateAudit?.lastName ||
+                users?.find(
+                  (user) => user.ZUID === item?.meta?.createdByUserZUID
+                )?.lastName}
             </div>
           )
         }


### PR DESCRIPTION
There is a known bug with audit trail where a created record is not being created for new content items. see linked ticket for more context. But due to pressure from Product to get this out the door this PR provides a fallback solution.