### PR TITLE
Ensure promise rejection is always of an Error instance

### DIFF
--- a/src/utility/request.js
+++ b/src/utility/request.js
@@ -101,7 +101,11 @@ export function request(url, opts = {}) {
       } else {
         // Network errors
         store.dispatch(notify({ message: err.message, kind: "warn" }));
-        return Promise.reject(err);
+        return Promise.reject(
+          err instanceof Error
+            ? err
+            : new Error(err.message || JSON.stringify(err))
+        );
       }
     });
 }


### PR DESCRIPTION
This makes sure that when returning a Promise rejection, it is always of an Error instance

Fixes #3229 