### PR TITLE
[Content] Make sure ref exists before calculating offsets

### DIFF
--- a/src/shell/components/Comment/CommentsList.tsx
+++ b/src/shell/components/Comment/CommentsList.tsx
@@ -73,10 +73,12 @@ export const CommentsList = ({
     }
 
     setTimeout(() => {
-      const { top, bottom } = topOffsetRef.current?.getBoundingClientRect();
+      if (topOffsetRef.current?.getBoundingClientRect()) {
+        const { top, bottom } = topOffsetRef.current.getBoundingClientRect();
 
-      setPopperTopOffset(top);
-      setPopperBottomOffset(bottom);
+        setPopperTopOffset(top);
+        setPopperBottomOffset(bottom);
+      }
     });
 
     // HACK: Prevents UI flicker when popper renders and is temporarily out of bounds


### PR DESCRIPTION
Prevents error when trying to calculate and set offsets when ref does not exists
Resolves #3346 