### PR TITLE
[Content] Skip url path part validation for datasets

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.tsx
+++ b/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.tsx
@@ -164,7 +164,13 @@ export const ItemCreate = () => {
     setSaving(true);
 
     try {
-      const res: any = await dispatch(createItem(modelZUID, itemZUID));
+      const res: any = await dispatch(
+        createItem({
+          modelZUID,
+          itemZUID,
+          skipPathPartValidation: model?.type === "dataset",
+        })
+      );
       if (res.err || res.error) {
         if (res.missingRequired || res.lackingCharLength) {
           const missingRequiredFieldNames: string[] =

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/index.tsx
@@ -138,13 +138,18 @@ export const Meta = forwardRef(
               };
             });
 
+            // No need to validate pathPart for datasets
+            if (model?.type === "dataset") {
+              delete currentErrors.pathPart;
+            }
+
             setTimeout(() => {
               setErrors(currentErrors);
             });
           },
         };
       },
-      [errors, web]
+      [errors, web, model]
     );
 
     useEffect(() => {

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -514,7 +514,7 @@ export function saveItem({
   };
 }
 
-export function createItem(modelZUID, itemZUID) {
+export function createItem({ modelZUID, itemZUID, skipPathPartValidation }) {
   return (dispatch, getState) => {
     const state = getState();
 
@@ -553,10 +553,11 @@ export function createItem(modelZUID, itemZUID) {
       return false;
     });
 
-    const hasMissingRequiredSEOFields =
-      !item?.web?.metaTitle ||
-      !item?.web?.metaDescription ||
-      !item?.web?.pathPart;
+    const hasMissingRequiredSEOFields = skipPathPartValidation
+      ? !item?.web?.metaTitle || !item?.web?.metaDescription
+      : !item?.web?.metaTitle ||
+        !item?.web?.metaDescription ||
+        !item?.web?.pathPart;
 
     // Check minlength is satisfied
     const lackingCharLength = fields?.filter(


### PR DESCRIPTION
Fixes an issue where users will not be able to create dataset items because of the missing url path part even if it is not needed for dataset items.