### PR TITLE
fix: Content: SEO Tab - Title Bar reflects Published State

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
@@ -280,7 +280,8 @@ export const ItemEditHeaderActions = ({
           {itemState === ITEM_STATES.draft ||
           itemState === ITEM_STATES.dirty ||
           publishAfterSave ||
-          isFetching ? (
+          isFetching ||
+          saving ? (
             <ButtonGroup
               variant="contained"
               color="success"


### PR DESCRIPTION
Will close https://github.com/zesty-io/manager-ui/issues/2503

Issue: When selecting a live/published version then trying to make some changes, it temporarily shows the `Published` text which made an impression that while being save it is also being published at the same time. Which is not how the system doing behind the scene.

[screencast-8-aaeffee09b-7w6v22.manager.dev.zesty.io_8080-2024.03.13-11_11_51.webm](https://github.com/zesty-io/manager-ui/assets/44116036/7f5ff2f2-aef5-47a9-a6d0-7b80e9e206b9)

Upon further checking that the `itemState` have dirty | published | scheduled | draft. When selecting published version at first it will return `published` but when you try to edit it it will change to `dirty` but when the user tries to save it will be back to `published` state which is true in a sense that it is currently `published`. That's where the issue lies on the condition of rendering `Published` label

Resolution: So to resolve the issue , since the problem lies when the user tries on saving. I added the saving state in the condition of rendering the dropdown for the `Publish` Button and the `Published` Label

[screencast-8-aaeffee09b-7w6v22.manager.dev.zesty.io_8080-2024.03.13-11_21_42.webm](https://github.com/zesty-io/manager-ui/assets/44116036/0563f4cf-9f4b-46f6-8e21-215598412f56)
