### PR TITLE
[Global Search] Handle cases where languages is empty or undefined

### DIFF
--- a/src/shell/components/GlobalSearch/utils.ts
+++ b/src/shell/components/GlobalSearch/utils.ts
@@ -18,7 +18,7 @@ export const getContentTitle = (
   }
 
   const title = content?.web?.metaTitle || "Missing Meta Title";
-  const langCode = languages.find(
+  const langCode = languages?.find(
     (lang: any) => lang.ID === content?.meta?.langID
   )?.code;
   const langDisplay = langCode ? `(${langCode}) ` : null;


### PR DESCRIPTION
Handles cases where searching for an item in the global search causes an app crash when languages is empty or undefined
Resolves #3691 