### PR TITLE
fix: have workflows create necessary branch and clean up prior branches

### DIFF
--- a/.github/workflows/cd-beta.yaml
+++ b/.github/workflows/cd-beta.yaml
@@ -1,5 +1,9 @@
 name: cd-beta
 
+concurrency:
+  group: beta
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -21,7 +25,7 @@ jobs:
   #           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   #         if: "github.ref != 'refs/heads/master'"
   #       - name: Checkout Repo
-  #         uses: actions/checkout@v2
+  #         uses: actions/checkout@v4
   #       - name: Auth with Gcloud
   #         uses: google-github-actions/auth@v0
   #         with:
@@ -77,12 +81,25 @@ jobs:
   #           SLACK_USERNAME: Deploy Bot
   #           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-  create_stable_pr:
+  # Delete the stage branch after it is merged into beta
+  delete_stage_branch:
+    if: github.head_ref == 'stage'
     runs-on: ubuntu-latest
-    # needs: [deploy_beta]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+      - name: Delete stage branch
+        run: git push origin :stage
+
+  create_stable_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Ensure origin/stable branch exists
+        if: git branch -r --list origin/stable != 'origin/stable'
+        run: it checkout beta && git switch --create stable && git push -u origin stable
 
       - name: Check if PR exists
         id: check
@@ -101,7 +118,6 @@ jobs:
 
       - name: Create Stable Release
         if: "!steps.check.outputs.skip"
-
         run: gh pr create -B stable -H beta --title 'Stable Release' --body 'Created by Github action'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd-beta.yaml
+++ b/.github/workflows/cd-beta.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Ensure origin/stable branch exists
         if: git branch -r --list origin/stable != 'origin/stable'
-        run: it checkout beta && git switch --create stable && git push -u origin stable
+        run: git checkout beta && git switch --create stable && git push -u origin stable
 
       - name: Check if PR exists
         id: check

--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -5,9 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  # Uncomment to work on CD in development mode.
-  # pull_request:
-  #   branches: [ master ]
   push:
     branches:
       - dev
@@ -44,7 +41,7 @@ jobs:
       - name: Deploy to Dev
         run: gcloud app deploy app.yaml --quiet --project zesty-dev
 
-  failed_deploy_notification_to_slack:
+  deploy_failed_notification_to_slack:
     runs-on: ubuntu-latest
     if: ${{ failure() }}
     needs: [deploy_dev]
@@ -60,7 +57,7 @@ jobs:
           SLACK_USERNAME: Deploy Bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-  success_deploy_notification_to_slack:
+  deploy_success_notification_to_slack:
     runs-on: ubuntu-latest
     if: ${{ success() }}
     needs: [deploy_dev]
@@ -76,41 +73,15 @@ jobs:
           SLACK_USERNAME: Deploy Bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-  # create_release:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout Repo
-  #       uses: actions/checkout@v4
-  #     - name: create local branch
-  #       run: git switch --create stage
-  #     - name: push local branch to origin
-  #       run: git push -u origin stage
-  #     - name: make pr
-  #       run: gh pr create -B stage -H dev --title 'Stage Release' --body 'Created by Github action'
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # release-please:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout Repo
-  #       uses: actions/checkout@v2
-  #     - uses: google-github-actions/release-please-action@v4
-  #       with:
-  #         # this assumes that you have created a personal access token
-  #         # (PAT) and configured it as a GitHub action secret named
-  #         # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         # this is a built-in strategy in release-please, see "Action Inputs"
-  #         # for more options
-  #         release-type: node
-  #         target-branch: stage
-
   create_stage_pr:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+
+      - name: Ensure origin/stage branch exists
+        if: git branch -r --list origin/stage != 'origin/stage'
+        run: git checkout dev && git switch --create stage && git push -u origin stage
 
       - name: Check if PR exists
         id: check

--- a/.github/workflows/cd-stable.yaml
+++ b/.github/workflows/cd-stable.yaml
@@ -6,45 +6,81 @@ on:
       - stable
 
 jobs:
-#   deploy_stable:
-#     runs-on: ubuntu-latest
-#     env:
-#       ENV: "prod"
+  #   deploy_stable:
+  #     runs-on: ubuntu-latest
+  #     env:
+  #       ENV: "prod"
 
