### PR TITLE
[Content] Properly import and set prosemirror plugins

### DIFF
--- a/src/shell/components/FieldTypeEditor/Editors/react-prosemirror-plugins/index.js
+++ b/src/shell/components/FieldTypeEditor/Editors/react-prosemirror-plugins/index.js
@@ -1,1 +1,1 @@
-export { default as plugins } from "./plugins";
+export { plugins } from "./plugins";

--- a/src/shell/components/FieldTypeEditor/Editors/react-prosemirror-plugins/plugins.js
+++ b/src/shell/components/FieldTypeEditor/Editors/react-prosemirror-plugins/plugins.js
@@ -3,6 +3,7 @@ import { dropCursor } from "prosemirror-dropcursor";
 import { gapCursor } from "prosemirror-gapcursor";
 import { placeholder } from "@aeaton/prosemirror-placeholder";
 import { footnotes } from "@aeaton/prosemirror-footnotes";
+import { PluginKey, Plugin } from "prosemirror-state";
 
 import keys from "./keys";
 import rules from "./rules";
@@ -12,14 +13,38 @@ import "prosemirror-gapcursor/style/gapcursor.css";
 import "@aeaton/prosemirror-footnotes/style/footnotes.css";
 import "@aeaton/prosemirror-placeholder/style/placeholder.css";
 
+const placeholderKey = new PluginKey("custom-placeholder");
+const footnotesKey = new PluginKey("custom-footnotes");
+
+// Clone the original plugins with custom keys
+const placeholderPlugin = placeholder();
+const customPlaceholderPlugin = new Plugin({
+  key: placeholderKey,
+  props: placeholderPlugin.props || {},
+});
+
+const footnotesPlugin = footnotes();
+const customFootnotesPlugin = new Plugin({
+  key: footnotesKey,
+  state: {
+    init: footnotesPlugin.state?.init || (() => {}),
+    apply: footnotesPlugin.state?.apply || ((tr, value) => value),
+  },
+  props: footnotesPlugin.props || {},
+});
+
+const dropCursorPlugin = dropCursor();
+const gapCursorPlugin = gapCursor();
+const historyPlugin = history();
+
 const plugins = [
   rules,
   keys,
-  placeholder(),
-  footnotes(),
-  dropCursor(),
-  gapCursor(),
-  history(),
+  customPlaceholderPlugin,
+  customFootnotesPlugin,
+  dropCursorPlugin,
+  gapCursorPlugin,
+  historyPlugin,
 ];
 
 export { plugins };


### PR DESCRIPTION
Properly import prosemirror plugins and added workaround to prevent duplicate plugin key error which causes the app to crash
Resolves #3613 

[Content---All-Field-Types---Zesty-io---zesty-pw---Manager (1).webm](https://github.com/user-attachments/assets/212a7d6a-cc88-4847-a31e-f128724044d1)
