### PR TITLE
Media folders memory leak fix

### DIFF
--- a/src/apps/media/src/app/components/Sidebar/Folders.tsx
+++ b/src/apps/media/src/app/components/Sidebar/Folders.tsx
@@ -99,12 +99,15 @@ export const Folders = ({ lockedToGroupId }: Props) => {
   };
 
   useEffect(() => {
-    window.addEventListener("storage", () =>
-      setHiddenGroups(JSON.parse(localStorage.getItem("zesty:navMedia:hidden")))
-    );
+    const handleStorage = () =>
+      setHiddenGroups(
+        JSON.parse(localStorage.getItem("zesty:navMedia:hidden"))
+      );
+
+    window.addEventListener("storage", handleStorage);
 
     return () => {
-      window.removeEventListener("storage", () => {});
+      window.removeEventListener("storage", handleStorage);
     };
   }, []);
 


### PR DESCRIPTION
Event listeners for storage being created and nor properly released causing multiple listeners to be registered and to be retained even after unmount 
<img width="1332" height="849" alt="Screenshot 2025-07-29 at 3 52 59 PM" src="https://github.com/user-attachments/assets/8cfcbe06-f9e5-4c94-9458-e6418573514b" />


Postfix we can observe only one Storage Event Listener is being registered
<img width="1195" height="725" alt="Screenshot 2025-07-29 at 3 54 16 PM" src="https://github.com/user-attachments/assets/0e3cbc0a-5b36-4c06-9ec9-74060eadddd8" />


And we can also observe it is not being retained on unmount
<img width="1210" height="637" alt="Screenshot 2025-07-29 at 3 54 31 PM" src="https://github.com/user-attachments/assets/881b22c6-72c1-4f12-93bd-912a27c5851f" />

