### PR TITLE
[Content] Remove frontend validation limits to one-to-many fields

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/Editor.js
+++ b/src/apps/content-editor/src/app/components/Editor/Editor.js
@@ -211,18 +211,6 @@ export default memo(function Editor({
         };
       }
 
-      if (field.datatype === "one_to_many") {
-        // Value is stored as string in DB with max char limit of 255.
-        // This means users can only add up to 12 item zuids
-        errors[name] = {
-          ...(errors[name] ?? []),
-          CUSTOM_ERROR:
-            !!value && value?.length > 255
-              ? "Cannot save field. Please reduce the total number of items selected."
-              : "",
-        };
-      }
-
       onUpdateFieldErrors(errors);
 
       // Always dispatch the data update

--- a/src/apps/content-editor/src/app/components/Editor/Editor.js
+++ b/src/apps/content-editor/src/app/components/Editor/Editor.js
@@ -211,6 +211,14 @@ export default memo(function Editor({
         };
       }
 
+      if (field.datatype === "one_to_many") {
+        // Clear out the error after changing the value
+        errors[name] = {
+          ...(errors[name] ?? []),
+          CUSTOM_ERROR: "",
+        };
+      }
+
       onUpdateFieldErrors(errors);
 
       // Always dispatch the data update

--- a/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.tsx
+++ b/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.tsx
@@ -300,8 +300,8 @@ export const ItemCreate = () => {
         if (res.error) {
           dispatch(
             notify({
-              message: res.error,
-              kind: "warn",
+              message: `Cannot Save: ${res.error}`,
+              kind: "error",
             })
           );
         }

--- a/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.tsx
+++ b/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.tsx
@@ -298,6 +298,24 @@ export const ItemCreate = () => {
         }
 
         if (res.error) {
+          // Handles backend validation error for when the data is too long
+          if (res.error?.toLowerCase()?.includes("data too long")) {
+            const dataLongErrorMatch = res.error?.match(/'([^']*)'/);
+
+            if (dataLongErrorMatch?.[1]) {
+              const fieldName = dataLongErrorMatch[1];
+              const errors = cloneDeep(fieldErrors);
+
+              errors[fieldName] = {
+                ...(errors[fieldName] ?? {}),
+                CUSTOM_ERROR:
+                  "Cannot save field. Please reduce the total number of items selected.",
+              };
+
+              setFieldErrors(errors);
+            }
+          }
+
           dispatch(
             notify({
               message: `Cannot Save: ${res.error}`,

--- a/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.tsx
+++ b/src/apps/content-editor/src/app/views/ItemCreate/ItemCreate.tsx
@@ -305,11 +305,22 @@ export const ItemCreate = () => {
             if (dataLongErrorMatch?.[1]) {
               const fieldName = dataLongErrorMatch[1];
               const errors = cloneDeep(fieldErrors);
+              const oneToManyFieldNames = activeFields?.reduce(
+                (names, currItem) => {
+                  if (currItem?.datatype === "one_to_many") {
+                    return [...names, currItem?.name];
+                  }
+
+                  return names;
+                },
+                []
+              );
 
               errors[fieldName] = {
                 ...(errors[fieldName] ?? {}),
-                CUSTOM_ERROR:
-                  "Cannot save field. Please reduce the total number of items selected.",
+                CUSTOM_ERROR: oneToManyFieldNames?.includes(fieldName)
+                  ? "Cannot save field. Please reduce the total number of items selected."
+                  : "Cannot save field. Value is too long.",
               };
 
               setFieldErrors(errors);

--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -396,11 +396,22 @@ export default function ItemEdit() {
           if (dataLongErrorMatch?.[1]) {
             const fieldName = dataLongErrorMatch[1];
             const errors = cloneDeep(fieldErrors);
+            const oneToManyFieldNames = activeFields?.reduce(
+              (names, currItem) => {
+                if (currItem?.datatype === "one_to_many") {
+                  return [...names, currItem?.name];
+                }
+
+                return names;
+              },
+              []
+            );
 
             errors[fieldName] = {
               ...(errors[fieldName] ?? {}),
-              CUSTOM_ERROR:
-                "Cannot save field. Please reduce the total number of items selected.",
+              CUSTOM_ERROR: oneToManyFieldNames?.includes(fieldName)
+                ? "Cannot save field. Please reduce the total number of items selected."
+                : "Cannot save field. Value is too long.",
             };
 
             setFieldErrors(errors);

--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -389,6 +389,24 @@ export default function ItemEdit() {
         throw new Error(errors);
       }
       if (res.status === 400) {
+        // Handles backend validation error for when the data is too long
+        if (res.error?.toLowerCase()?.includes("data too long")) {
+          const dataLongErrorMatch = res.error?.match(/'([^']*)'/);
+
+          if (dataLongErrorMatch?.[1]) {
+            const fieldName = dataLongErrorMatch[1];
+            const errors = cloneDeep(fieldErrors);
+
+            errors[fieldName] = {
+              ...(errors[fieldName] ?? {}),
+              CUSTOM_ERROR:
+                "Cannot save field. Please reduce the total number of items selected.",
+            };
+
+            setFieldErrors(errors);
+          }
+        }
+
         dispatch(
           notify({
             message: `Cannot Save: ${item.web.metaTitle} - ${res.error}`,

--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -391,11 +391,11 @@ export default function ItemEdit() {
       if (res.status === 400) {
         dispatch(
           notify({
-            message: `Cannot Save: ${item.web.metaTitle}`,
+            message: `Cannot Save: ${item.web.metaTitle} - ${res.error}`,
             kind: "error",
           })
         );
-        throw new Error(`Cannot Save: ${item.web.metaTitle}`);
+        throw new Error(`Cannot Save: ${item.web.metaTitle} - ${res.error}`);
       }
 
       dispatch(

--- a/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
@@ -340,18 +340,12 @@ export const FieldForm = ({
     let newErrorsObj: Errors = {};
 
     Object.keys(formData).map((inputName) => {
-      if (inputName === "defaultValue" && isDefaultValueEnabled) {
-        if (formData.defaultValue === "" || formData.defaultValue === null) {
-          newErrorsObj[inputName] = "Required Field. Please enter a value.";
-        } else if (
-          type === "one_to_many" &&
-          (formData.defaultValue as string)?.length > 255
-        ) {
-          // Value is stored as string in DB with max char limit of 255.
-          // This means users can only add up to 12 item zuids
-          newErrorsObj[inputName] =
-            "Cannot save field. Please reduce the total number of items selected.";
-        }
+      if (
+        inputName === "defaultValue" &&
+        isDefaultValueEnabled &&
+        (formData.defaultValue === "" || formData.defaultValue === null)
+      ) {
+        newErrorsObj[inputName] = "Required Field. Please enter a value.";
       }
 
       if (type === "text" || type === "textarea") {


### PR DESCRIPTION
Removes the predefined frontend validation limit for one-to-many fields and rely on the backend limit validation.

Resolves #3303 