### PR TITLE
[Content] Default to 0 when a user deletes all input field value

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemList/TableCells/SortCell.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/TableCells/SortCell.tsx
@@ -17,7 +17,7 @@ export const SortCell = ({ params }: { params: GridRenderCellParams }) => {
         (params.value?.toString() || "0")
       }
       onChange={(evt) => {
-        handleChange(parseInt(evt.target.value));
+        handleChange(parseInt(evt.target.value) || 0);
       }}
       onClick={(e) => e.stopPropagation()}
       InputProps={{


### PR DESCRIPTION
The original issue has already been fixed on a different PR (#3443)
Just had to fix a minor issue where completely deleting all the value on the input field makes the value NaN instead of  defaulting to 0.
Resolves #3427 

### Preview
[Content---nar-test-schema---Zesty-io---zesty-pw---Manager.webm](https://github.com/user-attachments/assets/4cf4f405-beaf-46ca-a283-be3fed4e7401)
