### PR TITLE
[Global Sidebar] Refetch headtags on login to get favicon data

### DIFF
--- a/src/shell/components/global-sidebar/components/InstanceAvatar.tsx
+++ b/src/shell/components/global-sidebar/components/InstanceAvatar.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useMemo } from "react";
+import { FC, useMemo } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Avatar, Skeleton, Box, SxProps, Theme } from "@mui/material";
 import ImageRoundedIcon from "@mui/icons-material/ImageRounded";
@@ -20,11 +20,10 @@ export const InstanceAvatar: FC<InstanceAvatar> = ({
 }) => {
   const { valid } = useSelector((state: AppState) => state.auth);
   const dispatch = useDispatch();
-  const {
-    data: headTags,
-    isLoading: isLoadingHeadTags,
-    refetch: refetchHeadTags,
-  } = useGetHeadTagsQuery();
+  const { data: headTags, isLoading: isLoadingHeadTags } = useGetHeadTagsQuery(
+    null,
+    { skip: !valid }
+  );
   const { data: instance, isLoading: isLoadingInstance } =
     useGetInstanceQuery();
 
@@ -42,14 +41,6 @@ export const InstanceAvatar: FC<InstanceAvatar> = ({
 
     return "";
   }, [headTags]);
-
-  useEffect(() => {
-    // Trigger refetching of headtags once user has logged in to make sure
-    // favicon gets loaded
-    if (valid) {
-      refetchHeadTags();
-    }
-  }, [valid]);
 
   if (isLoadingHeadTags || isLoadingInstance) {
     return (

--- a/src/shell/components/global-sidebar/components/InstanceAvatar.tsx
+++ b/src/shell/components/global-sidebar/components/InstanceAvatar.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from "react";
+import { FC, useEffect, useMemo } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Avatar, Skeleton, Box, SxProps, Theme } from "@mui/material";
 import ImageRoundedIcon from "@mui/icons-material/ImageRounded";
@@ -18,10 +18,13 @@ export const InstanceAvatar: FC<InstanceAvatar> = ({
   onFaviconModalOpen,
   avatarSx,
 }) => {
-  const ui = useSelector((state: AppState) => state.ui);
+  const { valid } = useSelector((state: AppState) => state.auth);
   const dispatch = useDispatch();
-  const { data: headTags, isLoading: isLoadingHeadTags } =
-    useGetHeadTagsQuery();
+  const {
+    data: headTags,
+    isLoading: isLoadingHeadTags,
+    refetch: refetchHeadTags,
+  } = useGetHeadTagsQuery();
   const { data: instance, isLoading: isLoadingInstance } =
     useGetInstanceQuery();
 
@@ -39,6 +42,14 @@ export const InstanceAvatar: FC<InstanceAvatar> = ({
 
     return "";
   }, [headTags]);
+
+  useEffect(() => {
+    // Trigger refetching of headtags once user has logged in to make sure
+    // favicon gets loaded
+    if (valid) {
+      refetchHeadTags();
+    }
+  }, [valid]);
 
   if (isLoadingHeadTags || isLoadingInstance) {
     return (


### PR DESCRIPTION
Manually refetch headtags on successful login so that favicon data can be loaded
Resolves #3720 

[All-Media---media-folder-2-10100b97-fpzv05---Zesty-io---Manager.webm](https://github.com/user-attachments/assets/95b348dd-b3e4-4638-805e-b41de2a393eb)
