### PR TITLE
[Activity Log] Show workflow status name instead of workflow status ZUID

### DIFF
--- a/src/apps/reports/src/app/views/ActivityLog/components/ActionTimelineItem/TimelineItem.js
+++ b/src/apps/reports/src/app/views/ActivityLog/components/ActionTimelineItem/TimelineItem.js
@@ -17,6 +17,7 @@ import {
   faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { useHistory, useLocation } from "react-router";
+import { useGetWorkflowStatusLabelsQuery } from "../../../../../../../../shell/services/instance";
 
 const actionIconMap = {
   1: faPencilAlt,
@@ -48,6 +49,10 @@ const actionIconColorMap = {
 export const TimelineItem = (props) => {
   const location = useLocation();
   const history = useHistory();
+  const {
+    data: workflowStatusLabels,
+    isLoading: isLoadingWorkflowStatusLabels,
+  } = useGetWorkflowStatusLabelsQuery({ showDeleted: true });
 
   const actionMessage = useMemo(() => {
     if (props.action?.meta?.uri?.includes("labels")) {
@@ -55,7 +60,13 @@ export const TimelineItem = (props) => {
       // This regex captures the labels inside the backticks.
       const match = props.action?.meta?.message?.match(/`([^`]*)`/);
       const labels = match?.[1]
-        ? match[1].split(",").map((label) => `"${label}"`)
+        ? match[1].split(",").map((labelZUID) => {
+            const workflowStatus = workflowStatusLabels?.find(
+              (label) => label.ZUID === labelZUID
+            );
+
+            return `"${workflowStatus?.name || labelZUID}"`;
+          })
         : [];
 
       switch (props.action?.action) {

--- a/src/apps/reports/src/app/views/ActivityLog/components/ResourceHeaderTitle.tsx
+++ b/src/apps/reports/src/app/views/ActivityLog/components/ResourceHeaderTitle.tsx
@@ -13,6 +13,7 @@ import {
   useGetContentItemQuery,
   useGetContentModelsQuery,
   useGetInstanceSettingsQuery,
+  useGetWorkflowStatusLabelsQuery,
 } from "../../../../../../../shell/services/instance";
 import {
   modelNameMap,
@@ -42,6 +43,10 @@ export const ResourceHeaderTitle = ({
     useGetContentModelsQuery();
   const { data: instanceSettings, isLoading: isLoadingInstanceSettings } =
     useGetInstanceSettingsQuery();
+  const {
+    data: workflowStatusLabels,
+    isLoading: isLoadingWorkflowStatusLabels,
+  } = useGetWorkflowStatusLabelsQuery({ showDeleted: true });
   const fileData = useSelector((state: AppState) =>
     Object.values(state.files).find((item) => item.ZUID === affectedZUID)
   );
@@ -50,6 +55,7 @@ export const ResourceHeaderTitle = ({
     isLoadingContentItem ||
     isLoadingContentModels ||
     isLoadingActions ||
+    isLoadingWorkflowStatusLabels ||
     isLoadingInstanceSettings;
 
   const headerData = useMemo(() => {
@@ -115,6 +121,21 @@ export const ResourceHeaderTitle = ({
 
           case "21":
             data.title = "Head Tag";
+            break;
+
+          case "36":
+            const workflowStatusData = workflowStatusLabels?.find(
+              (label) => label.ZUID === affectedZUID
+            );
+
+            if (workflowStatusData?.name) {
+              data.title = actionDescription?.replace(
+                /`([^`]+)`/g,
+                `"${workflowStatusData?.name}"`
+              );
+            } else {
+              data.title = actionDescription;
+            }
             break;
 
           default:

--- a/src/apps/reports/src/app/views/ActivityLog/components/ResourceHeaderTitle.tsx
+++ b/src/apps/reports/src/app/views/ActivityLog/components/ResourceHeaderTitle.tsx
@@ -131,7 +131,7 @@ export const ResourceHeaderTitle = ({
             if (workflowStatusData?.name) {
               data.title = actionDescription?.replace(
                 /`([^`]+)`/g,
-                `"${workflowStatusData?.name}"`
+                `${workflowStatusData?.name}`
               );
             } else {
               data.title = actionDescription;

--- a/src/apps/reports/src/app/views/ActivityLog/components/ResourceListItem/SettingsResourceListItem.js
+++ b/src/apps/reports/src/app/views/ActivityLog/components/ResourceListItem/SettingsResourceListItem.js
@@ -34,7 +34,7 @@ export const SettingsResourceListItem = (props) => {
         if (workflowStatusData?.name) {
           return props.message?.replace(
             /`([^`]+)`/g,
-            `"${workflowStatusData?.name}"`
+            `${workflowStatusData?.name}`
           );
         }
         return props.message;

--- a/src/apps/reports/src/app/views/ActivityLog/components/ResourceListItem/SettingsResourceListItem.js
+++ b/src/apps/reports/src/app/views/ActivityLog/components/ResourceListItem/SettingsResourceListItem.js
@@ -3,13 +3,24 @@ import { faCog } from "@fortawesome/free-solid-svg-icons";
 import moment from "moment";
 import { useSelector } from "react-redux";
 import { ListItem } from "./ListItem";
+import { useGetWorkflowStatusLabelsQuery } from "../../../../../../../../shell/services/instance";
 
 export const SettingsResourceListItem = (props) => {
+  const { data: workflowStatusLabels } = useGetWorkflowStatusLabelsQuery();
   const settingsData = useSelector((state) =>
     state.settings.instance.find(
       (instanceSetting) => instanceSetting.ZUID === props.affectedZUID
     )
   );
+
+  const workflowStatusData = useMemo(() => {
+    if (!workflowStatusLabels || !props.affectedZUID?.startsWith("36"))
+      return null;
+
+    return workflowStatusLabels.find(
+      (label) => label.ZUID === props.affectedZUID
+    );
+  }, [workflowStatusLabels, props.affectedZUID]);
 
   const primaryText = useMemo(() => {
     switch (props.affectedZUID?.split("-")?.[0]) {
@@ -17,6 +28,14 @@ export const SettingsResourceListItem = (props) => {
         return settingsData?.keyFriendly || props.message;
       case "21":
         return "Head Tag";
+      case "36":
+        if (workflowStatusData?.name) {
+          return props.message?.replace(
+            /`([^`]+)`/g,
+            `"${workflowStatusData?.name}"`
+          );
+        }
+        return props.message;
       default:
         return props.message;
     }

--- a/src/apps/reports/src/app/views/ActivityLog/components/ResourceListItem/SettingsResourceListItem.js
+++ b/src/apps/reports/src/app/views/ActivityLog/components/ResourceListItem/SettingsResourceListItem.js
@@ -6,7 +6,9 @@ import { ListItem } from "./ListItem";
 import { useGetWorkflowStatusLabelsQuery } from "../../../../../../../../shell/services/instance";
 
 export const SettingsResourceListItem = (props) => {
-  const { data: workflowStatusLabels } = useGetWorkflowStatusLabelsQuery();
+  const { data: workflowStatusLabels } = useGetWorkflowStatusLabelsQuery({
+    showDeleted: true,
+  });
   const settingsData = useSelector((state) =>
     state.settings.instance.find(
       (instanceSetting) => instanceSetting.ZUID === props.affectedZUID


### PR DESCRIPTION
Properly formatted workflow status ZUIDs so that the workflow status name will be shown in the activity log

![image](https://github.com/user-attachments/assets/767ed860-cf1c-494a-b317-d1661b296bf8)
![image](https://github.com/user-attachments/assets/388c13a4-aad7-4674-8263-33b0550f9caf)
![image](https://github.com/user-attachments/assets/38cd9470-a542-4b5b-a17c-2d212b1745e4)
