### PR TITLE
[Content] Show an asterisk to required fields during model field creation

### DIFF
--- a/src/apps/schema/src/app/components/AddFieldModal/FieldFormInput.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/FieldFormInput.tsx
@@ -323,7 +323,7 @@ export const FieldFormInput = ({
             height={18}
           >
             <Typography component="span" variant="body2" fontWeight={600}>
-              {fieldConfig.label}
+              {fieldConfig.label} {fieldConfig.required && "*"}
             </Typography>
             {fieldConfig.label?.toLowerCase().includes("description") && (
               <Typography


### PR DESCRIPTION
Show an asterisk to visually indicate a required field when creating a new field on a model
Resolves #3354 

**Creating a new field**
![image](https://github.com/user-attachments/assets/7fc72f15-eaa2-47e1-8693-a245ae459a64)

**Editing an existing field**
![image](https://github.com/user-attachments/assets/9f129d9c-72e0-4e26-b4e9-45c604eae518)