-#     steps:
-#       # This Clean step simply checks if there's already a workflow running from the last
-#       # commit and cancels it if there is. This helps us save on cloud cost in the long run.
-#       # See https://github.com/rokroskar/workflow-run-cleanup-action for more information.
-#       - name: Clean
-#         uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-#         env:
-#           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-#         if: "github.ref != 'refs/heads/master'"
-#       - name: Checkout Repo
-#         uses: actions/checkout@v2
-#       - name: Auth with Gcloud
-#         uses: google-github-actions/auth@v0
-#         with:
-#           credentials_json: ${{ secrets.GCP_DEV_SA_KEY }}
-#       - name: Set up Gcloud SDK
-#         uses: google-github-actions/setup-gcloud@v0
-#         with:
-#           project_id: zesty-prod
-#       - name: Set up Node
-#         uses: actions/setup-node@v2
-#         with:
-#           node-version: "16.5.0"
-#           cache: "npm"
-#           cache-dependency-path: package-lock.json
-#       - name: Install Dependencies
-#         run: npm install
-#       - name: Build
-#         run: npm run build:prod
-#         env:
-#           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-#       - name: Deploy Stable
-#         run: gcloud app deploy app.yaml --quiet --project zesty-prod
+  #     steps:
+  #       # This Clean step simply checks if there's already a workflow running from the last
+  #       # commit and cancels it if there is. This helps us save on cloud cost in the long run.
+  #       # See https://github.com/rokroskar/workflow-run-cleanup-action for more information.
+  #       - name: Clean
+  #         uses: rokroskar/workflow-run-cleanup-action@v0.2.2
+  #         env:
+  #           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  #         if: "github.ref != 'refs/heads/master'"
+  #       - name: Checkout Repo
+  #         uses: actions/checkout@v4
+  #       - name: Auth with Gcloud
+  #         uses: google-github-actions/auth@v0
+  #         with:
+  #           credentials_json: ${{ secrets.GCP_DEV_SA_KEY }}
+  #       - name: Set up Gcloud SDK
+  #         uses: google-github-actions/setup-gcloud@v0
+  #         with:
+  #           project_id: zesty-prod
+  #       - name: Set up Node
+  #         uses: actions/setup-node@v2
+  #         with:
+  #           node-version: "16.5.0"
+  #           cache: "npm"
+  #           cache-dependency-path: package-lock.json
+  #       - name: Install Dependencies
+  #         run: npm install
+  #       - name: Build
+  #         run: npm run build:prod
+  #         env:
+  #           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  #       - name: Deploy Stable
+  #         run: gcloud app deploy app.yaml --quiet --project zesty-prod
 
+  create_release_tag:
+    runs-on: ubuntu-latest
+    #  needs: [deploy_stable]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Switch branch to beta
+        run: git checkout beta
+      - name: Get commit short hash
+        id: get_commit
+        run: echo "hash=release-$(git rev-parse --short HEAD)"
+      - name: Tag Release
+        run: git tag ${{steps.get_commit.hash}}
+      - name: Push tag to remote
+        run: git push origin tag ${{steps.get_commit.hash}}
+
+  # Delete the beta branch after it is merged into beta
+  delete_beta_branch:
+    # needs: [deploy_stable]
+    if: github.head_ref == 'beta'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Delete beta branch
+        run: git push origin :beta
+
+  # Delete the stable branch after it is merged into stable
+  delete_stable_branch:
+    needs: [deploy_stable]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Delete stable branch
+        run: git push origin :stable
 #   failed_deploy_notification_to_slack:
 #     runs-on: ubuntu-latest
 #     if: ${{ failure() }}

--- a/.github/workflows/cd-stable.yaml
+++ b/.github/workflows/cd-stable.yaml
@@ -55,11 +55,11 @@ jobs:
         run: git checkout beta
       - name: Get commit short hash
         id: get_commit
-        run: echo "hash=release-$(git rev-parse --short HEAD)"
+        run: echo "hash=$(git rev-parse --short HEAD)"
       - name: Tag Release
-        run: git tag ${{steps.get_commit.hash}}
+        run: git tag release-${{steps.get_commit.hash}} ${{steps.get_commit.hash}}
       - name: Push tag to remote
-        run: git push origin tag ${{steps.get_commit.hash}}
+        run: git push origin tag release-${{steps.get_commit.hash}}
 
   # Delete the beta branch after it is merged into beta
   delete_beta_branch:

--- a/.github/workflows/cd-stage.yaml
+++ b/.github/workflows/cd-stage.yaml
@@ -1,9 +1,14 @@
 name: cd-stage
 
+concurrency:
+  group: stage
+  cancel-in-progress: true
+
 on:
   push:
     branches:
       - stage
+
 jobs:
   deploy_stage:
     runs-on: ubuntu-latest
@@ -20,7 +25,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         if: "github.ref != 'refs/heads/master'"
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Auth with Gcloud
         uses: google-github-actions/auth@v0
         with:
@@ -44,7 +49,7 @@ jobs:
       - name: Deploy to Stage
         run: gcloud app deploy app.yaml --quiet --project zesty-stage
 
-  failed_deploy_notification_to_slack:
+  deploy_failed_notification_to_slack:
     runs-on: ubuntu-latest
     if: ${{ failure() }}
     needs: [deploy_stage]
@@ -60,7 +65,7 @@ jobs:
           SLACK_USERNAME: Deploy Bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-  success_deploy_notification_to_slack:
+  deploy_success_notification_to_slack:
     runs-on: ubuntu-latest
     if: ${{ success() }}
     needs: [deploy_stage]
@@ -78,10 +83,13 @@ jobs:
 
   create_beta_pr:
     runs-on: ubuntu-latest
-    # needs: [deploy_stage]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+
+      - name: Ensure origin/beta branch exists
+        if: git branch -r --list origin/beta != 'origin/beta'
+        run: git checkout stage && git switch --create beta && git push -u origin beta
 
       - name: Check if PR exists
         id: check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         if: "github.ref != 'refs/heads/master'"
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Auth with Gcloud
         uses: google-github-actions/auth@v0
         with:


### PR DESCRIPTION
- add job to remove prior env branch
- add job on stable workflow to tag release and push to origin. Tag will follow the format `release-GIT_SHORT_HASH`
- update job to ensure branch is present at origin before checking/creating PR
- rename jobs for consistency