### PR TITLE
schema ui enhancements

### DIFF
--- a/src/apps/schema/src/app/components/AddFieldModal/ComingSoon.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/ComingSoon.tsx
@@ -35,8 +35,7 @@ export const ComingSoon = () => {
             <>
               <Typography variant="body2">Default Value</Typography>
               <Typography variant="body3" color="text.secondary">
-                Ensures that multiple items can't have the same value for this
-                field
+                Set a predefined value for this field
               </Typography>
             </>
           }

--- a/src/apps/schema/src/app/components/AddFieldModal/FieldFormInput.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/FieldFormInput.tsx
@@ -140,81 +140,6 @@ export const FieldFormInput = ({
 
   return (
     <Grid item xs={fieldConfig.gridSize}>
-      {fieldConfig.type === "input" && (
-        <>
-          <Stack
-            flexDirection="row"
-            alignItems="center"
-            mb={!!fieldConfig.subLabel ? 0 : 0.5}
-            height={18}
-          >
-            <Typography component="span" variant="body2" fontWeight={600}>
-              {fieldConfig.label}
-            </Typography>
-            {fieldConfig.label?.toLowerCase().includes("description") && (
-              <Typography
-                component="span"
-                variant="body2"
-                color="text.secondary"
-                sx={{ whiteSpace: "pre" }}
-              >
-                {" "}
-                (optional)
-              </Typography>
-            )}
-            {fieldConfig.tooltip && (
-              <Tooltip placement="right" title={fieldConfig.tooltip}>
-                <InfoRoundedIcon
-                  sx={{ ml: 1, width: "12px", height: "12px" }}
-                  color="action"
-                />
-              </Tooltip>
-            )}
-          </Stack>
-          {fieldConfig.subLabel && (
-            <Typography
-              component="p"
-              variant="body3"
-              color="text.secondary"
-              mb={0.5}
-            >
-              {fieldConfig.subLabel}
-            </Typography>
-          )}
-          <InputTextField
-            autoFocus={fieldConfig.autoFocus}
-            data-cy={`FieldFormInput_${fieldConfig.name}`}
-            name={fieldConfig.name}
-            required={fieldConfig.required}
-            fullWidth={fieldConfig.fullWidth}
-            multiline={fieldConfig.multiline}
-            minRows={fieldConfig.multiline && 2}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              onDataChange({
-                inputName: fieldConfig.name,
-                value: e.target.value,
-              });
-            }}
-            value={prefillData}
-            error={Boolean(errorMsg)}
-            helperText={
-              errorMsg && (
-                <Typography
-                  data-cy={`ErrorMsg_${fieldConfig.name}`}
-                  variant="caption"
-                >
-                  {errorMsg}
-                </Typography>
-              )
-            }
-            type={fieldConfig.inputType || "text"}
-            inputProps={{
-              min: 1,
-            }}
-          />
-        </>
-      )}
-
       {fieldConfig.type === "checkbox" && (
         <FormControlLabel
           control={
@@ -336,6 +261,80 @@ export const FieldFormInput = ({
         </>
       )}
 
+      {fieldConfig.type === "input" && (
+        <>
+          <Stack
+            flexDirection="row"
+            alignItems="center"
+            mb={!!fieldConfig.subLabel ? 0 : 0.5}
+            height={18}
+          >
+            <Typography component="span" variant="body2" fontWeight={600}>
+              {fieldConfig.label}
+            </Typography>
+            {fieldConfig.label?.toLowerCase().includes("description") && (
+              <Typography
+                component="span"
+                variant="body2"
+                color="text.secondary"
+                sx={{ whiteSpace: "pre" }}
+              >
+                {" "}
+                (optional)
+              </Typography>
+            )}
+            {fieldConfig.tooltip && (
+              <Tooltip placement="right" title={fieldConfig.tooltip}>
+                <InfoRoundedIcon
+                  sx={{ ml: 1, width: "12px", height: "12px" }}
+                  color="action"
+                />
+              </Tooltip>
+            )}
+          </Stack>
+          {fieldConfig.subLabel && (
+            <Typography
+              component="p"
+              variant="body3"
+              color="text.secondary"
+              mb={0.5}
+            >
+              {fieldConfig.subLabel}
+            </Typography>
+          )}
+          <InputTextField
+            autoFocus={fieldConfig.autoFocus}
+            data-cy={`FieldFormInput_${fieldConfig.name}`}
+            name={fieldConfig.name}
+            required={fieldConfig.required}
+            fullWidth={fieldConfig.fullWidth}
+            multiline={fieldConfig.multiline}
+            minRows={fieldConfig.multiline && 2}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              onDataChange({
+                inputName: fieldConfig.name,
+                value: e.target.value,
+              });
+            }}
+            value={prefillData}
+            error={Boolean(errorMsg)}
+            helperText={
+              errorMsg && (
+                <Typography
+                  data-cy={`ErrorMsg_${fieldConfig.name}`}
+                  variant="caption"
+                >
+                  {errorMsg}
+                </Typography>
+              )
+            }
+            type={fieldConfig.inputType || "text"}
+            inputProps={{
+              min: 1,
+            }}
+          />
+        </>
+      )}
       {(fieldConfig.type === "options" ||
         fieldConfig.type === "toggle_options") && (
         <>
@@ -375,6 +374,7 @@ export const FieldFormInput = ({
               variant="outlined"
               startIcon={<AddRoundedIcon />}
               onClick={handleAddNewOption}
+              size="small"
             >
               Add Option
             </Button>
@@ -427,9 +427,9 @@ const KeyValueInput = ({
       display="flex"
       justifyContent="space-between"
       alignItems="center"
-      mb={2}
+      mb={1}
     >
-      <Box display="flex" gap={2} width="480px">
+      <Box display="flex" gap={1} width="480px">
         <TextField
           data-cy={`OptionLabel_${id}`}
           name="value"

--- a/src/apps/schema/src/app/components/configs.ts
+++ b/src/apps/schema/src/app/components/configs.ts
@@ -416,7 +416,7 @@ const FORM_CONFIG: { [key: string]: FormConfig } = {
   },
   dropdown: {
     details: [
-      ...COMMON_FIELDS.slice(0, 3),
+      ...COMMON_FIELDS.slice(0, 4),
       {
         name: "options",
         type: "options",
@@ -426,7 +426,7 @@ const FORM_CONFIG: { [key: string]: FormConfig } = {
         maxLength: 150,
         validate: ["length", "unique"],
       },
-      ...COMMON_FIELDS.slice(3),
+      ...COMMON_FIELDS.slice(4),
     ],
     rules: [],
   },


### PR DESCRIPTION
- [x] make the gap between each and cells by 8px
- [x] make the add option button small
- [x] reorder the section of description(optional) above dropdown options

![image](https://github.com/zesty-io/manager-ui/assets/44116036/b26c14b2-3bbd-4be0-8f86-b0c2ecc4b959)

- [x] changing description

![image](https://github.com/zesty-io/manager-ui/assets/44116036/42ff4ed0-409d-421f-ba98-2033f3945a08)
