### PR TITLE
[Active Preview] Ensure that runtime envs are loaded in active-preview

### DIFF
--- a/src/apps/active-preview/index.js
+++ b/src/apps/active-preview/index.js
@@ -2,9 +2,10 @@ import { createRoot } from "react-dom/client";
 import { Preview } from "./Preview";
 import { ThemeProvider } from "@mui/material/styles";
 import { theme } from "@zesty-io/material";
+import getRuntimeEnv from "../../utility/getRuntimeEnv";
 
 // interploated by webpack at build time
-window.CONFIG = __CONFIG__;
+window.CONFIG = { ...__CONFIG__, ...getRuntimeEnv() };
 
 const container = document.getElementById("root");
 const root = createRoot(container);


### PR DESCRIPTION
Ensure that runtime envs are loaded in active-preview

Resolves https://github.com/zesty-io/webengine/issues/582

[Content---Homepage---Zesty-io---zesty-pw---Manager.webm](https://github.com/user-attachments/assets/843efd46-9cd5-4a2f-8dc9-f7be4a30e426)
