### PR TITLE
fix: Media: Upload Modal - Title does not become plural

### DIFF
--- a/src/apps/media/src/app/components/UploadModal.tsx
+++ b/src/apps/media/src/app/components/UploadModal.tsx
@@ -227,7 +227,12 @@ const UploadHeaderText = ({ uploads }: UploadHeaderTextProps) => {
         {filesUploading?.length > 0
           ? filesUploading.length
           : filesUploaded.length}{" "}
-        File{filesUploading.length > 1 && "s"}{" "}
+        File
+        {filesUploading.length > 1
+          ? "s"
+          : filesUploaded.length > 1
+          ? "s"
+          : ""}{" "}
         {filesUploading?.length > 0 ? "Uploading" : "Uploaded"}
       </Typography>
     </Stack>


### PR DESCRIPTION
Will close https://github.com/zesty-io/manager-ui/issues/2495

Since I can't reproduced the success uploading in the `local` environment cause it keeps failing to upload.
While testing I set a fixed value of 2 for `filesUploaded` variable to reproduce and check if the condition is now working fiine.

Note: pls ignore the failed uploading messages, since this is a local environment, when this is deployed in dev or prod this will work as intended.

[screencast-8-aaeffee09b-7w6v22.manager.dev.zesty.io_8080-2024.03.13-06_31_50.webm](https://github.com/zesty-io/manager-ui/assets/44116036/d1094671-9c55-4574-b4a9-4301f0d1a89a)
