### PR TITLE
Dispose monaco model on unmount

### DIFF
--- a/src/apps/code-editor/src/app/components/Editor/components/MemoizedEditor/MemoizedEditor.js
+++ b/src/apps/code-editor/src/app/components/Editor/components/MemoizedEditor/MemoizedEditor.js
@@ -29,9 +29,12 @@ export const MemoizedEditor = memo(
           // attach contentModelZUID to monaco model for lookup within completion provider
           query: `contentModelZUID=${props.contentModelZUID}&fileZUID=${props.fileZUID}`,
         });
-        const model =
-          monaco.editor.getModel(filenameURI) ||
-          monaco.editor.createModel(props.code, language, filenameURI);
+        let model = monaco.editor.getModel(filenameURI);
+        const didCreate = !model;
+
+        if (!model) {
+          model = monaco.editor.createModel(props.code, language, filenameURI);
+        }
 
         ref.current.editor.setModel(model);
 
@@ -52,6 +55,9 @@ export const MemoizedEditor = memo(
                 [props.fileZUID]: ref.current.editor.getPosition(),
               })
             );
+          }
+          if (didCreate && model && !model.isDisposed()) {
+            model.dispose();
           }
         };
       }

--- a/src/apps/code-editor/src/app/components/Editor/components/MemoizedEditor/MemoizedEditor.js
+++ b/src/apps/code-editor/src/app/components/Editor/components/MemoizedEditor/MemoizedEditor.js
@@ -30,7 +30,6 @@ export const MemoizedEditor = memo(
           query: `contentModelZUID=${props.contentModelZUID}&fileZUID=${props.fileZUID}`,
         });
         let model = monaco.editor.getModel(filenameURI);
-        const didCreate = !model;
 
         if (!model) {
           model = monaco.editor.createModel(props.code, language, filenameURI);
@@ -56,7 +55,7 @@ export const MemoizedEditor = memo(
               })
             );
           }
-          if (didCreate && model && !model.isDisposed()) {
+          if (model && !model.isDisposed()) {
             model.dispose();
           }
         };


### PR DESCRIPTION
Here we can see TextModel is being retained by monaco even after code app unmount. We have x38 retained models in this example
<img width="1207" height="679" alt="Screenshot 2025-07-28 at 12 47 22 PM" src="https://github.com/user-attachments/assets/6f5deb6b-83a9-4a47-a2bb-5be4472e82db" />
I also exposed monaco object to the window to more easily visualize the models that are retained
<img width="1466" height="553" alt="Screenshot 2025-07-28 at 12 42 50 PM" src="https://github.com/user-attachments/assets/c2db2637-8416-4b0c-a119-cf20d3de624c" />


After the disposal code update we can observe the TextModels are no longer retained
<img width="1226" height="504" alt="Screenshot 2025-07-28 at 12 52 21 PM" src="https://github.com/user-attachments/assets/aa4a9cb0-9e0e-43bd-ad36-b3b59b149045" />

Requesting the models from console also now shows no retained models
<img width="1145" height="524" alt="Screenshot 2025-07-28 at 12 48 46 PM" src="https://github.com/user-attachments/assets/3d366f62-9518-4442-8da3-946777b70079" />