### PR TITLE
[Content] Show correct values in relational fields when switching versions

### DIFF
--- a/src/shell/components/RelationalFieldBase/index.tsx
+++ b/src/shell/components/RelationalFieldBase/index.tsx
@@ -66,6 +66,12 @@ export const RelationalFieldBase = ({
         skip: !relatedModelZUID,
       }
     );
+
+  useEffect(() => {
+    // Ensures that the values always synced
+    setItemZUIDs(value?.split(",") || []);
+  }, [value]);
+
   useEffect(() => {
     if (!!relatedModelZUID) {
       dispatch(fetchItems(relatedModelZUID));
@@ -77,7 +83,6 @@ export const RelationalFieldBase = ({
       const newItemZUIDs = [...itemZUIDs, newlyCreatedItemZUID];
 
       onChange(!!newItemZUIDs?.length ? newItemZUIDs.join(",") : null, name);
-      setItemZUIDs(!!newItemZUIDs?.length ? newItemZUIDs : null);
       setInitiatorZUID(null);
       setNewlyCreatedItemZUID(null);
     }
@@ -129,9 +134,6 @@ export const RelationalFieldBase = ({
                 onMoveCard={handleMoveCard}
                 onDropCard={handleReorder}
                 onRemoveCard={(itemZUID) => {
-                  setItemZUIDs((prev) =>
-                    prev.filter((zuid) => zuid !== itemZUID)
-                  );
                   onChange(
                     itemZUIDs.filter((zuid) => zuid !== itemZUID).join(","),
                     name
@@ -213,7 +215,7 @@ export const RelationalFieldBase = ({
               !!selectedZUIDs?.length ? selectedZUIDs.join(",") : null,
               name
             );
-            setItemZUIDs(!!selectedZUIDs?.length ? selectedZUIDs : null);
+            // setItemZUIDs(!!selectedZUIDs?.length ? selectedZUIDs : null);
             closeFieldSelectorDialog();
           }}
           replace={replace}

--- a/src/shell/components/RelationalFieldBase/index.tsx
+++ b/src/shell/components/RelationalFieldBase/index.tsx
@@ -215,7 +215,6 @@ export const RelationalFieldBase = ({
               !!selectedZUIDs?.length ? selectedZUIDs.join(",") : null,
               name
             );
-            // setItemZUIDs(!!selectedZUIDs?.length ? selectedZUIDs : null);
             closeFieldSelectorDialog();
           }}
           replace={replace}


### PR DESCRIPTION
Fixed a bug where the values of the relational fields doesn't update when changing versions
Fixes #3789 

[Content---nar-test-schema---Zesty-io---zesty-pw---Manager.webm](https://github.com/user-attachments/assets/73c6bb9b-c8e8-4649-b36f-de4ab439a39b)
