### PR TITLE
[Blocks] Remove bypassError to show if there's an error in block preview

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/PreviewMode/PreviewMode.js
+++ b/src/apps/content-editor/src/app/components/Editor/PreviewMode/PreviewMode.js
@@ -33,7 +33,7 @@ export default function PreviewMode(props) {
         let url = "";
 
         if (props?.model?.type === "block") {
-          url = `/-/block/${props?.model?.name}.html?variant=${item?.meta?.ZUID}&version=${props.version}&preview=global&_bypassError=true`;
+          url = `/-/block/${props?.model?.name}.html?variant=${item?.meta?.ZUID}&version=${props.version}&preview=global`;
         } else {
           url = item?.web?.path
             ? `${item.web.path}`


### PR DESCRIPTION
Removed _bypassError flag to let users know if there's a parsely error in the block's preview. 
Resolves #3485 

![image](https://github.com/user-attachments/assets/1a45252f-03d6-4498-b528-c2aaca2eaa38)
