### PR TITLE
[Global] Support .content.one domain for manager-ui

### DIFF
--- a/src/shell/app.config.js
+++ b/src/shell/app.config.js
@@ -31,7 +31,6 @@ module.exports = {
       media_resolver: "",
     },
 
-    URL_MANAGER: ".manager.zesty.io",
     URL_MANAGER_PROTOCOL: "https://",
     URL_PREVIEW: "-dev.webengine.zesty.io",
     URL_PREVIEW_PROTOCOL: "https://",
@@ -40,7 +39,6 @@ module.exports = {
     URL_APPS: "https://apps.zesty.io",
 
     COOKIE_NAME: "APP_SID",
-    COOKIE_DOMAIN: ".zesty.io",
 
     GOOGLE_WEB_FONTS_KEY: "AIzaSyD075qEo9IXa4BPsSZ_YJGWlTw34T51kuk",
 
@@ -77,7 +75,6 @@ module.exports = {
       "https://us-central1-zesty-stage.cloudfunctions.net/googleAnalyticsGetPageViews",
     SERVICE_INSTANCE_INSTALLER: "https://installer-m3rbwjxm5q-uc.a.run.app",
 
-    URL_MANAGER: ".manager.stage.zesty.io",
     URL_MANAGER_PROTOCOL: "https://",
     URL_PREVIEW: "-dev.preview.stage.zesty.io",
     URL_PREVIEW_PROTOCOL: "https://",
@@ -87,7 +84,6 @@ module.exports = {
     URL_APPS: "https://apps-beta.zesty.io",
 
     COOKIE_NAME: "STAGE_APP_SID",
-    COOKIE_DOMAIN: ".zesty.io",
 
     GOOGLE_WEB_FONTS_KEY: "AIzaSyD075qEo9IXa4BPsSZ_YJGWlTw34T51kuk",
 
@@ -128,7 +124,6 @@ module.exports = {
       media_resolver: "",
     },
 
-    URL_MANAGER: ".manager.dev.zesty.io:8080",
     URL_MANAGER_PROTOCOL: "http://",
     URL_PREVIEW: "-dev.preview.dev.zesty.io",
     URL_PREVIEW_PROTOCOL: "http://",
@@ -138,7 +133,6 @@ module.exports = {
     URL_APPS: "https://apps-beta.zesty.io",
 
     COOKIE_NAME: "DEV_APP_SID",
-    COOKIE_DOMAIN: ".zesty.io",
 
     TIME_DISPLAY_FORMAT: "MMMM Do YYYY, [at] h:mm a",
     TIME_UTC_FORMAT: "YYYY-MM-DD HH:mm:ss",
@@ -177,14 +171,12 @@ module.exports = {
       media_resolver: "http://svc.zesty.localdev:3007/media-resolver-service",
     },
 
-    URL_MANAGER: ".manager.zesty.localdev:9000",
     URL_MANAGER_PROTOCOL: "http://",
     URL_PREVIEW: "-dev.preview.zesty.localdev",
     URL_PREVIEW_PROTOCOL: "https://",
     URL_ACCOUNTS: "https://accounts.zesty.localdev:9001",
 
     COOKIE_NAME: "DEV_APP_SID",
-    COOKIE_DOMAIN: ".zesty.localdev",
 
     TIME_DISPLAY_FORMAT: "MMMM Do YYYY, [at] h:mm a",
     TIME_UTC_FORMAT: "YYYY-MM-DD HH:mm:ss",

--- a/src/shell/components/login/Login.js
+++ b/src/shell/components/login/Login.js
@@ -1,5 +1,5 @@
 import { memo, useEffect, useState } from "react";
-import { connect } from "react-redux";
+import { connect, useDispatch } from "react-redux";
 import { alpha } from "@mui/material/styles";
 import Link from "@mui/material/Link";
 import {
@@ -35,6 +35,7 @@ export default connect((state) => {
   };
 })(
   memo(function Login(props) {
+    const dispatch = useDispatch();
     const [loading, setLoading] = useState(false);
     const [twoFactor, setTwoFactor] = useState(false);
     const [error, setError] = useState("");
@@ -172,7 +173,16 @@ export default connect((state) => {
               </Box>
               <SSOButtonGroup
                 authServiceUrl={CONFIG.SERVICE_AUTH}
-                onSuccess={() => {
+                onSuccess={(data) => {
+                  dispatch({
+                    type: "FETCH_LOGIN_SUCCESS",
+                    payload: {
+                      code: data.status,
+                      meta: {
+                        token: data.token,
+                      },
+                    },
+                  });
                   setIsAuthenticated(true);
                 }}
                 onError={(err) => {

--- a/src/shell/index.js
+++ b/src/shell/index.js
@@ -1,7 +1,3 @@
-// interploated by webpack at build time
-// must be setup before starting the store
-window.CONFIG = __CONFIG__;
-
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
@@ -35,6 +31,11 @@ import { MonacoSetup } from "../apps/code-editor/src/app/components/Editor/compo
 import { actions } from "shell/store/ui";
 import { CommentProvider } from "./contexts/CommentProvider";
 import { CreateContentItemDialogProvider } from "./contexts/CreateContentItemDialogProvider";
+import getRuntimeEnv from "../utility/getRuntimeEnv";
+
+// interploated by webpack at build time
+// must be setup before starting the store
+window.CONFIG = { ...__CONFIG__, ...getRuntimeEnv() };
 
 // needed for Breadcrumbs in Shell
 injectReducer(store, "navContent", navContent);

--- a/src/utility/getRuntimeEnv.ts
+++ b/src/utility/getRuntimeEnv.ts
@@ -31,7 +31,7 @@ export default () => {
         };
 
       default:
-        break;
+        throw new Error(`Invalid NODE_ENV value: ${process.env.NODE_ENV}`);
     }
   } else {
     const COOKIE_DOMAIN = ".zesty.io";

--- a/src/utility/getRuntimeEnv.ts
+++ b/src/utility/getRuntimeEnv.ts
@@ -1,6 +1,5 @@
 export default () => {
-  const isContentOneDomain =
-    window.location.hostname.includes(".cms.content.one");
+  const isContentOneDomain = window.location.hostname.includes(".content.one");
 
   if (isContentOneDomain) {
     const COOKIE_DOMAIN = ".content.one";
@@ -14,19 +13,19 @@ export default () => {
 
       case "stage":
         return {
-          URL_MANAGER: ".stage.cms.content.one",
+          URL_MANAGER: ".cms.stage.content.one",
           COOKIE_DOMAIN,
         };
 
       case "development":
         return {
-          URL_MANAGER: ".dev.cms.content.one:8080",
+          URL_MANAGER: ".cms.dev.content.one:8080",
           COOKIE_DOMAIN,
         };
 
       case "local":
         return {
-          URL_MANAGER: ".local.cms.content.one:9000",
+          URL_MANAGER: ".cms.local.content.one:9000",
           COOKIE_DOMAIN,
         };
 

--- a/src/utility/getRuntimeEnv.ts
+++ b/src/utility/getRuntimeEnv.ts
@@ -62,7 +62,7 @@ export default () => {
         };
 
       default:
-        break;
+        throw new Error(`Unhandled NODE_ENV value: ${process.env.NODE_ENV}`);
     }
   }
 };

--- a/src/utility/getRuntimeEnv.ts
+++ b/src/utility/getRuntimeEnv.ts
@@ -1,0 +1,64 @@
+export default () => {
+  const isContentOneDomain =
+    window.location.hostname.includes(".cms.content.one");
+
+  if (isContentOneDomain) {
+    switch (process.env.NODE_ENV) {
+      case "production":
+        return {
+          URL_MANAGER: ".cms.content.one",
+          COOKIE_DOMAIN: ".content.one",
+        };
+
+      case "stage":
+        return {
+          URL_MANAGER: ".stage.cms.content.one",
+          COOKIE_DOMAIN: ".content.one",
+        };
+
+      case "development":
+        return {
+          URL_MANAGER: ".dev.cms.content.one:8080",
+          COOKIE_DOMAIN: ".content.one",
+        };
+
+      case "local":
+        return {
+          URL_MANAGER: ".local.cms.content.one:9000",
+          COOKIE_DOMAIN: ".content.one",
+        };
+
+      default:
+        break;
+    }
+  } else {
+    switch (process.env.NODE_ENV) {
+      case "production":
+        return {
+          URL_MANAGER: ".manager.zesty.io",
+          COOKIE_DOMAIN: ".zesty.io",
+        };
+
+      case "stage":
+        return {
+          URL_MANAGER: ".manager.stage.zesty.io",
+          COOKIE_DOMAIN: ".zesty.io",
+        };
+
+      case "development":
+        return {
+          URL_MANAGER: ".manager.dev.zesty.io:8080",
+          COOKIE_DOMAIN: ".zesty.io",
+        };
+
+      case "local":
+        return {
+          URL_MANAGER: ".manager.zesty.localdev:9000",
+          COOKIE_DOMAIN: ".zesty.io",
+        };
+
+      default:
+        break;
+    }
+  }
+};

--- a/src/utility/getRuntimeEnv.ts
+++ b/src/utility/getRuntimeEnv.ts
@@ -3,58 +3,62 @@ export default () => {
     window.location.hostname.includes(".cms.content.one");
 
   if (isContentOneDomain) {
+    const COOKIE_DOMAIN = ".content.one";
+
     switch (process.env.NODE_ENV) {
       case "production":
         return {
           URL_MANAGER: ".cms.content.one",
-          COOKIE_DOMAIN: ".content.one",
+          COOKIE_DOMAIN,
         };
 
       case "stage":
         return {
           URL_MANAGER: ".stage.cms.content.one",
-          COOKIE_DOMAIN: ".content.one",
+          COOKIE_DOMAIN,
         };
 
       case "development":
         return {
           URL_MANAGER: ".dev.cms.content.one:8080",
-          COOKIE_DOMAIN: ".content.one",
+          COOKIE_DOMAIN,
         };
 
       case "local":
         return {
           URL_MANAGER: ".local.cms.content.one:9000",
-          COOKIE_DOMAIN: ".content.one",
+          COOKIE_DOMAIN,
         };
 
       default:
         break;
     }
   } else {
+    const COOKIE_DOMAIN = ".zesty.io";
+
     switch (process.env.NODE_ENV) {
       case "production":
         return {
           URL_MANAGER: ".manager.zesty.io",
-          COOKIE_DOMAIN: ".zesty.io",
+          COOKIE_DOMAIN,
         };
 
       case "stage":
         return {
           URL_MANAGER: ".manager.stage.zesty.io",
-          COOKIE_DOMAIN: ".zesty.io",
+          COOKIE_DOMAIN,
         };
 
       case "development":
         return {
           URL_MANAGER: ".manager.dev.zesty.io:8080",
-          COOKIE_DOMAIN: ".zesty.io",
+          COOKIE_DOMAIN,
         };
 
       case "local":
         return {
           URL_MANAGER: ".manager.zesty.localdev:9000",
-          COOKIE_DOMAIN: ".zesty.io",
+          COOKIE_DOMAIN,
         };
 
       default:


### PR DESCRIPTION
Makes sure that all subsequent api calls are using the appropriate auth token when using the `.content.one` domain with manager-ui.

[Content---Zesty-io---Manager.webm](https://github.com/user-attachments/assets/dcf70ea8-c657-485a-a46a-32bfeea676b7)
