### PR TITLE
[Code] Automatically open create new file dialog when create code file is selected on launchpad FAB

### DIFF
--- a/cypress/e2e/code/all-files-page.spec.js
+++ b/cypress/e2e/code/all-files-page.spec.js
@@ -35,6 +35,11 @@ describe("All Files Page", () => {
     cy.getElement('[data-cy="AllFilesTable"]').should("exist");
   });
 
+  it("Automatically opens create file dialog if URL search param includes ?triggerCreate=true", () => {
+    cy.visit("/code?triggerCreate=true");
+    cy.getElement('[data-cy="CodeAppCreateFileDialog"]').should("exist");
+  });
+
   it("Create New File", () => {
     cy.visit("/code");
     cy.getElement('[data-cy="AllFilesCreateButton"]').click();

--- a/src/apps/code-editor/src/app/components/RecentFiles/index.tsx
+++ b/src/apps/code-editor/src/app/components/RecentFiles/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import { Box } from "@mui/material";
 
 import { TopBar } from "./TopBar";
@@ -7,7 +7,7 @@ import { DevResources } from "./DevResources";
 import { useSelector } from "react-redux";
 import { AppState } from "../../../../../../shell/store/types";
 import { NavCodeTypes } from "../constants";
-import { useMemo } from "react";
+import { useParams as useSearchParams } from "../../../../../../shell/hooks/useParams";
 
 type RecentFilesProps = {
   openCreateFileDialog: (
@@ -20,6 +20,13 @@ export const RecentFiles = ({ openCreateFileDialog }: RecentFilesProps) => {
   const searchInputRef = useRef(undefined);
   const files = useSelector((state: AppState) => state?.navCode?.raw);
   const [searchKeyword, setSearchKeyword] = useState("");
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get("triggerCreate") === "true") {
+      openCreateFileDialog("snippet", "file");
+    }
+  }, [searchParams]);
 
   const recentFiles = useMemo(() => {
     if (!files?.length) return;


### PR DESCRIPTION
Ensure that the create new code file dialog automatically opens when the create code file option is selected from the launchpad FAB
Fixes #3594 

[Launchpad---Zesty-io---zesty-pw---Manager.webm](https://github.com/user-attachments/assets/c659c109-1b26-4c36-9f10-e26d383363fc)
