### PR TITLE
[Chore] Resolve failing Redirects test

### DIFF
--- a/src/apps/seo/src/views/RedirectsManager/RedirectActions/index.tsx
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectActions/index.tsx
@@ -12,12 +12,16 @@ import { GridRowId } from "@mui/x-data-grid-pro";
 
 export default function RedirectActions() {
   const { openCreateForm } = useRedirectsDialog();
-  const { redirects, searchFilter, setSearchFilter, apiRef } =
+  const { redirects, searchFilter, setSearchFilter, apiRef, isTableLoaded } =
     useRedirectsTable();
   const [selectedRedirects, setSelectedRedirects] = useState<GridRowId[]>([]);
 
   useEffect(() => {
-    if (!apiRef.current || !Object.keys(apiRef.current).length) {
+    if (
+      !isTableLoaded ||
+      !apiRef.current ||
+      !Object.keys(apiRef.current).length
+    ) {
       return;
     }
 
@@ -31,7 +35,7 @@ export default function RedirectActions() {
       "rowSelectionChange",
       handleSelectionChange
     );
-  }, [apiRef.current]);
+  }, [apiRef.current, isTableLoaded]);
 
   return (
     <>

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableContextProvider.tsx
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/RedirectsTableContextProvider.tsx
@@ -27,6 +27,8 @@ export type RedirectsTableContextProps = {
   setHttpCodeFilter: (httpCodeFilter: string | null) => void;
   setTypeFilter: (typeFilter: string | null) => void;
   apiRef: MutableRefObject<GridApi>;
+  isTableLoaded: boolean;
+  setIsTableLoaded: (isTableLoaded: boolean) => void;
 };
 
 const RedirectsTableContext = createContext<RedirectsTableContextProps | null>(
@@ -43,6 +45,7 @@ const RedirectsTableContextProvider = ({
   const [typeFilter, setTypeFilter] = useState(null);
   const [searchFilter, setSearchFilter] = useState("");
   const apiRef = useGridApiRef<GridApi>();
+  const [isTableLoaded, setIsTableLoaded] = useState(false);
 
   const dispatch = useDispatch();
 
@@ -73,6 +76,8 @@ const RedirectsTableContextProvider = ({
         setHttpCodeFilter,
         setTypeFilter,
         apiRef,
+        isTableLoaded,
+        setIsTableLoaded,
       }}
     >
       {isLoading ? <LoadingQuote /> : children}

--- a/src/apps/seo/src/views/RedirectsManager/RedirectsTable/index.tsx
+++ b/src/apps/seo/src/views/RedirectsManager/RedirectsTable/index.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useLayoutEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   DataGridPro,
   GRID_CHECKBOX_SELECTION_COL_DEF,
@@ -39,6 +45,7 @@ const RedirectsTable = () => {
     typeFilter,
     searchFilter,
     apiRef,
+    setIsTableLoaded,
   } = useRedirectsTable();
 
   const [initialState, setInitialState] = useState<any>();
@@ -260,6 +267,10 @@ const RedirectsTable = () => {
       saveSnapshot();
     };
   }, [saveSnapshot, columns, GRID_CHECKBOX_SELECTION_COL_DEF]);
+
+  useEffect(() => {
+    setIsTableLoaded(true);
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
Resolve an issue where the apiRef is just an empty object due to a race condition. Due to apiRef not being able to trigger a useEffect, the fix is to add a boolean flag that will re-trigger the `RedirectsDelete.tsx`'s useEffect whenever the grid table has loaded. This ensures that when the useEffect is re-triggered, the apiRef will already be initialized and we can subscribe to any events that it has.