### PR TITLE
[Blocks] Prevent user from being redirected out of the blocks app upon variant deletion

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DeleteItemDialog.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DeleteItemDialog.tsx
@@ -12,7 +12,10 @@ import { useHistory, useParams } from "react-router";
 import { useDispatch, useSelector } from "react-redux";
 import { AppState } from "../../../../../../../../shell/store/types";
 import { ContentItem } from "../../../../../../../../shell/services/types";
-import { useDeleteContentItemMutation } from "../../../../../../../../shell/services/instance";
+import {
+  useDeleteContentItemMutation,
+  useGetContentModelItemsQuery,
+} from "../../../../../../../../shell/services/instance";
 
 type DuplicateItemProps = {
   onClose: () => void;
@@ -28,8 +31,20 @@ export const DeleteItemDialog = ({ onClose }: DuplicateItemProps) => {
   const item = useSelector(
     (state: AppState) => state.content[itemZUID] as ContentItem
   );
+  const { data: modelItems } = useGetContentModelItemsQuery(
+    { modelZUID },
+    { skip: !modelZUID }
+  );
 
   const [deleteContentItem, { isLoading }] = useDeleteContentItemMutation();
+
+  const handleRedirectBlockItem = () => {
+    if (modelItems?.length - 1 <= 0) {
+      history.push("/blocks");
+    } else {
+      history.push(`/blocks/${modelZUID}`);
+    }
+  };
 
   return (
     <Dialog open fullWidth maxWidth={"xs"} onClose={onClose}>
@@ -79,7 +94,12 @@ export const DeleteItemDialog = ({ onClose }: DuplicateItemProps) => {
                 type: "REMOVE_ITEM",
                 itemZUID,
               });
-              history.push(`/content/${modelZUID}`);
+
+              if (history.location.pathname.includes("blocks")) {
+                handleRedirectBlockItem();
+              } else {
+                history.push(`/content/${modelZUID}`);
+              }
             });
           }}
           loading={isLoading}


### PR DESCRIPTION
Makes sure that the user stays in the blocks app when deleting a block variant (Fixes #3660)
- If block item contains other variants, make sure the user stays on the same block item
- If no other variants exists, navigate the user to the all blocks page

[Blocks---Variant-2---Zesty-io---zesty-pw---Manager.webm](https://github.com/user-attachments/assets/66fedf1c-0f70-49b3-a99b-0614cb76d8a8)
