### PR TITLE
Update activity log logic to distinguish Scheduled vs Published actions

### DIFF
--- a/src/apps/reports/src/app/views/ActivityLog/components/ActionTimelineItem/TimelineItem.js
+++ b/src/apps/reports/src/app/views/ActivityLog/components/ActionTimelineItem/TimelineItem.js
@@ -62,9 +62,10 @@ export const TimelineItem = (props) => {
       case 5:
         return "Unpublished";
       case 6:
-        return `Scheduled to Publish on ${moment(
-          props.action?.happenedAt
-        ).format("MMMM DD [at] hh:mm A")}`;
+        const [publishAt] = props.action?.meta?.message.split(" ").slice(-1);
+        return `Scheduled to Publish on ${moment(publishAt).format(
+          "MMMM DD [at] hh:mm A"
+        )}`;
       default:
         return props.action?.meta?.message;
     }

--- a/src/shell/services/instance.ts
+++ b/src/shell/services/instance.ts
@@ -130,8 +130,9 @@ export const instanceApi = createApi({
             : action.affectedZUID;
 
           // Sets action number to 6 for scheduled publishes in order differentiate publish types
+          const [publishAt] = action?.meta?.message.split(" ").slice(-1);
           const normalizedAction =
-            action.action === 4 && action?.meta?.message.includes("scheduled")
+            action.action === 4 && publishAt !== action.happenedAt
               ? 6
               : action.action;
           return {


### PR DESCRIPTION
![image](https://github.com/zesty-io/manager-ui/assets/28705606/7a4006ef-77a6-41c5-8907-7c7c6d336238)

Fixes #2377 