### PR TITLE
[Content] Handle old content items with models that have the homepage as the parent

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/ItemSettings/settings/ItemParent.js
@@ -105,22 +105,33 @@ export const ItemParent = connect((state) => {
               if (res) {
                 if (res.data) {
                   if (Array.isArray(res.data) && res.data.length) {
-                    setParent(res.data[0]);
-                    /**
-                     * // HACK Because we pre-load all item publishings and store them in the same reducer as the `content`
-                     * we can't use array length comparision to determine a new parent has been added. Also since updates to the item
-                     * currently being edited cause a new `content` object to be created in it's reducer we can't use
-                     * referential equality checks to determine re-rendering. This scenario causes either the parent to not be pre-selected
-                     * or a performance issue. To work around this we maintain the `parents` state internal and add the new parent we load from the
-                     * API to allow it to be pre-selected while avoiding re-renders on changes to this item.
-                     */
+                    // Handles cases where the model's parent is the homepage. This is no longer possible for newly created models but
+                    // there are some old models that still have the homepage as their parent models.
+                    if (res.data[0]?.web?.path === "/") {
+                      setParent({
+                        meta: {
+                          ZUID: "0", // "0" = root level route
+                          path: "/",
+                        },
+                      });
+                    } else {
+                      setParent(res.data[0]);
+                      /**
+                       * // HACK Because we pre-load all item publishings and store them in the same reducer as the `content`
+                       * we can't use array length comparision to determine a new parent has been added. Also since updates to the item
+                       * currently being edited cause a new `content` object to be created in it's reducer we can't use
+                       * referential equality checks to determine re-rendering. This scenario causes either the parent to not be pre-selected
+                       * or a performance issue. To work around this we maintain the `parents` state internal and add the new parent we load from the
+                       * API to allow it to be pre-selected while avoiding re-renders on changes to this item.
+                       */
 
-                    setParents(
-                      parentOptions(props.currentItemLangID, props.path, {
-                        ...items,
-                        [res.data[0].meta.ZUID]: res.data[0],
-                      })
-                    );
+                      setParents(
+                        parentOptions(props.currentItemLangID, props.path, {
+                          ...items,
+                          [res.data[0].meta.ZUID]: res.data[0],
+                        })
+                      );
+                    }
                   } else {
                     props.dispatch(
                       notify({


### PR DESCRIPTION
Fixes #2768 
Properly handles instances where a content item has a model that was created with the homepage set as the parent model. This should no longer be the case for newly-created models but some legacy models can possibly have the homepage as their parent models.

![image](https://github.com/zesty-io/manager-ui/assets/28705606/0f3f202b-bbdd-4392-a247-44e62ac5b17c)
