### PR TITLE
[Global] Refetch users roles api call upon successful login

### DIFF
--- a/src/shell/components/AccessDenied.tsx
+++ b/src/shell/components/AccessDenied.tsx
@@ -53,8 +53,9 @@ const ProfileInfo: FC<ProfileInfoProps> = ({
 const AccessDenied = () => {
   const history = useHistory();
   const userRole = useSelector((state: AppState) => state.userRole);
+  const { valid } = useSelector((state: AppState) => state.auth);
   const appRoute = location.pathname.split("/")[1];
-  const { isLoading, data } = useGetUsersRolesQuery();
+  const { isLoading, data } = useGetUsersRolesQuery(null, { skip: !valid });
 
   const profileList = data
     ?.filter((profile: any) =>


### PR DESCRIPTION
Refetch the api call to fetch the user roles data on login to properly render the access denied screen
Fixes #3733 