### PR TITLE
remove child as selection for a parent model

### DIFF
--- a/src/apps/schema/src/app/components/SelectModelParentInput.tsx
+++ b/src/apps/schema/src/app/components/SelectModelParentInput.tsx
@@ -40,9 +40,17 @@ export const SelectModelParentInput = ({
           1
         );
       }
+      const currentItem = _navItems.find(
+        (item) => item.contentModelZUID === id
+      );
 
       return _navItems
-        ?.filter((item) => item.contentModelZUID !== id)
+        ?.filter(
+          (item) =>
+            item.contentModelZUID !== id &&
+            currentItem &&
+            currentItem.ZUID !== item.parentZUID
+        )
         ?.sort((a, b) => a.label.localeCompare(b.label));
     }
 

--- a/src/shell/services/instance.ts
+++ b/src/shell/services/instance.ts
@@ -310,6 +310,7 @@ export const instanceApi = createApi({
       invalidatesTags: (result, error, arg) => [
         { type: "ContentModel", id: arg.ZUID },
         "ContentModels",
+        "ContentNav",
       ],
     }),
     // https://www.zesty.io/docs/instances/api-reference/content/models/#Delete-Content-Model


### PR DESCRIPTION
Will close: https://github.com/zesty-io/manager-ui/issues/2580

As a solution for the issue above. I make sure that when an item is a child it should not be in a list where we can set a model parent.

To show how it resolves the issue. I set the parent of testDataSet to testPage, then go to testPage to try check if testDataSet is present as a model parent in the list which is not.

[screencast-8-9099fdbffb-hsbtls.manager.dev.zesty.io_8080-2024.07.17-20_39_01.webm](https://github.com/user-attachments/assets/3d179fd3-484f-456e-a9a9-5c7798e6b1e9)

