### PR TITLE
[Redirects] Minimize grid table re-renders when selection model changes

### DIFF
--- a/cypress/e2e/seo/redirects/redirects.spec.js
+++ b/cypress/e2e/seo/redirects/redirects.spec.js
@@ -384,6 +384,7 @@ describe("Redirects", () => {
     });
     it("Single Selection", () => {
       cy.visit("/redirects");
+      cy.wait(5000); // Need to add an arbitrary wait for the grid api ref to be set
       cy.getElement(".MuiDataGrid-cell")
         .contains(`/${TEST_DELETE_DATA[1]?.path}`, { matchCase: false })
         .parents(".MuiDataGrid-row")
@@ -411,6 +412,7 @@ describe("Redirects", () => {
 
     it("Multiple", () => {
       cy.visit("/redirects");
+      cy.wait(5000); // Need to add an arbitrary wait for the grid api ref to be set
       cy.getElement(".MuiDataGrid-cell")
         .contains(`/${TEST_DELETE_DATA[2]?.path}`, { matchCase: false })
         .parents(".MuiDataGrid-row")
@@ -427,7 +429,7 @@ describe("Redirects", () => {
         .contains(`/${TEST_DELETE_DATA[4]?.path}`, { matchCase: false })
         .parents(".MuiDataGrid-row")
         .find(".MuiDataGrid-cell:eq(0) .MuiCheckbox-root input")
-        .check();
+        .click();
 
       cy.getElement('[data-cy="RedirectActionDeleteButton"]').click();
       cy.getElement('[data-cy="RedirectsDeleteDialog"]').should("exist");

--- a/cypress/e2e/seo/redirects/redirects.spec.js
+++ b/cypress/e2e/seo/redirects/redirects.spec.js
@@ -429,7 +429,7 @@ describe("Redirects", () => {
         .contains(`/${TEST_DELETE_DATA[4]?.path}`, { matchCase: false })
         .parents(".MuiDataGrid-row")
         .find(".MuiDataGrid-cell:eq(0) .MuiCheckbox-root input")
-        .click();
+        .check();
 
       cy.getElement('[data-cy="RedirectActionDeleteButton"]').click();
       cy.getElement('[data-cy="RedirectsDeleteDialog"]').should("exist");

--- a/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectsDelete.tsx
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectsDelete.tsx
@@ -1,17 +1,35 @@
-import { FC } from "react";
+import { FC, useEffect, useState } from "react";
 import { Box, Typography, Button } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ClearIcon from "@mui/icons-material/Clear";
 import DoneAllIcon from "@mui/icons-material/DoneAll";
 import { useRedirectsDialog } from "../../../app/components/RedirectsDialogProvider";
 import { useRedirectsTable } from "../RedirectsTable/RedirectsTableContextProvider";
+import { GridRowId } from "@mui/x-data-grid-pro";
 
 type RedirectsDeleteProps = {};
 
 const RedirectsDelete: FC<RedirectsDeleteProps> = () => {
   const { openDeleteDialog } = useRedirectsDialog();
-  const { selectedRedirects, setSelectedRedirects, redirects } =
-    useRedirectsTable();
+  const { apiRef, redirects } = useRedirectsTable();
+  const [selectedRedirects, setSelectedRedirects] = useState<GridRowId[]>([]);
+
+  useEffect(() => {
+    if (!apiRef.current || !Object.keys(apiRef.current).length) {
+      return;
+    }
+
+    const handleSelectionChange = () => {
+      setSelectedRedirects(
+        Array.from(apiRef.current.getSelectedRows().keys() || [])
+      );
+    };
+
+    return apiRef.current.subscribeEvent(
+      "rowSelectionChange",
+      handleSelectionChange
+    );
+  }, [apiRef.current]);
 
   const handleDelete = () => {
     const deleteData = selectedRedirects.map((ZUID: any) => ({
@@ -48,7 +66,7 @@ const RedirectsDelete: FC<RedirectsDeleteProps> = () => {
           color="inherit"
           size="small"
           disabled={!selectedRedirects?.length}
-          onClick={() => setSelectedRedirects([])}
+          onClick={() => apiRef.current?.setRowSelectionModel([])}
           startIcon={<ClearIcon />}
         >
           Deselect All
@@ -60,7 +78,9 @@ const RedirectsDelete: FC<RedirectsDeleteProps> = () => {
           size="small"
           disabled={selectedRedirects?.length === redirects?.length}
           onClick={() =>
-            setSelectedRedirects(redirects.map((row: any) => row.ZUID))
+            apiRef.current?.setRowSelectionModel(
+              redirects.map((row: any) => row.ZUID)
+            )
           }
           startIcon={<DoneAllIcon />}
         >

--- a/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectsDelete.tsx
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectActions/RedirectsDelete.tsx
@@ -7,29 +7,13 @@ import { useRedirectsDialog } from "../../../app/components/RedirectsDialogProvi
 import { useRedirectsTable } from "../RedirectsTable/RedirectsTableContextProvider";
 import { GridRowId } from "@mui/x-data-grid-pro";
 
-type RedirectsDeleteProps = {};
+type RedirectsDeleteProps = {
+  selectedRedirects: GridRowId[];
+};
 
-const RedirectsDelete: FC<RedirectsDeleteProps> = () => {
+const RedirectsDelete: FC<RedirectsDeleteProps> = ({ selectedRedirects }) => {
   const { openDeleteDialog } = useRedirectsDialog();
   const { apiRef, redirects } = useRedirectsTable();
-  const [selectedRedirects, setSelectedRedirects] = useState<GridRowId[]>([]);
-
-  useEffect(() => {
-    if (!apiRef.current || !Object.keys(apiRef.current).length) {
-      return;
-    }
-
-    const handleSelectionChange = () => {
-      setSelectedRedirects(
-        Array.from(apiRef.current.getSelectedRows().keys() || [])
-      );
-    };
-
-    return apiRef.current.subscribeEvent(
-      "rowSelectionChange",
-      handleSelectionChange
-    );
-  }, [apiRef.current]);
 
   const handleDelete = () => {
     const deleteData = selectedRedirects.map((ZUID: any) => ({

--- a/src/apps/seo/src/views/RedirectsManager/RedirectActions/index.tsx
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectActions/index.tsx
@@ -8,12 +8,13 @@ import SearchIcon from "@mui/icons-material/Search";
 import RedirectsImport from "./RedirectsImport";
 import SearchBox from "../../../../../../shell/components/SearchBox";
 import { useEffect, useState } from "react";
+import { GridRowId } from "@mui/x-data-grid-pro";
 
 export default function RedirectActions() {
   const { openCreateForm } = useRedirectsDialog();
   const { redirects, searchFilter, setSearchFilter, apiRef } =
     useRedirectsTable();
-  const [showDeleteHeader, setShowDeleteHeader] = useState(false);
+  const [selectedRedirects, setSelectedRedirects] = useState<GridRowId[]>([]);
 
   useEffect(() => {
     if (!apiRef.current || !Object.keys(apiRef.current).length) {
@@ -21,7 +22,9 @@ export default function RedirectActions() {
     }
 
     const handleSelectionChange = () => {
-      setShowDeleteHeader(apiRef.current.getSelectedRows().size > 0);
+      setSelectedRedirects(
+        Array.from(apiRef.current.getSelectedRows().keys() || [])
+      );
     };
 
     return apiRef.current.subscribeEvent(
@@ -32,8 +35,8 @@ export default function RedirectActions() {
 
   return (
     <>
-      {showDeleteHeader ? (
-        <RedirectsDelete />
+      {selectedRedirects?.length ? (
+        <RedirectsDelete selectedRedirects={selectedRedirects} />
       ) : (
         <Box
           component="header"

--- a/src/apps/seo/src/views/RedirectsManager/RedirectActions/index.tsx
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectActions/index.tsx
@@ -7,14 +7,32 @@ import InputAdornment from "@mui/material/InputAdornment";
 import SearchIcon from "@mui/icons-material/Search";
 import RedirectsImport from "./RedirectsImport";
 import SearchBox from "../../../../../../shell/components/SearchBox";
+import { useEffect, useState } from "react";
 
 export default function RedirectActions() {
   const { openCreateForm } = useRedirectsDialog();
-  const { selectedRedirects, redirects, searchFilter, setSearchFilter } =
+  const { redirects, searchFilter, setSearchFilter, apiRef } =
     useRedirectsTable();
+  const [showDeleteHeader, setShowDeleteHeader] = useState(false);
+
+  useEffect(() => {
+    if (!apiRef.current || !Object.keys(apiRef.current).length) {
+      return;
+    }
+
+    const handleSelectionChange = () => {
+      setShowDeleteHeader(apiRef.current.getSelectedRows().size > 0);
+    };
+
+    return apiRef.current.subscribeEvent(
+      "rowSelectionChange",
+      handleSelectionChange
+    );
+  }, [apiRef.current]);
+
   return (
     <>
-      {!!selectedRedirects?.length ? (
+      {showDeleteHeader ? (
         <RedirectsDelete />
       ) : (
         <Box

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableContextProvider.tsx
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableContextProvider.tsx
@@ -4,9 +4,10 @@ import {
   ReactNode,
   useState,
   useEffect,
+  MutableRefObject,
 } from "react";
 
-import { GridRowId } from "@mui/x-data-grid-pro";
+import { GridApi, useGridApiRef } from "@mui/x-data-grid-pro";
 import { useDispatch } from "react-redux";
 import { useGetRedirectsQuery } from "../../../../../../shell/services/instance";
 import { notify } from "../../../../../../shell/store/notifications";
@@ -20,13 +21,12 @@ export type RedirectsTableContextProps = {
   sortBy: string;
   httpCodeFilter: string | null;
   typeFilter: string | null;
-  selectedRedirects: GridRowId[];
   searchFilter: string;
   setSearchFilter: (searchFilter: string) => void;
   setSortBy: (sortBy: string) => void;
   setHttpCodeFilter: (httpCodeFilter: string | null) => void;
   setTypeFilter: (typeFilter: string | null) => void;
-  setSelectedRedirects: (selectedRedirects: GridRowId[]) => void;
+  apiRef: MutableRefObject<GridApi>;
 };
 
 const RedirectsTableContext = createContext<RedirectsTableContextProps | null>(
@@ -42,7 +42,7 @@ const RedirectsTableContextProvider = ({
   const [httpCodeFilter, setHttpCodeFilter] = useState(null);
   const [typeFilter, setTypeFilter] = useState(null);
   const [searchFilter, setSearchFilter] = useState("");
-  const [selectedRedirects, setSelectedRedirects] = useState([]);
+  const apiRef = useGridApiRef<GridApi>();
 
   const dispatch = useDispatch();
 
@@ -67,13 +67,12 @@ const RedirectsTableContextProvider = ({
         sortBy,
         httpCodeFilter,
         typeFilter,
-        selectedRedirects,
         searchFilter,
         setSearchFilter,
         setSortBy,
         setHttpCodeFilter,
         setTypeFilter,
-        setSelectedRedirects,
+        apiRef,
       }}
     >
       {isLoading ? <LoadingQuote /> : children}

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/index.tsx
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/index.tsx
@@ -2,14 +2,11 @@ import { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import {
   DataGridPro,
   GRID_CHECKBOX_SELECTION_COL_DEF,
-  useGridApiRef,
   GridActionsCellItem,
-  GridApi,
   GridColDef,
   GridRenderCellParams,
   GridPinnedColumnFields,
   GridValidRowModel,
-  GridRowId,
 } from "@mui/x-data-grid-pro";
 import { Box, Typography } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -33,7 +30,6 @@ const TARGET_TYPES_MAP = {
 } as const;
 
 const RedirectsTable = () => {
-  const apiRef = useGridApiRef<GridApi>();
   const { openDeleteDialog, openCreateForm } = useRedirectsDialog();
   const {
     redirects,
@@ -41,9 +37,8 @@ const RedirectsTable = () => {
     sortBy,
     httpCodeFilter,
     typeFilter,
-    selectedRedirects,
-    setSelectedRedirects,
     searchFilter,
+    apiRef,
   } = useRedirectsTable();
 
   const [initialState, setInitialState] = useState<any>();
@@ -297,10 +292,6 @@ const RedirectsTable = () => {
                   setPinnedColumns(newPinnedColumns)
                 }
                 onColumnWidthChange={saveSnapshot}
-                rowSelectionModel={selectedRedirects}
-                onRowSelectionModelChange={(selection: GridRowId[]) => {
-                  setSelectedRedirects(selection);
-                }}
                 initialState={initialState}
                 style={{
                   width: width,


### PR DESCRIPTION
Leverage the grid table's internal hook to get and update selection model instead of storing it on an external state

[Redirects---Zesty-io---zesty-pw---Manager (1).webm](https://github.com/user-attachments/assets/8f62a57f-b9c9-4e5a-9b1c-aaf95682f0d2)
