### PR TITLE
[Content] Prevent No Fields screen from briefly flashing

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.js
@@ -24,9 +24,10 @@ export default function Content(props) {
     "zesty:content:sidebarOpen",
     false
   );
-  const { data: fields } = useGetContentModelFieldsQuery(props.modelZUID, {
-    skip: !props.modelZUID,
-  });
+  const { data: fields, isFetching: isFetchingFields } =
+    useGetContentModelFieldsQuery(props.modelZUID, {
+      skip: !props.modelZUID,
+    });
 
   const hasFields = useMemo(() => {
     if (!fields) return false;
@@ -64,7 +65,7 @@ export default function Content(props) {
       !Object.keys(props.item?.web).length ||
       !Object.keys(props.item?.meta).length);
 
-  if (!hasFields) {
+  if (!hasFields && !isFetchingFields) {
     return (
       <Stack height="100%" mx={3} justifyContent="center">
         <NoFields />


### PR DESCRIPTION
Makes sure that the No Fields screen does not briefly flash while the fields are being loaded. Fixes #3509 

[Content---content-6-e6e59ab5c3-rk7hzd-7-9cbcf1bfcc-wkv3lw---Zesty-io---zesty-pw---Manager.webm](https://github.com/user-attachments/assets/887427dd-d8a0-4e26-881e-2525751316df)
