### PR TITLE
[Content] Set number value to 0 if the api originally returned the value as null

### DIFF
--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -415,6 +415,17 @@ export function saveItem({
       )
       .map((fieldZUID) => state.fields[fieldZUID]);
 
+    Object.keys(item.data).forEach((key) => {
+      const field = fields.find((field) => field.name === key);
+      if (
+        field &&
+        field.datatype === "number" &&
+        (item.data[key] === null || item.data[key] === undefined)
+      ) {
+        item.data[key] = 0;
+      }
+    });
+
     // Check required fields are not empty strings or null valuess
     // Some falsey values are allowed. e.g. false, 0
     const missingRequired = fields.filter(


### PR DESCRIPTION
Makes sure that users are able to save a content item when a number field originally has a null value

Fixes #3154 