### PR TITLE
[Content] Make sure sibling exists before attempting to load

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/LanguageSelector.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/LanguageSelector.tsx
@@ -58,10 +58,12 @@ export const LanguageSelector = () => {
 
     // If we are at a content item level then reload newly selected language item
     const parts = location.pathname.split("/");
-    if (parts[3]) {
+    // @ts-ignore
+    const siblingZUID = item.siblings[langId];
+
+    if (parts[3] && siblingZUID) {
       const subpath = parts.slice(0, 3);
-      // @ts-ignore
-      subpath.push(item.siblings[langId]);
+      subpath.push(siblingZUID);
       history.push(`${subpath.join("/")}`);
     }
   };


### PR DESCRIPTION
Makes sure that a content item's language sibling exists before attempting to load it.
Fixes #3736 