### PR TITLE
[Global] Prevent app crash when opening the favicon update modal while the appropriate headtag is missing

### DIFF
--- a/src/shell/components/Favicon/index.tsx
+++ b/src/shell/components/Favicon/index.tsx
@@ -103,6 +103,11 @@ export const Favicon = ({ onCloseFaviconModal }: FaviconProps) => {
       const tag = Object.values(headTags).find(
         (tag) => tag.attributes?.sizes === "196x196"
       );
+
+      if (!tag) {
+        return;
+      }
+
       const faviconZUID = allMediaFiles.find(
         (file) => file.url === tag.attributes?.href
       )?.id;


### PR DESCRIPTION
Handle cases where the headtag for the favicon is undefined which causes the app to crash when a user opens the favicon update modal

[Apps---Zesty-io---Celtx-Main-Domain---Manager.webm](https://github.com/user-attachments/assets/9dde2826-2bee-48f1-a9cb-54fd0a696011)
