### PR TITLE
[Content] Do not store pinned columns to local storage

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemList/ItemListTable.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/ItemListTable.tsx
@@ -16,6 +16,7 @@ import {
   GRID_CHECKBOX_SELECTION_COL_DEF,
   useGridApiRef,
   GridInitialState,
+  GridPinnedColumns,
 } from "@mui/x-data-grid-pro";
 import { memo, useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { ContentItem } from "../../../../../../shell/services/types";
@@ -246,6 +247,7 @@ export const ItemListTable = memo(({ loading, rows }: ItemListTableProps) => {
   const history = useHistory();
   const { stagedChanges } = useStagedChanges();
   const [selectedItems, setSelectedItems] = useSelectedItems();
+  const [pinnedColumns, setPinnedColumns] = useState<GridPinnedColumns>({});
 
   const { data: fields } = useGetContentModelFieldsQuery(modelZUID);
 
@@ -266,18 +268,11 @@ export const ItemListTable = memo(({ loading, rows }: ItemListTableProps) => {
     );
 
     setInitialState(
-      stateFromLocalStorage
-        ? JSON.parse(stateFromLocalStorage)
-        : {
-            pinnedColumns: {
-              left: [
-                GRID_CHECKBOX_SELECTION_COL_DEF.field,
-                "version",
-                fields?.[0]?.name,
-              ],
-            },
-          }
+      stateFromLocalStorage ? JSON.parse(stateFromLocalStorage) : {}
     );
+    setPinnedColumns({
+      left: ["__check__", "version", fields?.[0]?.name],
+    });
 
     window.addEventListener("beforeunload", saveSnapshot);
 
@@ -352,6 +347,10 @@ export const ItemListTable = memo(({ loading, rows }: ItemListTableProps) => {
       loading={loading}
       rows={rows}
       columns={[...columns, ...METADATA_COLUMNS]}
+      pinnedColumns={pinnedColumns}
+      onPinnedColumnsChange={(newPinnedColumns) =>
+        setPinnedColumns(newPinnedColumns)
+      }
       rowHeight={54}
       hideFooter
       onRowClick={(row) => {


### PR DESCRIPTION
Prevents multipage table pinned columns from being stored in local storage
Resolves #2824 

#### Demo
[Screencast from Tuesday, 30 July, 2024 09:05:20 AM PST.webm](https://github.com/user-attachments/assets/07281341-7b91-45f9-9f99-245b16d83242)
