### PR TITLE
[Content] Fallback to modelZUID when viewing quick access API from multipage table

### DIFF
--- a/src/apps/content-editor/src/app/components/APIEndpoints.tsx
+++ b/src/apps/content-editor/src/app/components/APIEndpoints.tsx
@@ -18,7 +18,8 @@ type APIEndpointsProps = {
   type: Extract<ApiType, "quick-access" | "site-generators">;
 };
 export const APIEndpoints = ({ type }: APIEndpointsProps) => {
-  const { itemZUID } = useParams<{
+  const { modelZUID, itemZUID } = useParams<{
+    modelZUID: string;
     itemZUID: string;
   }>();
   const item = useSelector(
@@ -28,7 +29,7 @@ export const APIEndpoints = ({ type }: APIEndpointsProps) => {
   const { data: domains } = useGetDomainsQuery();
 
   const apiTypeEndpointMap: Partial<Record<ApiType, string>> = {
-    "quick-access": `/-/instant/${itemZUID}.json`,
+    "quick-access": `/-/instant/${itemZUID || modelZUID}.json`,
     "site-generators": item ? `/${item?.web?.path}/?toJSON` : "/?toJSON",
   };
 

--- a/src/apps/content-editor/src/app/views/ItemList/ItemListActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/ItemListActions.tsx
@@ -235,3 +235,5 @@ export const ItemListActions = forwardRef((props, ref) => {
     </Box>
   );
 });
+
+ItemListActions.displayName = "ItemListActions";


### PR DESCRIPTION
Ensure that when a user tries to view the quick access api from the multipage table, we use the modelZUID.

[Content---Articles---Zesty-io---zesty-pw---Manager.webm](https://github.com/user-attachments/assets/905acf00-b250-4514-bc03-11dc0e3e119c)
