### PR TITLE
[Global] Do not return error to prevent unhandled rejections

### DIFF
--- a/src/shell/store/instance.js
+++ b/src/shell/store/instance.js
@@ -46,7 +46,6 @@ export function fetchInstance() {
       })
       .catch((err) => {
         console.error("fetchInstance failed:", err);
-        return Promise.reject(err);
       });
   };
 }


### PR DESCRIPTION
Do not return a promise rejection to prevent an unhandled rejection when api call to fetch instance data fails
Fixes #3752 