### PR TITLE
[Content] Permanently remove deleted content items from cache even on page refresh

### DIFF
--- a/cypress/e2e/content/item-list-table.spec.js
+++ b/cypress/e2e/content/item-list-table.spec.js
@@ -1,3 +1,5 @@
+const NOW = Date.now();
+
 describe("Content item list table", () => {
   it("Resolves internal link zuids", () => {
     cy.waitOn("/search/items*", () => {
@@ -12,5 +14,38 @@ describe("Content item list table", () => {
         "5 Tricks to Teach Your Pitbull: Fun & Easy Tips for You & Your Dog!",
         { timeout: 15_000 }
       );
+  });
+
+  it("properly removes deleted content items from cache even after page reload", () => {
+    cy.waitOn("/search/items*", () => {
+      cy.waitOn("/v1/content/models*", () => {
+        cy.visit("/content/6-a1a600-k0b6f0/new");
+      });
+    });
+
+    cy.intercept("/search/items*").as("searchItems");
+    cy.intercept("/v1/content/models*").as("contentModels");
+
+    cy.get("input[name=title]").clear().type(`Delete me ${NOW}`);
+    cy.getBySelector("ManualMetaFlow").click();
+    cy.getBySelector("metaDescription")
+      .find("textarea")
+      .first()
+      .clear()
+      .type(`Delete me ${NOW}`);
+    cy.getBySelector("CreateItemSaveButton").click();
+
+    cy.contains("Created Item").should("exist");
+
+    cy.visit("/content/6-a1a600-k0b6f0");
+
+    cy.get(".MuiDataGrid-cellCheckbox").first().click();
+    cy.getBySelector("MultiPageTableDelete").click();
+    cy.getBySelector("ConfirmMultiPageTableDelete").click();
+
+    cy.reload();
+    cy.wait("@contentModels");
+
+    cy.contains(`Delete me ${NOW}`).should("not.exist");
   });
 });

--- a/src/apps/content-editor/src/app/views/ItemList/ConfirmDeletesDialog.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/ConfirmDeletesDialog.tsx
@@ -68,6 +68,7 @@ export const ConfirmDeletesDialog = ({
           Cancel
         </Button>
         <Button
+          data-cy="ConfirmMultiPageTableDelete"
           action={(actions) => (actionRef.current = actions)}
           variant="contained"
           color="error"

--- a/src/apps/content-editor/src/app/views/ItemList/UpdateListActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/UpdateListActions.tsx
@@ -221,6 +221,7 @@ export const UpdateListActions = ({ items }: UpdateListActionsProps) => {
             </Tooltip>
           ) : canDelete ? (
             <LoadingButton
+              data-cy="MultiPageTableDelete"
               loading={isDeleting}
               onClick={() => {
                 setShowDeletesModal(true);

--- a/src/shell/store/middleware/local-storage.js
+++ b/src/shell/store/middleware/local-storage.js
@@ -36,6 +36,7 @@ export const localStorage = (store) => (next) => (action) => {
       case "FETCH_ITEM_SUCCESS":
       case "FETCH_ITEMS_SUCCESS":
       case "SEARCH_ITEMS_SUCCESS":
+      case "REMOVE_ITEM":
         idb.set(`${state.instance.ZUID}:content`, state.content);
         break;
 


### PR DESCRIPTION
When a content item is deleted, immediately save the changes to indexedDB so it stays deleted even on page refresh.

[Content---Multipage-Delete-Bug---Zesty-io---zesty-pw---Manager.webm](https://github.com/user-attachments/assets/9d320e58-acf3-4d09-a046-d7d739e6eda6)
