### PR TITLE
[Content] Clear wysiwyg char length error when value is updated

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/Editor.js
+++ b/src/apps/content-editor/src/app/components/Editor/Editor.js
@@ -202,8 +202,13 @@ export default memo(function Editor({
         };
       }
 
-      if (field.datatype === "one_to_many") {
+      if (
+        ["one_to_many", "wysiwyg_advanced", "wysiwyg_basic"].includes(
+          field.datatype
+        )
+      ) {
         // Clear out the error after changing the value
+        // Note: These errors are most of the time validation errors from the api
         errors[name] = {
           ...(errors[name] ?? []),
           CUSTOM_ERROR: "",


### PR DESCRIPTION
Clears out the char length validation error from the api whenever the wysiwyg value is updated
Resolves #3541 

https://github.com/user-attachments/assets/8421ca36-b680-411a-b187-2fec49b310d4

