### PR TITLE
Remove content minwidth to ensure responsiveness

### DIFF
--- a/src/apps/content-editor/src/app/components/FieldTypeMedia.tsx
+++ b/src/apps/content-editor/src/app/components/FieldTypeMedia.tsx
@@ -417,7 +417,6 @@ export const FieldTypeMedia = forwardRef(
                 <Box
                   display="flex"
                   gap={1}
-                  width={400}
                   justifyContent="center"
                   flexWrap="wrap"
                 >

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.js
@@ -220,7 +220,7 @@ export default function Content(props) {
         <Box
           height="100%"
           flex="1 1 auto"
-          minWidth={360}
+          minWidth={300}
           display="flex"
           flexDirection="column"
           gap={2}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.js
@@ -57,9 +57,10 @@ export default function Content(props) {
 
   const xLarge = useMediaQuery((theme) => theme.breakpoints.up("xl"));
 
+  const showDuoMode = props?.model?.type === "block" || showDuoModeContextValue;
+
   const isFocusMode = !showDuoMode && !showSidebar;
 
-  const showDuoMode = props?.model?.type === "block" || showDuoModeContextValue;
   const isLoadingItem =
     props.loading &&
     (!props.item ||
@@ -105,17 +106,11 @@ export default function Content(props) {
           overflowY: "scroll",
           maxWidth: showDuoMode ? 640 : "unset",
           width: showDuoMode ? "100%" : "unset",
-          minWidth: showDuoMode || showSidebar ? 640 : "unset",
         }}
         pr={3}
         pl={4}
       >
-        <Box
-          width={isFocusMode ? "60%" : "100%"}
-          height="100%"
-          minWidth={isFocusMode && 640}
-          flex="0 1 auto"
-        >
+        <Box width={isFocusMode ? "75%" : "100%"} height="100%" flex="0 1 auto">
           <Box width="100%">
             {props.saveClicked && props.hasErrors && (
               <Box mb={3}>


### PR DESCRIPTION
Maxed out sidebar width on small screen

<img width="1489" alt="Screenshot 2025-07-03 at 3 53 24 PM" src="https://github.com/user-attachments/assets/1b801173-aafd-445b-9c97-3b57103401b1" />
<img width="1488" alt="Screenshot 2025-07-03 at 3 53 01 PM" src="https://github.com/user-attachments/assets/3604195b-42e1-4243-be3c-7c2b065658b2" />
<img width="1488" alt="Screenshot 2025-07-03 at 3 53 09 PM" src="https://github.com/user-attachments/assets/2086b652-bb90-4551-bad1-25b5294cdcf1" />
