### PR TITLE
[#3189] - Blocks App: Deleting a Block in Blocks App, should redirect…

### DIFF
--- a/src/apps/schema/src/app/components/DeleteModelDialogue.tsx
+++ b/src/apps/schema/src/app/components/DeleteModelDialogue.tsx
@@ -41,9 +41,10 @@ export const DeleteModelDialogue = ({ onClose, model }: Props) => {
   useEffect(() => {
     if (isSuccess) {
       onClose();
-      history.push("/schema");
+      const targetPath = `/${history?.location?.pathname.split("/")[1]}`;
+      history.push(targetPath);
     }
-  }, [isSuccess]);
+  }, [isSuccess, history]);
 
   useEffect(() => {
     // @ts-ignore

--- a/src/apps/schema/src/app/components/ModelMenu.tsx
+++ b/src/apps/schema/src/app/components/ModelMenu.tsx
@@ -47,7 +47,12 @@ export const ModelMenu: FC<Props> = ({ anchorEl, onClose, modelZUID }) => {
 
   return (
     <ThemeProvider theme={theme}>
-      <Menu anchorEl={anchorEl} open={!!anchorEl} onClose={onClose}>
+      <Menu
+        anchorEl={anchorEl}
+        open={!!anchorEl}
+        onClose={onClose}
+        container={() => document.getElementById(modelZUID)!}
+      >
         <MenuItem
           onClick={() => {
             setShowDialogue("rename");

--- a/src/shell/components/NavTree/components/NavTreeItem.tsx
+++ b/src/shell/components/NavTree/components/NavTreeItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC, HTMLAttributes } from "react";
+import React, { FC } from "react";
 import { TreeItem } from "@mui/x-tree-view";
 import { Stack, Box, Typography, Tooltip, alpha } from "@mui/material";
 
@@ -15,8 +15,6 @@ interface Props {
   nodeData?: any;
   onItemDrop?: (draggedItem: any, targetItem: any) => void;
   dragAndDrop?: boolean;
-  hoveredItemId?: string;
-  setHoveredItemId?: (id: string) => void;
 }
 export const NavTreeItem: FC<Props> = React.memo(
   ({
@@ -30,12 +28,9 @@ export const NavTreeItem: FC<Props> = React.memo(
     nodeData,
     onItemDrop,
     dragAndDrop = false,
-    hoveredItemId = "",
-    setHoveredItemId = () => {},
   }) => {
     const currentDepth = depth + 1;
     const depthPadding = currentDepth * 1;
-    const itemId = `${nodeId}-${currentDepth}`;
 
     return (
       <TreeItem
@@ -98,10 +93,6 @@ export const NavTreeItem: FC<Props> = React.memo(
             py: 0.5,
             pl: 1,
             borderRadius: 0,
-            "&.is-hovered": {
-              backgroundColor: (theme) =>
-                alpha(theme.palette.primary.main, 0.07),
-            },
             ".MuiTreeItem-iconContainer": {
               width: 20,
               height: 20,
@@ -144,10 +135,7 @@ export const NavTreeItem: FC<Props> = React.memo(
           },
         }}
         ContentProps={{
-          className: itemId === hoveredItemId ? "is-hovered" : "",
-          onMouseEnter: (event: any) => {
-            setHoveredItemId(itemId);
-          },
+          id: nodeId.split("/").pop(),
           onDragOver: (event: any) => {
             if (dragAndDrop) {
               event.preventDefault();
@@ -189,8 +177,6 @@ export const NavTreeItem: FC<Props> = React.memo(
                 actions={item.actions ?? []}
                 onItemDrop={onItemDrop}
                 dragAndDrop={dragAndDrop}
-                hoveredItemId={hoveredItemId}
-                setHoveredItemId={setHoveredItemId}
               />
             );
           })}

--- a/src/shell/components/NavTree/index.tsx
+++ b/src/shell/components/NavTree/index.tsx
@@ -45,7 +45,6 @@ export const NavTree: FC<Readonly<Props>> = ({
   dragAndDrop = false,
 }) => {
   const history = useHistory();
-  const [hoveredItemId, setHoveredItemId] = React.useState<string>("");
 
   return (
     <>
@@ -89,8 +88,6 @@ export const NavTree: FC<Readonly<Props>> = ({
                 nodeData={item.nodeData}
                 onItemDrop={onItemDrop}
                 dragAndDrop={dragAndDrop}
-                hoveredItemId={hoveredItemId}
-                setHoveredItemId={setHoveredItemId}
               />
             );
           })}


### PR DESCRIPTION
… a user to the All Blocks Page

### NOTE:
This update includes a fix for the sidebar tree item hover issue I noticed, which was introduced in my previous PR ([#3119](https://github.com/zesty-io/manager-ui/pull/3119)). The issue caused the hover highlight to persist when moving to a different NavTree section.

Fix: The menu portal is now set to the target NavTreeItem, ensuring that the hover effect is not disrupted when opening the popup menu.