### PR TITLE
Fix/filter out doctype tags from legacy head tags

### DIFF
--- a/src/shell/components/Head/Head.js
+++ b/src/shell/components/Head/Head.js
@@ -49,7 +49,7 @@ export default connect((state, props) => {
 
   const legacyHeadTags = useMemo(() => {
     const customRawLegacyHeadTags = rawLegacyHeadTags?.filter(
-      (tag) => tag.resourceZUID === null && tag.ID > 1
+      (tag) => tag.resourceZUID === null && tag.ID > 1 && tag.type !== "doctype"
     );
 
     return customRawLegacyHeadTags?.map((tag) => {


### PR DESCRIPTION
doctype tag is typically ID: 1 so this filter was removing it properly. However there is an edge case that can include more doctype tags so a better solution is to filter them out by type