### PR TITLE
Blocks-App-and-Modals-Enhancements

### DIFF
--- a/cypress/e2e/schema/models.spec.js
+++ b/cypress/e2e/schema/models.spec.js
@@ -8,10 +8,11 @@ const TIMEOUT = {
 };
 
 const BLOCK_MODEL_NAME = "Test Block Model";
+const CYPRESS_TEST_MODEL = "Cypress Test Model";
 
 describe("Schema: Models", () => {
   before(() => {
-    cy.deleteModels([BLOCK_MODEL_NAME]);
+    cy.deleteModels([BLOCK_MODEL_NAME, CYPRESS_TEST_MODEL]);
     cy.waitOn("/v1/content/models*", () => {
       cy.visit("/schema");
     });
@@ -35,6 +36,9 @@ describe("Schema: Models", () => {
     cy.get("body").type("{esc}");
   });
   it("Creates model", () => {
+    cy.intercept("POST", "**/v1/content/models").as("createModel");
+    cy.intercept("GET", "**/v1/content/models").as("getModels");
+
     cy.getBySelector(`create-model-button-all-models`).click(TIMEOUT);
     cy.contains("Multi Page Model").click(TIMEOUT);
     cy.contains("Next").click();
@@ -52,7 +56,7 @@ describe("Schema: Models", () => {
 
     cy.get(".MuiAutocomplete-popper")
       .contains("Cypress test (Group with visible fields in list)", {
-        timeout: 50_000,
+        timeout: 60_000,
       })
       .click();
 
@@ -60,13 +64,13 @@ describe("Schema: Models", () => {
     cy.get(".MuiDialog-container").within(() => {
       cy.contains("Create Model").click();
     });
-    cy.intercept("POST", "/models");
-    cy.intercept("GET", "/models");
+    cy.wait(["@createModel", "@getModels"]);
   });
 
   it("Renames model", () => {
     cy.getBySelector(`model-header-menu`, options).click(forceClick);
     cy.contains("Rename Model", options).click(forceClick);
+
     cy.get(".MuiDialog-container", options).within(() => {
       cy.get("label", options).contains("Display Name").next().type(" Updated");
       cy.get("label", options).contains("Reference ID").next().type("_updated");
@@ -80,7 +84,7 @@ describe("Schema: Models", () => {
     cy.getBySelector(`model-header-menu`, options).click(forceClick);
     cy.contains("Delete Model", options).click(forceClick);
     cy.get(".MuiDialog-container", options).within(() => {
-      cy.get(".MuiOutlinedInput-root", options).type(
+      cy.get(".MuiOutlinedInput-root input", options).type(
         "Cypress Test Model Updated"
       );
     });

--- a/src/apps/blocks/components/Sidebar.tsx
+++ b/src/apps/blocks/components/Sidebar.tsx
@@ -73,6 +73,7 @@ export const Sidebar = () => {
       </AppSideBar>
       {isCreateModelDialogueOpen && (
         <CreateModelDialogue
+          typeIsSet={true}
           modelType="block"
           onClose={() => setIsCreateModelDialogueOpen(false)}
         />

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DeleteItemDialog.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DeleteItemDialog.tsx
@@ -47,14 +47,14 @@ export const DeleteItemDialog = ({ onClose }: DuplicateItemProps) => {
             display: "flex",
             justifyContent: "center",
             alignItems: "center",
+            mb: 1.5,
           }}
         >
           <DeleteRounded color="error" />
         </Box>
-        <Stack mt={1.5} display="inline">
+        <Stack>
           Delete Content Item:
           <Typography variant="inherit" fontWeight={600}>
-            {" "}
             {item?.web?.metaTitle || item?.web?.metaLinkText}
           </Typography>
         </Stack>

--- a/src/apps/media/src/app/components/DeleteFolderDialog.tsx
+++ b/src/apps/media/src/app/components/DeleteFolderDialog.tsx
@@ -46,11 +46,13 @@ export const DeleteFolderDialog = ({ open, onClose, id, groupId }: Props) => {
         <DeleteIcon
           color="error"
           sx={{
-            padding: "8px",
+            p: 1,
             borderRadius: "20px",
             backgroundColor: "red.100",
             display: "block",
-            mb: 2,
+            mb: 1.5,
+            width: "40px",
+            height: "40px",
           }}
         />
         Delete Folder?

--- a/src/apps/schema/src/app/components/CreateModelDialogue.tsx
+++ b/src/apps/schema/src/app/components/CreateModelDialogue.tsx
@@ -46,6 +46,7 @@ import StarterBlocks from "./StarterBlocks";
 interface Props {
   onClose: () => void;
   modelType?: string;
+  typeIsSet?: boolean;
 }
 
 const modelTypes = [
@@ -83,8 +84,13 @@ const largeWidth = ["block"];
 
 const TextFieldWithCursorPosition = withCursorPosition(TextField);
 
-export const CreateModelDialogue = ({ onClose, modelType = "" }: Props) => {
+export const CreateModelDialogue = ({
+  onClose,
+  modelType = "templateset",
+  typeIsSet = false,
+}: Props) => {
   const [type, setType] = useState(modelType);
+  const [isTypeSet, setIsTypeSet] = useState(typeIsSet);
   const dispatch = useDispatch();
   const history = useHistory();
   const [selectedBlankBlock, setSelectedBlankBlock] = useState(false);
@@ -237,7 +243,7 @@ export const CreateModelDialogue = ({ onClose, modelType = "" }: Props) => {
   }, [error]);
 
   const getView = () => {
-    if (!model.type) {
+    if (!isTypeSet) {
       return (
         <>
           <DialogTitle component="div">
@@ -354,7 +360,10 @@ export const CreateModelDialogue = ({ onClose, modelType = "" }: Props) => {
             </Button>
             <Button
               variant="contained"
-              onClick={() => updateModel({ type })}
+              onClick={() => {
+                setIsTypeSet(true);
+                updateModel({ type });
+              }}
               disabled={!type}
               data-cy="create-model-next-button"
             >
@@ -573,7 +582,13 @@ export const CreateModelDialogue = ({ onClose, modelType = "" }: Props) => {
       open
       onClose={onClose}
       sx={{
-        py: "20px",
+        "& .MuiDialog-container": {
+          py: "20px",
+          alignItems:
+            largeWidth?.includes(model?.type) && !selectedBlankBlock
+              ? "flex-start"
+              : "center",
+        },
       }}
       fullScreen
       PaperProps={{
@@ -592,7 +607,7 @@ export const CreateModelDialogue = ({ onClose, modelType = "" }: Props) => {
               : "auto",
           minHeight:
             largeWidth?.includes(model?.type) && !selectedBlankBlock
-              ? "860px"
+              ? "680px"
               : "auto",
           maxHeight: "1240px",
           overflow: "hidden",

--- a/src/apps/schema/src/app/components/Sidebar/ModelList.tsx
+++ b/src/apps/schema/src/app/components/Sidebar/ModelList.tsx
@@ -167,6 +167,7 @@ export const ModelList = ({ title, models, type, app = "schema" }: Props) => {
 
       {showCreateModelDialogue && (
         <CreateModelDialogue
+          typeIsSet={true}
           modelType={type}
           onClose={() => setShowCreateModelDialogue(false)}
         />

--- a/src/apps/schema/src/app/components/StarterBlocks/StarterBlocksSelection.tsx
+++ b/src/apps/schema/src/app/components/StarterBlocks/StarterBlocksSelection.tsx
@@ -114,6 +114,7 @@ export type StarterBlocksSelectionProps = {
   setActiveStep: (step: "selection" | "form") => void;
   selectBlockType: (blockType: StarterBlockProps) => void;
   selectBlank?: () => void;
+  blockType?: StarterBlockProps;
 };
 
 export const StarterBlocksSelection: React.FC<StarterBlocksSelectionProps> = ({
@@ -121,18 +122,17 @@ export const StarterBlocksSelection: React.FC<StarterBlocksSelectionProps> = ({
   setActiveStep,
   selectBlockType,
   selectBlank,
+  blockType,
 }) => {
   const searchRef = useRef<HTMLDivElement>();
   const [filteredBlockTypes, setFilteredBlockTypes] =
     useState<StarterBlockProps[]>(STARTER_BLOCKS);
-  const [activeBlock, setActiveBlock] = useState(null);
 
   const [search, setSearch] = useState("");
 
-  const handleBlockSelect = (blockType: any) => {
+  const handleBlockSelect = (block: StarterBlockProps) => {
     return () => {
-      selectBlockType(blockType);
-      setActiveBlock(blockType);
+      selectBlockType(block);
     };
   };
 
@@ -142,11 +142,11 @@ export const StarterBlocksSelection: React.FC<StarterBlocksSelectionProps> = ({
   };
 
   const handleNext = useCallback(() => {
-    if (activeBlock?.name === "blank") return selectBlank();
-    if (!!activeBlock) {
+    if (blockType?.name === "blank") return selectBlank();
+    if (!!blockType) {
       setActiveStep("form");
     }
-  }, [activeBlock, setActiveStep]);
+  }, [blockType, setActiveStep]);
 
   useEffect(() => {
     if (!search) return setFilteredBlockTypes(STARTER_BLOCKS);
@@ -280,7 +280,7 @@ export const StarterBlocksSelection: React.FC<StarterBlocksSelectionProps> = ({
                 >
                   <BlockItem
                     block={block}
-                    isActive={activeBlock?.name === block?.name}
+                    isActive={blockType?.name === block?.name}
                     onClick={handleBlockSelect(block)}
                   />
                 </Grid>
@@ -304,7 +304,13 @@ export const StarterBlocksSelection: React.FC<StarterBlocksSelectionProps> = ({
         <Button
           variant="contained"
           onClick={handleNext}
-          disabled={!activeBlock}
+          disabled={
+            !blockType ||
+            !filteredBlockTypes?.length ||
+            !filteredBlockTypes?.filter(
+              (block) => block?.name === blockType?.name
+            )?.length
+          }
           data-cy="select-block-type-next-button"
         >
           Next

--- a/src/apps/schema/src/app/components/StarterBlocks/index.tsx
+++ b/src/apps/schema/src/app/components/StarterBlocks/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { STARTER_BLOCKS } from "./configs";
 
 import { StarterBlockForm } from "./StarterBlockForm";
 import { StarterBlocksSelection } from "./StarterBlocksSelection";
@@ -12,7 +13,7 @@ const StarterBlocksDialogue: React.FC<StarterBlocksDialogueProps> = ({
   onClose,
   selectBlank,
 }) => {
-  const [blockType, setBlockType] = useState(null);
+  const [blockType, setBlockType] = useState(STARTER_BLOCKS[0]);
   const [activeStep, setActiveStep] = useState<"selection" | "form">(
     "selection"
   );
@@ -25,6 +26,7 @@ const StarterBlocksDialogue: React.FC<StarterBlocksDialogueProps> = ({
           setActiveStep={setActiveStep}
           selectBlockType={setBlockType}
           selectBlank={selectBlank}
+          blockType={blockType}
         />
       ) : activeStep === "form" ? (
         <StarterBlockForm

--- a/src/shell/components/InviteMembersModal/ConfirmationDialog.tsx
+++ b/src/shell/components/InviteMembersModal/ConfirmationDialog.tsx
@@ -72,9 +72,12 @@ export const ConfirmationModal = ({
             borderRadius: "20px",
             backgroundColor: hasFailedInvites ? "red.100" : "green.100",
             display: "block",
+            width: "40px",
+            height: "40px",
+            mb: 1.5,
           }}
         />
-        <Typography variant="h5" fontWeight={700} sx={{ mt: 1.5 }}>
+        <Typography variant="h5" fontWeight={700}>
           {generateHeaderText()}
         </Typography>
 

--- a/src/shell/components/InviteMembersModal/index.tsx
+++ b/src/shell/components/InviteMembersModal/index.tsx
@@ -214,9 +214,12 @@ const InviteMembersModal = ({ onClose }: Props) => {
               borderRadius: "20px",
               backgroundColor: "deepOrange.50",
               display: "block",
+              width: "40px",
+              height: "40px",
+              mb: 1.5,
             }}
           />
-          <Box sx={{ mt: 1.5, fontWeight: 700 }}>Invite Users</Box>
+          <Box sx={{ fontWeight: 700 }}>Invite Users</Box>
           <Typography sx={{ mt: 1 }} variant="body2" color="text.secondary">
             These invites will be sent as emails
           </Typography>

--- a/src/shell/components/NoPermission.tsx
+++ b/src/shell/components/NoPermission.tsx
@@ -54,9 +54,12 @@ export const NoPermission = ({
             borderRadius: "20px",
             backgroundColor: "red.100",
             display: "block",
+            width: "40px",
+            height: "40px",
+            mb: 1.5,
           }}
         />
-        <Box fontWeight={700} mb={1} mt={1.5}>
+        <Box fontWeight={700} mb={1}>
           {headerTitle
             ? headerTitle
             : "You do not have permission to invite users"}


### PR DESCRIPTION
https://github.com/zesty-io/manager-ui/pull/3345#issuecomment-2764476808

## Modals

- [x] **Backdrop:** Implement the new Design System backdrop for all modals across the content, schema, and media apps.

- [x] **Modal Consistency:** Resolve the following interlinked issues:
    - [x] **Modal: Icon Size and Padding:** Standardize icon sizes, padding, and spacing across all modals.
    
# Blocks App

- [x] Create Block Modal Height is not set correctly. Please ensure the Modal height occupies the viewport's height with 20px padding at the top and 20px padding at the bottom. Add a minimum height of 680px and maximum height of 1240px. Please see how this same modal height behavior was implemented for the Select Item dialog modal of the One to Many field as a reference


## Enhancements

- [x] Create Block and Create Model Pop Up: Select First Option in list by default 
