### PR TITLE
[Global] Prevent AI drawer from overflowing browser width

### DIFF
--- a/src/apps/content-editor/src/app/views/Analytics/views/AnalyticsDashboard/ItemsTable/ItemsTable.tsx
+++ b/src/apps/content-editor/src/app/views/Analytics/views/AnalyticsDashboard/ItemsTable/ItemsTable.tsx
@@ -8,6 +8,7 @@ import {
   TrendingDownRounded,
 } from "@mui/icons-material";
 import { DataGridPro, GridRenderCellParams } from "@mui/x-data-grid-pro";
+import AutoSizer, { Size } from "react-virtualized-auto-sizer";
 import {
   useGetAnalyticsPropertiesQuery,
   useGetAnalyticsPropertyDataByQueryQuery,
@@ -343,8 +344,8 @@ export const ItemsTableContent = ({
     })) || [];
 
   return (
-    <>
-      <Box height="718px">
+    <AutoSizer>
+      {({ width }: Size) => (
         <DataGridPro
           rows={
             isFetching || showSkeleton
@@ -357,6 +358,7 @@ export const ItemsTableContent = ({
           disableColumnMenu
           disableSelectionOnClick
           rowHeight={66}
+          style={{ width, height: 781 }}
           sx={{
             ".MuiDataGrid-virtualScrollerContent": {
               backgroundColor: "background.paper",
@@ -373,7 +375,7 @@ export const ItemsTableContent = ({
             },
           }}
         />
-      </Box>
-    </>
+      )}
+    </AutoSizer>
   );
 };

--- a/src/apps/home/app/components/ResourceTable.tsx
+++ b/src/apps/home/app/components/ResourceTable.tsx
@@ -13,6 +13,7 @@ import { Database } from "@zesty-io/material";
 import { useHistory } from "react-router";
 import { useMemo } from "react";
 import { uniqBy } from "lodash";
+import AutoSizer, { Size } from "react-virtualized-auto-sizer";
 import { EmptyState } from "./EmptyState";
 import { resolveUrlFromAudit } from "../../../../utility/resolveResourceUrlFromAudit";
 import { Audit } from "../../../../shell/services/types";
@@ -167,30 +168,37 @@ export const ResourceTable = ({ dateRange }: Props) => {
   }
 
   return (
-    <DataGridPro
-      // @ts-expect-error - missing types for headerAlign and align on DataGridPro
-      columns={columns}
-      rows={
-        uniqBy(
-          audit?.filter((resource) =>
-            viewableResourceTypes.includes(resource.resourceType)
-          ),
-          "affectedZUID"
-        )?.map((row: any) => ({ id: row.ZUID, ...row })) || []
-      }
-      rowHeight={52}
-      hideFooter
-      disableSelectionOnClick
-      disableColumnFilter
-      loading={isAuditFetching}
-      onRowClick={(params) => handleRowClick(params.row)}
-      onCellClick={() => {}}
-      sx={{
-        backgroundColor: "common.white",
-        ".MuiDataGrid-row": {
-          cursor: "pointer",
-        },
-      }}
-    />
+    <Box width="100%">
+      <AutoSizer>
+        {({ width, height }: Size) => (
+          <DataGridPro
+            // @ts-expect-error - missing types for headerAlign and align on DataGridPro
+            columns={columns}
+            rows={
+              uniqBy(
+                audit?.filter((resource) =>
+                  viewableResourceTypes.includes(resource.resourceType)
+                ),
+                "affectedZUID"
+              )?.map((row: any) => ({ id: row.ZUID, ...row })) || []
+            }
+            rowHeight={52}
+            hideFooter
+            disableSelectionOnClick
+            disableColumnFilter
+            loading={isAuditFetching}
+            onRowClick={(params) => handleRowClick(params.row)}
+            onCellClick={() => {}}
+            style={{ width, height }}
+            sx={{
+              backgroundColor: "common.white",
+              ".MuiDataGrid-row": {
+                cursor: "pointer",
+              },
+            }}
+          />
+        )}
+      </AutoSizer>
+    </Box>
   );
 };


### PR DESCRIPTION
Make sure that the AI drawer doesn't overflow the browser width when opened on the launchpad and the content app dashboard
Resolves #3577 

[Launchpad---Zesty-io---zesty-pw---Manager (1).webm](https://github.com/user-attachments/assets/c81fa2d2-a145-4589-88d4-85275777f23e)
