### PR TITLE
[Content] Keep selected rows even when filtering in the relational field selector dialog

### DIFF
--- a/cypress/e2e/content/content.spec.js
+++ b/cypress/e2e/content/content.spec.js
@@ -562,5 +562,16 @@ describe("Content Specs", () => {
         retries: 1,
       }).should("have.length", 3);
     });
+
+    it("preserves selected items while filtering", () => {
+      cy.get("#12-269a28-1bkm34 [data-cy='add-relational-item-button']").click({
+        force: true,
+      });
+
+      cy.getBySelector("relational-fields-search-input")
+        .find("input")
+        .type("someveryrandomtextthatshouldnotmatchanything");
+      cy.contains("3 selected").should("exist");
+    });
   });
 });

--- a/src/shell/components/RelationalFieldBase/FieldSelectorDialog/index.tsx
+++ b/src/shell/components/RelationalFieldBase/FieldSelectorDialog/index.tsx
@@ -475,7 +475,7 @@ export const FieldSelectorDialog = ({
     });
 
     return _rows;
-  }, [mappedRows, filterKeyword, relatedModelFields]);
+  }, [mappedRows, relatedModelFields]);
 
   const deletedItemZUIDs = useMemo(() => {
     if (!contentItems?.length || !selectedZUIDs) return [];
@@ -597,6 +597,7 @@ export const FieldSelectorDialog = ({
             <AutoSizer>
               {({ width, height }: Size) => (
                 <DataGridPro
+                  keepNonExistentRowsSelected
                   style={{
                     width: width,
                     height: height,

--- a/src/shell/components/RelationalFieldBase/FieldSelectorDialog/index.tsx
+++ b/src/shell/components/RelationalFieldBase/FieldSelectorDialog/index.tsx
@@ -559,6 +559,7 @@ export const FieldSelectorDialog = ({
         }}
       >
         <TextField
+          data-cy="relational-fields-search-input"
           ref={searchField}
           fullWidth
           onChange={(evt) => debouncedSetFilterKeyword(evt.currentTarget.value)}


### PR DESCRIPTION
Preserve row selections even when filtering the related items table
Fixes #3527 

[Content---nar-test-2---Zesty-io---zesty-pw---Manager (1).webm](https://github.com/user-attachments/assets/e5813065-4eae-4795-8bec-00813d8765f8)
