### PR TITLE
[Content] Make sure newly-created field is always added at the end

### DIFF
--- a/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
@@ -551,13 +551,11 @@ export const FieldForm = ({
     const hasErrors = Object.values(errors)
       .flat(2)
       .some((error) => error.length);
-    // Calculate the highest sort value from all fields
     const highestSortValue = fields.reduce(
       (max, field) => (field.sort > max ? field.sort : max),
       0
     );
 
-    console.log(highestSortValue);
     const sort = isInbetweenField ? sortIndex : highestSortValue + 1;
 
     if (hasErrors) {

--- a/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
@@ -551,7 +551,14 @@ export const FieldForm = ({
     const hasErrors = Object.values(errors)
       .flat(2)
       .some((error) => error.length);
-    const sort = isInbetweenField ? sortIndex : fields?.length;
+    // Calculate the highest sort value from all fields
+    const highestSortValue = fields.reduce(
+      (max, field) => (field.sort > max ? field.sort : max),
+      0
+    );
+
+    console.log(highestSortValue);
+    const sort = isInbetweenField ? sortIndex : highestSortValue + 1;
 
     if (hasErrors) {
       // Switch the active tab to details to show the user the errors if


### PR DESCRIPTION
**Cause:** When there is an existing field that has a very high sort value (ie 10000) even if the total number of fields does not total to that amount, a newly-created field will always end up being added before that field with a very hight sort value.
**Fix:** When creating a new field, check what the current highest sort value is and add 1 from that as the new field's sort value.

Fixes #3256 

[Schema---Test-Page-2---Zesty-io---Acme-Recipes---Manager.webm](https://github.com/user-attachments/assets/2c1599e3-4c4e-4a79-a8d3-4c1d4c903c00)

