### PR TITLE
[Content] Resolve relational field zuids with the actual field values

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemList/TableCells/OneToManyCell.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/TableCells/OneToManyCell.tsx
@@ -29,21 +29,13 @@ type OneToManyCellProps = {
   items: any[];
 };
 export const OneToManyCell = ({ items }: OneToManyCellProps) => {
-  const dispatch = useDispatch();
   const allItems = useSelector((state: AppState) => state.content);
   const chipContainerRef = useRef<HTMLDivElement>();
-  const [lastValidIndex, setLastValidIndex] = useState(allItems?.length - 1);
+  const [lastValidIndex, setLastValidIndex] = useState(
+    Object.keys(allItems)?.length - 1
+  );
   const parentWidth = chipContainerRef.current?.parentElement?.clientWidth;
   const hiddenItems = items?.length - lastValidIndex - 1;
-
-  useEffect(() => {
-    items?.forEach((item) => {
-      // If value starts with '7-', that means it was unable to find the item in the store so we need to fetch it
-      if (item?.startsWith("7-")) {
-        dispatch(searchItems(item));
-      }
-    });
-  }, [items, dispatch]);
 
   useEffect(() => {
     setLastValidIndex(
@@ -54,15 +46,11 @@ export const OneToManyCell = ({ items }: OneToManyCellProps) => {
   return (
     <>
       <Box display="flex" gap={0.5}>
-        {items?.slice(0, lastValidIndex + 1)?.map((id: string) => {
-          return (
-            <Chip
-              key={id}
-              label={allItems?.[id]?.web?.metaTitle || id}
-              size="small"
-            />
-          );
-        })}
+        {items
+          ?.slice(0, lastValidIndex + 1)
+          ?.map((id: string, index: number) => {
+            return <Chip key={index} label={id} size="small" />;
+          })}
         {!!hiddenItems && (
           <Tooltip
             title={`${items?.slice(lastValidIndex + 1)?.join(", ")}`}
@@ -74,14 +62,8 @@ export const OneToManyCell = ({ items }: OneToManyCellProps) => {
       </Box>
       {/** Element below is only needed to calculate the actual chip widths */}
       <Box visibility="hidden" display="flex" gap={0.5} ref={chipContainerRef}>
-        {items?.map((id: string) => {
-          return (
-            <Chip
-              key={id}
-              label={allItems?.[id]?.web?.metaTitle || id}
-              size="small"
-            />
-          );
+        {items?.map((id: string, index: number) => {
+          return <Chip key={index} label={id} size="small" />;
         })}
       </Box>
     </>

--- a/src/apps/content-editor/src/app/views/ItemList/TableCells/SingleRelationshipCell.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/TableCells/SingleRelationshipCell.tsx
@@ -1,20 +1,10 @@
 import { GridRenderCellParams } from "@mui/x-data-grid-pro";
 import { Chip } from "@mui/material";
-import { useEffect } from "react";
-import { useDispatch } from "react-redux";
-import { searchItems } from "../../../../../../../shell/store/content";
 
 export const SingleRelationshipCell = ({
   params,
 }: {
   params: GridRenderCellParams;
 }) => {
-  const dispatch = useDispatch();
-  useEffect(() => {
-    // If value starts with '7-', that means it was unable to find the item in the store so we need to fetch it
-    if (params.value?.startsWith("7-")) {
-      dispatch(searchItems(params.value));
-    }
-  }, [params.value, dispatch]);
   return <Chip label={params.value} size="small" />;
 };


### PR DESCRIPTION
- Makes sure that `one_to_one` and `one_to_many` field values are properly resolved to whatever the actual text is.
- This also makes sure that each individual `one_to_one` and `one_to_many` chip no longer has to do an api call to retrieve their data

Resolves #2901 

### Demo
![image](https://github.com/user-attachments/assets/bd59ee28-ea4f-4c2f-b0b7-33c9453cf084)
