### PR TITLE
[#3366]: Redirects: Delete Redirect Confirmation Modal

### DIFF
--- a/src/apps/seo/src/store/redirects.js
+++ b/src/apps/seo/src/store/redirects.js
@@ -115,11 +115,11 @@ export function removeRedirect(zuid) {
     dispatch({
       type: "REDIRECT_REMOVE",
     });
-    request(`${CONFIG.API_INSTANCE}/web/redirects/${zuid}`, {
+    return request(`${CONFIG.API_INSTANCE}/web/redirects/${zuid}`, {
       method: "DELETE",
     })
       .then((json) => {
-        if (!json.error) {
+        if (json.status === 200) {
           dispatch({
             type: "REDIRECT_REMOVE_SUCCESS",
             zuid,
@@ -132,6 +132,7 @@ export function removeRedirect(zuid) {
             })
           );
         }
+        return json;
       })
       .catch((err) => {
         dispatch(

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/DeleteDialog.tsx
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/DeleteDialog.tsx
@@ -1,0 +1,231 @@
+import { memo, useState, useCallback } from "react";
+import { useHistory } from "react-router";
+import LoadingButton from "@mui/lab/LoadingButton";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogTitle,
+  Typography,
+  Stack,
+  Box,
+} from "@mui/material";
+import { DeleteRounded } from "@mui/icons-material";
+import { useDispatch } from "react-redux";
+import { removeRedirect } from "../../../store/redirects";
+import { notify } from "../../../../../../shell/store/notifications";
+import { DialogContent } from "@mui/material";
+import { RedirectTargetCell } from "./RedirectTargetCell";
+import { CellWrapper } from "./RedirectTable";
+
+interface DeleteDialogProps {
+  open: boolean;
+  onClose: () => void;
+  ZUID: string;
+  path: string;
+  type: string;
+  target: string;
+  code: number;
+}
+
+export const DeleteDialog = memo(function DeleteDialog(
+  props: DeleteDialogProps
+) {
+  const { open, onClose, ZUID, path, type, target, code } = props;
+
+  const [deleting, setDeleting] = useState(false);
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  const handleDeleteFile = () => {
+    if (!ZUID) return;
+
+    try {
+      setDeleting(true);
+      Promise.resolve(dispatch(removeRedirect(ZUID))).then((res: any) => {
+        setDeleting(false);
+        onClose();
+        if (res.status === 200) {
+          dispatch(
+            notify({
+              kind: "error",
+              message: `Redirect Delete: ${path}`,
+            })
+          );
+        } else {
+          throw new Error(`Redirect Delete failed: ${path}`);
+        }
+      });
+    } catch (err) {
+      setDeleting(false);
+      onClose();
+    }
+  };
+  return (
+    <Dialog open={open} fullWidth maxWidth="xs" onClose={onClose}>
+      <DialogTitle>
+        <Box
+          sx={{
+            backgroundColor: "red.100",
+            borderRadius: "100%",
+            width: "40px",
+            height: "40px",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            mb: 1.5,
+          }}
+        >
+          <DeleteRounded color="error" />
+        </Box>
+        <Stack
+          display="flex"
+          flexDirection="row"
+          justifyContent="flex-start"
+          alignItems="center"
+          columnGap={1}
+          overflow="hidden"
+          textOverflow="ellipsis"
+        >
+          <Typography
+            variant="inherit"
+            fontWeight={700}
+            flexGrow={0}
+            flexShrink={0}
+          >
+            Delete Redirect:
+          </Typography>
+          <Typography variant="inherit" fontWeight={600} noWrap flexGrow={0}>
+            {`${path}`}
+          </Typography>
+        </Stack>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: "8px" }}>
+          Deleting this redirect will remove it immediately from your site. This
+          cannot be undone.
+        </Typography>
+      </DialogTitle>
+      <DialogContent>
+        <Typography
+          variant="body2"
+          color="text.primary"
+          mb="10px"
+          fontWeight={700}
+        >
+          More details
+        </Typography>
+        <Box
+          display="flex"
+          flexDirection="column"
+          sx={{
+            border: "1px solid",
+            borderColor: "grey.100",
+            borderRadius: "8px",
+          }}
+        >
+          <Box
+            display="flex"
+            flexDirection="row"
+            justifyContent="space-between"
+            alignItems="center"
+            px="16px"
+            py="14px"
+          >
+            <Typography
+              variant="body2"
+              color="text.primary"
+              width="160px"
+              flexGrow={0}
+              flexShrink={0}
+              fontWeight={700}
+            >
+              HTTP Code
+            </Typography>
+            <Typography variant="body2" color="text.primary" flexGrow={1}>
+              {code}
+            </Typography>
+          </Box>
+
+          <Box
+            display="flex"
+            flexDirection="row"
+            justifyContent="space-between"
+            alignItems="center"
+            px="16px"
+            py="14px"
+            borderTop="1px solid"
+            borderBottom="1px solid"
+            borderColor="grey.100"
+          >
+            <Typography
+              variant="body2"
+              color="text.primary"
+              width="160px"
+              flexGrow={0}
+              flexShrink={0}
+              fontWeight={700}
+            >
+              Redirect Type
+            </Typography>
+            <Typography variant="body2" color="text.primary" flexGrow={1}>
+              {type === "page"
+                ? "Internal"
+                : type === "path"
+                ? "Wildcard"
+                : type}
+            </Typography>
+          </Box>
+
+          <Box
+            display="flex"
+            flexDirection="row"
+            justifyContent="space-between"
+            alignItems="center"
+            px="16px"
+            py="14px"
+          >
+            <Typography
+              variant="body2"
+              color="text.primary"
+              width="160px"
+              flexGrow={0}
+              flexShrink={0}
+              fontWeight={700}
+            >
+              Redirect Target
+            </Typography>
+            <Typography
+              variant="body2"
+              color="info.main"
+              flexGrow={1}
+              display="flex"
+              alignItems="center"
+              gap="4px"
+              overflow="hidden"
+              textOverflow="ellipsis"
+            >
+              <RedirectTargetCell
+                wrapper={CellWrapper}
+                target={target}
+                targetType={type}
+              />
+            </Typography>
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="text" color="inherit" onClick={onClose}>
+          Cancel
+        </Button>
+        <LoadingButton
+          data-cy="DeleteContentItemConfirmButton"
+          variant="contained"
+          color="error"
+          onClick={handleDeleteFile}
+          loading={deleting}
+        >
+          Delete Forever
+        </LoadingButton>
+      </DialogActions>
+    </Dialog>
+  );
+});

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/DeleteDialog.tsx
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/DeleteDialog.tsx
@@ -1,5 +1,4 @@
-import { memo, useState, useCallback } from "react";
-import { useHistory } from "react-router";
+import { memo, useState } from "react";
 import LoadingButton from "@mui/lab/LoadingButton";
 import {
   Button,
@@ -34,17 +33,14 @@ export const DeleteDialog = memo(function DeleteDialog(
   const { open, onClose, ZUID, path, type, target, code } = props;
 
   const [deleting, setDeleting] = useState(false);
-  const history = useHistory();
   const dispatch = useDispatch();
 
   const handleDeleteFile = () => {
     if (!ZUID) return;
 
-    try {
-      setDeleting(true);
-      Promise.resolve(dispatch(removeRedirect(ZUID))).then((res: any) => {
-        setDeleting(false);
-        onClose();
+    setDeleting(true);
+    Promise.resolve(dispatch(removeRedirect(ZUID)))
+      .then((res: any) => {
         if (res.status === 200) {
           dispatch(
             notify({
@@ -52,14 +48,12 @@ export const DeleteDialog = memo(function DeleteDialog(
               message: `Redirect Delete: ${path}`,
             })
           );
-        } else {
-          throw new Error(`Redirect Delete failed: ${path}`);
         }
+      })
+      .finally(() => {
+        setDeleting(false);
+        onClose();
       });
-    } catch (err) {
-      setDeleting(false);
-      onClose();
-    }
   };
   return (
     <Dialog open={open} fullWidth maxWidth="xs" onClose={onClose}>

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
@@ -160,7 +160,7 @@ export function RedirectCreator(props) {
       </Box>
       <Box width="fit-content" flexGrow={0}>
         <Button
-          variant="outlined"
+          variant="contained"
           color="primary"
           size="small"
           onClick={handleCreateRedirect}

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectCreator/RedirectCreator.js
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import {
-  Button,
   ToggleButtonGroup,
   ToggleButton,
   TextField,
@@ -12,6 +11,7 @@ import SearchIcon from "@mui/icons-material/Search";
 import { createRedirect } from "../../../../store/redirects";
 import ContentSearch from "shell/components/LegacyContentSearch";
 import { Box } from "@mui/material";
+import LoadingButton from "@mui/lab/LoadingButton";
 
 const optionTypes = [
   { label: "Internal", value: "page" },
@@ -25,6 +25,7 @@ export function RedirectCreator(props) {
   const [code, setCode] = useState(301); // Toggle defaults to 301
   const [contentSearchValue, setContentSearchValue] = useState("");
   const [type, setType] = useState(optionTypes[0]); // Set initial type as full object
+  const [isLoading, setIsLoading] = useState(false);
 
   const determineTerm = (term) => {
     // ContentSearch return Object while Search return string
@@ -36,6 +37,7 @@ export function RedirectCreator(props) {
   };
 
   const handleCreateRedirect = () => {
+    setIsLoading(true);
     props
       .dispatch(
         createRedirect({
@@ -48,6 +50,9 @@ export function RedirectCreator(props) {
       .then(() => {
         setFrom("");
         setContentSearchValue("");
+      })
+      .finally(() => {
+        setIsLoading(false);
       });
   };
 
@@ -159,7 +164,8 @@ export function RedirectCreator(props) {
         )}
       </Box>
       <Box width="fit-content" flexGrow={0}>
-        <Button
+        <LoadingButton
+          loading={isLoading}
           variant="contained"
           color="primary"
           size="small"
@@ -171,7 +177,7 @@ export function RedirectCreator(props) {
           sx={{ whiteSpace: "nowrap" }}
         >
           Create Redirect
-        </Button>
+        </LoadingButton>
       </Box>
     </Box>
   );

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
@@ -48,6 +48,10 @@ export const CellWrapper = ({ color = "", children, type = "text" }) => {
 export default function RedirectTable(props) {
   const [deleteDialogIsOpen, setDeleteDialogIsOpen] = useState(false);
   const [deleteRedirect, setDeleteRedirect] = useState(null);
+  const [pinnedColumns, setPinnedColumns] = useState({
+    left: [],
+    right: ["actions"],
+  });
   const handleRemoveRedirect = useCallback((item) => {
     setDeleteRedirect(item);
     setDeleteDialogIsOpen(true);
@@ -58,13 +62,13 @@ export default function RedirectTable(props) {
       { field: "id", headerName: "Id", hide: true },
       {
         field: "path",
-        flex: 2,
+        minWidth: 206,
         renderHeader: () => (
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
             <Typography variant="body2" fontWeight={600} color="text.primary">
               Incoming Path
             </Typography>
-            <Tooltip title="File Path Only" placement="top-start">
+            <Tooltip title="File Path Only" placement="top">
               <InfoIcon fontSize="small" sx={{ color: "action.disabled" }} />
             </Tooltip>
           </Box>
@@ -83,6 +87,7 @@ export default function RedirectTable(props) {
       {
         field: "code",
         width: 185,
+        minWidth: 185,
         renderHeader: () => (
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
             <Typography variant="body2" fontWeight={600} color="text.primary">
@@ -95,7 +100,7 @@ export default function RedirectTable(props) {
                   302: Temporarily Moved
                 </>
               }
-              placement="top-start"
+              placement="top"
             >
               <InfoIcon fontSize="small" sx={{ color: "action.disabled" }} />
             </Tooltip>
@@ -114,26 +119,29 @@ export default function RedirectTable(props) {
       },
       {
         field: "targetType",
-        width: 195,
-        renderHeader: () => (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-            <Typography variant="body2" fontWeight={600} color="text.primary">
-              Redirect Type
-            </Typography>
-            <Tooltip
-              title={
-                <>
-                  Internal E.g. /about <br />
-                  External E.g. https://zesty.org/ <br />
-                  Wildcard E.g. /blog/*/*/
-                </>
-              }
-              placement="top-start"
-            >
-              <InfoIcon fontSize="small" sx={{ color: "action.disabled" }} />
-            </Tooltip>
-          </Box>
-        ),
+        width: 200,
+        minWidth: 200,
+        renderHeader: () => {
+          return (
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+              <Typography variant="body2" fontWeight={600} color="text.primary">
+                Redirect Type
+              </Typography>
+              <Tooltip
+                title={
+                  <>
+                    Internal E.g. /about <br />
+                    External E.g. https://zesty.org/ <br />
+                    Wildcard E.g. /blog/*/*/
+                  </>
+                }
+                placement="top"
+              >
+                <InfoIcon fontSize="small" sx={{ color: "action.disabled" }} />
+              </Tooltip>
+            </Box>
+          );
+        },
         renderCell: ({ value }) => {
           return (
             <CellWrapper>
@@ -159,12 +167,14 @@ export default function RedirectTable(props) {
       },
       {
         field: "target",
+        minWidth: 190,
+        flex: 1,
         headerName: (
           <Typography variant="body2" fontWeight={600} color="text.primary">
             Redirect Target
           </Typography>
         ),
-        flex: 2,
+
         renderCell: ({ value, row }) => (
           <RedirectTargetCell
             wrapper={CellWrapper}
@@ -177,6 +187,9 @@ export default function RedirectTable(props) {
         field: "actions",
         type: "actions",
         width: 40,
+        minWidth: 40,
+        maxWidth: 40,
+        resizable: false,
         getActions: ({ row }) => [
           <GridActionsCellItem
             icon={<DeleteIcon />}
@@ -238,8 +251,24 @@ export default function RedirectTable(props) {
           "& .MuiDataGrid-cell, & .MuiDataGrid-columnHeader": {
             outline: "none!important",
           },
+          "& .MuiDataGrid-pinnedColumnHeaders": {
+            bgcolor: "transparent",
+          },
+
+          "& .MuiDataGrid-columnHeader:hover": {
+            "& .MuiDataGrid-columnSeparator": {
+              visibility: "visible",
+            },
+          },
         }}
         hideFooter
+        pinnedColumns={pinnedColumns}
+        onPinnedColumnsChange={(e) => {
+          setPinnedColumns({
+            left: e?.left,
+            right: [...e?.right?.filter((col) => col !== "actions"), "actions"],
+          });
+        }}
       />
       <DeleteDialog
         open={deleteDialogIsOpen}

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
@@ -7,9 +7,6 @@ import ArrowForwardRoundedIcon from "@mui/icons-material/ArrowForwardRounded";
 import OpenInNewRoundedIcon from "@mui/icons-material/OpenInNewRounded";
 import InsertDriveFileRoundedIcon from "@mui/icons-material/InsertDriveFileRounded";
 import DescriptionRoundedIcon from "@mui/icons-material/DescriptionRounded";
-
-import { removeRedirect } from "../../../store/redirects";
-
 import { RedirectCreator } from "./RedirectCreator";
 import { RedirectTargetCell } from "./RedirectTargetCell";
 import { DeleteDialog } from "./DeleteDialog";
@@ -52,26 +49,6 @@ export default function RedirectTable(props) {
   const [deleteDialogIsOpen, setDeleteDialogIsOpen] = useState(false);
   const [deleteRedirect, setDeleteRedirect] = useState(null);
   const handleRemoveRedirect = useCallback((item) => {
-    // if (item?.targetType === "page") {
-    //   const targetPath = Object.values(props?.content).find(
-    //     (item) => item?.meta?.ZUID === item?.target
-    //   );
-    //   redirect.target = targetPath?.web?.path;
-    //   redirect.targetType = "internal";
-    // }
-
-    // console.debug("item: ", { item, redirects: props.redirects, redirect });
-
-    // const redirect = { ...item };
-
-    // if (redirect?.targetType === "page") {
-    //   redirect.targetType = "internal";
-    // }
-
-    // if (redirect?.targetType === "path") {
-    //   redirect.targetType = "wildcard";
-    // }
-
     setDeleteRedirect(item);
     setDeleteDialogIsOpen(true);
   }, []);
@@ -87,7 +64,7 @@ export default function RedirectTable(props) {
             <Typography variant="body2" fontWeight={600} color="text.primary">
               Incoming Path
             </Typography>
-            <Tooltip title="File Path Only" arrow placement="top-start">
+            <Tooltip title="File Path Only" placement="top-start">
               <InfoIcon fontSize="small" sx={{ color: "action.disabled" }} />
             </Tooltip>
           </Box>
@@ -118,7 +95,6 @@ export default function RedirectTable(props) {
                   302: Temporarily Moved
                 </>
               }
-              arrow
               placement="top-start"
             >
               <InfoIcon fontSize="small" sx={{ color: "action.disabled" }} />
@@ -152,7 +128,6 @@ export default function RedirectTable(props) {
                   Wildcard E.g. /blog/*/*/
                 </>
               }
-              arrow
               placement="top-start"
             >
               <InfoIcon fontSize="small" sx={{ color: "action.disabled" }} />
@@ -260,6 +235,9 @@ export default function RedirectTable(props) {
           bgcolor: "background.paper",
           color: "text.primary",
           fontSize: "typography.body2.fontSize",
+          "& .MuiDataGrid-cell, & .MuiDataGrid-columnHeader": {
+            outline: "none!important",
+          },
         }}
         hideFooter
       />

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectTable.js
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useState } from "react";
 import { DataGridPro, GridActionsCellItem } from "@mui/x-data-grid-pro";
 import { Box, Tooltip, Typography } from "@mui/material";
 import InfoIcon from "@mui/icons-material/InfoOutlined";
@@ -12,8 +12,9 @@ import { removeRedirect } from "../../../store/redirects";
 
 import { RedirectCreator } from "./RedirectCreator";
 import { RedirectTargetCell } from "./RedirectTargetCell";
+import { DeleteDialog } from "./DeleteDialog";
 
-const CellWrapper = ({ color = "", children, type = "text" }) => {
+export const CellWrapper = ({ color = "", children, type = "text" }) => {
   return (
     <Box
       sx={{
@@ -48,8 +49,31 @@ const CellWrapper = ({ color = "", children, type = "text" }) => {
 };
 
 export default function RedirectTable(props) {
-  const handleRemoveRedirect = useCallback((zuid) => {
-    props.dispatch(removeRedirect(zuid));
+  const [deleteDialogIsOpen, setDeleteDialogIsOpen] = useState(false);
+  const [deleteRedirect, setDeleteRedirect] = useState(null);
+  const handleRemoveRedirect = useCallback((item) => {
+    // if (item?.targetType === "page") {
+    //   const targetPath = Object.values(props?.content).find(
+    //     (item) => item?.meta?.ZUID === item?.target
+    //   );
+    //   redirect.target = targetPath?.web?.path;
+    //   redirect.targetType = "internal";
+    // }
+
+    // console.debug("item: ", { item, redirects: props.redirects, redirect });
+
+    // const redirect = { ...item };
+
+    // if (redirect?.targetType === "page") {
+    //   redirect.targetType = "internal";
+    // }
+
+    // if (redirect?.targetType === "path") {
+    //   redirect.targetType = "wildcard";
+    // }
+
+    setDeleteRedirect(item);
+    setDeleteDialogIsOpen(true);
   }, []);
 
   const columns = useMemo(
@@ -183,7 +207,7 @@ export default function RedirectTable(props) {
             icon={<DeleteIcon />}
             color="action.secondary"
             label="Delete"
-            onClick={() => handleRemoveRedirect(row.ZUID)}
+            onClick={() => handleRemoveRedirect(row)}
           />,
         ],
       },
@@ -238,6 +262,15 @@ export default function RedirectTable(props) {
           fontSize: "typography.body2.fontSize",
         }}
         hideFooter
+      />
+      <DeleteDialog
+        open={deleteDialogIsOpen}
+        onClose={() => setDeleteDialogIsOpen(false)}
+        ZUID={deleteRedirect?.ZUID}
+        path={deleteRedirect?.path}
+        type={deleteRedirect?.targetType}
+        target={deleteRedirect?.target}
+        code={deleteRedirect?.code}
       />
     </Box>
   );

--- a/src/shell/index.js
+++ b/src/shell/index.js
@@ -63,12 +63,11 @@ const appTheme = createTheme(theme, {
     },
 
     action: {
-      active: "rgba(127, 127, 126, 0.7)",
+      active: "rgba(127, 127, 126, 0.68)",
       selected: "rgba(127,127, 126, 0.125)",
-      disabled: "rgba(127,127, 126, 0.47)",
-      disabledBackground: "rgba(127,127, 126, 0.28)",
+      disabled: "rgba(127,127, 126, 0.48)",
+      disabledBackground: "rgba(127,127, 126, 0.15)",
       hover: "rgba(127, 127, 126, 0.07)",
-      hoverOpacity: 0.1,
     },
     background: {
       editor: "#0F0F0F",

--- a/src/shell/index.js
+++ b/src/shell/index.js
@@ -63,10 +63,10 @@ const appTheme = createTheme(theme, {
     },
 
     action: {
-      active: "rgba(127, 127, 126, 0.68)",
+      active: "rgba(127, 127, 126, 0.7)",
       selected: "rgba(127,127, 126, 0.125)",
-      disabled: "rgba(127,127, 126, 0.48)",
-      disabledBackground: "rgba(127,127, 126, 0.15)",
+      disabled: "rgba(127,127, 126, 0.47)",
+      disabledBackground: "rgba(127,127, 126, 0.28)",
       hover: "rgba(127, 127, 126, 0.07)",
     },
     background: {


### PR DESCRIPTION
1.  **Confirmation Modal:** Before a redirect is deleted, display a modal dialog asking the user to explicitly confirm the action.
2.  **Success Notification:** After a redirect has been successfully deleted, display a notification (e.g., a toast message) to inform the user the action was completed.

## Enhancements
- [x] Make Create Redirect into a Primary Filled Button (instead of Outline). 
- [x] Add ability to resize columns to maintain feature parity.
- [x] Remove pointy arrows from tooltip.
- [x] Add Delete Redirect Confirmation Modal when user clicks on delete button. 

https://github.com/user-attachments/assets/9ddfd1c3-23e7-44c0-a7b1-4e4693b19f9d