### PR TITLE
Resolve non-promise rejections from unhandled rtk query unwrap()

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/SocialMediaPreview/useImageURL.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/SocialMediaPreview/useImageURL.ts
@@ -59,7 +59,8 @@ export const useImageURL: () => string = () => {
           .unwrap()
           .then((res) => {
             setImageURL(res.url);
-          });
+          })
+          .catch((error) => console.error("Error fetching og_image:", error));
       } else {
         setImageURL(String(item.data.og_image));
       }
@@ -70,21 +71,28 @@ export const useImageURL: () => string = () => {
       }
 
       let validImages = contentImages.map(async (value) => {
-        const isZestyMediaFile = value.startsWith("3-");
-        // Need to resolve media zuids to determine if these are actually images
-        const res = isZestyMediaFile && (await getFile(value).unwrap());
-        const isImage = [
-          "png",
-          "jpg",
-          "jpeg",
-          "svg",
-          "gif",
-          "tif",
-          "webp",
-        ].includes(fileExtension(isZestyMediaFile ? res.url : value));
+        try {
+          const isZestyMediaFile = value.startsWith("3-");
+          // Need to resolve media zuids to determine if these are actually images
+          const res = isZestyMediaFile && (await getFile(value).unwrap());
+          const isImage = [
+            "png",
+            "jpg",
+            "jpeg",
+            "svg",
+            "gif",
+            "tif",
+            "webp",
+          ].includes(fileExtension(isZestyMediaFile ? res.url : value));
 
-        if (isImage) {
-          return isZestyMediaFile ? res.url : value;
+          if (isImage) {
+            return isZestyMediaFile ? res.url : value;
+          }
+
+          return null;
+        } catch (error) {
+          console.error("Error fetching file:", error);
+          return null;
         }
       });
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/MetaImage.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/MetaImage.tsx
@@ -96,21 +96,24 @@ export const MetaImage = ({ onChange }: MetaImageProps) => {
     }
 
     let validImages = contentImages.map(async (value) => {
-      const isZestyMediaFile = value.startsWith("3-");
-      // Need to resolve media zuids to determine if these are actually images
-      const res = isZestyMediaFile && (await getFile(value).unwrap());
-      const isImage = [
-        "png",
-        "jpg",
-        "jpeg",
-        "svg",
-        "gif",
-        "tif",
-        "webp",
-      ].includes(fileExtension(isZestyMediaFile ? res.url : value));
+      try {
+        const isZestyMediaFile = value.startsWith("3-");
+        // Need to resolve media zuids to determine if these are actually images
+        const res = isZestyMediaFile && (await getFile(value).unwrap());
+        const isImage = [
+          "png",
+          "jpg",
+          "jpeg",
+          "svg",
+          "gif",
+          "tif",
+          "webp",
+        ].includes(fileExtension(isZestyMediaFile ? res.url : value));
 
-      if (isImage) {
-        return value;
+        return isImage ? value : null;
+      } catch (error) {
+        console.error("Error fetching file:", error);
+        return null;
       }
     });
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
@@ -8,7 +8,9 @@ import {
 } from "@mui/material";
 import { ContentCopyRounded } from "@mui/icons-material";
 import { useHistory, useParams } from "react-router";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
+import { LoadingButton } from "@mui/lab";
+
 import { AppState } from "../../../../../../../../shell/store/types";
 import { ContentItem } from "../../../../../../../../shell/services/types";
 import {
@@ -16,13 +18,14 @@ import {
   useGetContentModelFieldsQuery,
   useGetContentModelsQuery,
 } from "../../../../../../../../shell/services/instance";
-import { LoadingButton } from "@mui/lab";
+import { notify } from "../../../../../../../../shell/store/notifications";
 
 type DuplicateItemProps = {
   onClose: () => void;
 };
 
 export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
+  const dispatch = useDispatch();
   const { modelZUID, itemZUID } = useParams<{
     modelZUID: string;
     itemZUID: string;
@@ -86,6 +89,15 @@ export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
               ? "blocks"
               : "content"
           }/${modelZUID}/${res.data.ZUID}`
+        );
+      })
+      .catch((error) => {
+        console.error("Failed to duplicate item", error);
+        dispatch(
+          notify({
+            message: "Failed to duplicate item.",
+            kind: "error",
+          })
         );
       });
   };

--- a/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
@@ -666,7 +666,8 @@ export const FieldForm = ({
             });
           }
         })
-        .catch(() => {
+        .catch((error) => {
+          console.error("Failed to update the field", error);
           dispatch(
             notify({
               message: "Failed to update the field",

--- a/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
@@ -133,11 +133,7 @@ export const FieldForm = ({
   ] = useCreateContentModelFieldMutation();
   const [
     updateContentModelField,
-    {
-      isLoading: isUpdatingField,
-      isSuccess: isFieldUpdated,
-      error: fieldUpdateError,
-    },
+    { isLoading: isUpdatingField, isSuccess: isFieldUpdated },
   ] = useUpdateContentModelFieldMutation();
   const [
     bulkUpdateContentModelField,
@@ -498,25 +494,15 @@ export const FieldForm = ({
   }, [formData, isDefaultValueEnabled]);
 
   useEffect(() => {
-    if (fieldCreationError || fieldUpdateError) {
-      let errorMsg = "";
-
-      if (fieldCreationError) {
-        errorMsg = "Failed to create the field";
-      }
-
-      if (fieldUpdateError) {
-        errorMsg = "Failed to update the field";
-      }
-
+    if (fieldCreationError) {
       dispatch(
         notify({
-          message: errorMsg,
+          message: "Failed to create the field",
           kind: "error",
         })
       );
     }
-  }, [fieldCreationError, fieldUpdateError]);
+  }, [fieldCreationError]);
 
   useEffect(() => {
     if (isFieldDeleted) {
@@ -679,6 +665,14 @@ export const FieldForm = ({
               fieldZUID: fieldData?.ZUID,
             });
           }
+        })
+        .catch(() => {
+          dispatch(
+            notify({
+              message: "Failed to update the field",
+              kind: "error",
+            })
+          );
         });
     } else {
       // We want to skip field cache invalidation when creating an in-between field


### PR DESCRIPTION
Unhandled errors from using `unwrap()` on an rtk query causes the non-error promise rejections since unwrap purposely rejects with plain objects on instead of an Error object. The solution is to make sure that when using `unwrap()` errors should be handled.