### PR TITLE
[Content] VQA: Prevent dialog height shift

### DIFF
--- a/src/shell/components/RelationalFieldBase/FieldSelectorDialog/index.tsx
+++ b/src/shell/components/RelationalFieldBase/FieldSelectorDialog/index.tsx
@@ -513,12 +513,13 @@ export const FieldSelectorDialog = ({
     <Dialog
       open
       onClose={onClose}
+      fullScreen
       PaperProps={{
         sx: {
           width: 800,
           maxWidth: 800,
           minHeight: 680,
-          maxHeight: "min(1240px, calc(100% - 64px))",
+          maxHeight: "min(1240px, calc(100% - 40px))", // 40px is the top & bottom margin
         },
       }}
     >


### PR DESCRIPTION
Prevents dialog shift when items are loading and are actually loaded

[Content---nar-test-2---Zesty-io---zesty-pw---Manager (3).webm](https://github.com/user-attachments/assets/8d4db6f2-b3c0-466c-ad35-a929cc4fb736)
