### PR TITLE
[#3673] : Blocks - Duplicating a variant and renaming it does not update the seo title

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
@@ -13,11 +13,13 @@ import { useSelector, useDispatch } from "react-redux";
 import { AppState } from "../../../../../../../../shell/store/types";
 import { ContentItem } from "../../../../../../../../shell/services/types";
 import {
+  instanceApi,
   useCreateContentItemMutation,
   useGetContentModelFieldsQuery,
   useGetContentModelsQuery,
 } from "../../../../../../../../shell/services/instance";
 import { notify } from "../../../../../../../../shell/store/notifications";
+import { fetchItems } from "../../../../../../../../shell/store/content";
 
 type DuplicateItemProps = {
   onClose: () => void;
@@ -34,7 +36,8 @@ export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
   const item = useSelector(
     (state: AppState) => state.content[itemZUID] as ContentItem
   );
-  const { data: models } = useGetContentModelsQuery();
+  const { data: models, refetch: refetchContentModels } =
+    useGetContentModelsQuery();
 
   const [createContentItem, { isLoading }] = useCreateContentItemMutation();
 
@@ -66,8 +69,13 @@ export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
         web: {
           canonicalTagMode: item.web.canonicalTagMode,
           parentZUID: item.web.parentZUID,
+          metaLinkText: !item.web.metaLinkText
+            ? null
+            : item.web.metaLinkText?.slice(0, 143) + " (copy)",
           metaTitle: item.web.metaTitle?.slice(0, 143) + " (copy)",
-          metaDescription: item.web.metaDescription?.slice(0, 153) + " (copy)",
+          metaDescription: !item.web.metaDescription
+            ? null
+            : item.web.metaDescription?.slice(0, 153) + " (copy)",
           pathPart: item.web.pathPart
             ? item.web.pathPart + `-${new Date().toISOString()}`
             : undefined,
@@ -80,6 +88,8 @@ export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
     })
       .unwrap()
       .then((res) => {
+        dispatch(fetchItems(modelZUID));
+        refetchContentModels();
         onClose();
         history.push(
           `/${

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
@@ -66,7 +66,6 @@ export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
         web: {
           canonicalTagMode: item.web.canonicalTagMode,
           parentZUID: item.web.parentZUID,
-          metaLinkText: item.web.metaLinkText?.slice(0, 143) + " (copy)",
           metaTitle: item.web.metaTitle?.slice(0, 143) + " (copy)",
           metaDescription: item.web.metaDescription?.slice(0, 153) + " (copy)",
           pathPart: item.web.pathPart

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/RenameItemDialog.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/RenameItemDialog.tsx
@@ -15,7 +15,10 @@ import { useHistory, useParams } from "react-router";
 import { useDispatch, useSelector } from "react-redux";
 import { AppState } from "../../../../../../../../shell/store/types";
 import { ContentItem } from "../../../../../../../../shell/services/types";
-import { useUpdateContentItemMutation } from "../../../../../../../../shell/services/instance";
+import {
+  useGetContentModelsQuery,
+  useUpdateContentItemMutation,
+} from "../../../../../../../../shell/services/instance";
 import { fetchItem } from "../../../../../../../../shell/store/content";
 
 type DuplicateItemProps = {
@@ -35,6 +38,7 @@ export const RenameItemDialog = ({ onClose }: DuplicateItemProps) => {
   const [newTitle, setNewTitle] = useState(item?.web?.metaTitle || "");
 
   const [updateContentItem, { isLoading }] = useUpdateContentItemMutation();
+  const { refetch: refetchContentModels } = useGetContentModelsQuery();
 
   return (
     <Dialog open fullWidth maxWidth={"xs"} onClose={onClose}>
@@ -86,6 +90,7 @@ export const RenameItemDialog = ({ onClose }: DuplicateItemProps) => {
               },
             }).then(() => {
               dispatch(fetchItem(modelZUID, itemZUID));
+              refetchContentModels();
               onClose();
             });
           }}

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -283,16 +283,10 @@ export function fetchItem(modelZUID, itemZUID) {
         }
         return res;
       },
-    })
-      .then(() => {
-        dispatch(
-          instanceApi.util.invalidateTags(["ContentItems", "ContentModels"])
-        );
-      })
-      .catch((err) => {
-        console.error("Failed to fetch item:", err);
-        return err;
-      });
+    }).catch((err) => {
+      console.error("Failed to fetch item:", err);
+      return err;
+    });
   };
 }
 

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -283,10 +283,16 @@ export function fetchItem(modelZUID, itemZUID) {
         }
         return res;
       },
-    }).catch((err) => {
-      console.error("Failed to fetch item:", err);
-      return err;
-    });
+    })
+      .then(() => {
+        dispatch(
+          instanceApi.util.invalidateTags(["ContentItems", "ContentModels"])
+        );
+      })
+      .catch((err) => {
+        console.error("Failed to fetch item:", err);
+        return err;
+      });
   };
 }
 


### PR DESCRIPTION
RCA:
- [ ] Undefined metaLinkText: The value was being incorrectly assigned during variant duplication.
- [ ] Stale Data: No cache invalidation after duplicating/renaming variants caused UI-state mismatches.

Fix:
- [ ] Excluded the field during duplication to avoid undefined assignments.
- [ ] Added automatic data refetching and cache invalidation post-duplication/rename to ensure real-time UI updates.

https://github.com/user-attachments/assets/35a3d350-e2e8-4ea6-aec9-f8bdd6887fcd

