### PR TITLE
[Content] Use bynder instance setting to determine bynder session validity

### DIFF
--- a/src/apps/content-editor/src/app/components/FieldTypeMedia.tsx
+++ b/src/apps/content-editor/src/app/components/FieldTypeMedia.tsx
@@ -99,8 +99,9 @@ export const FieldTypeMedia = forwardRef(
       (setting) => setting.key === "bynder_token"
     );
     // Checks if the bynder portal and token are set
-    const isBynderSessionValid =
-      localStorage.getItem("cvrt") && localStorage.getItem("cvad");
+    const isBynderSessionValid = useMemo(() => {
+      return bynderPortalUrlSetting?.value && bynderTokenSetting?.value;
+    }, [bynderPortalUrlSetting, bynderTokenSetting]);
 
     useEffect(() => {
       setLocalImageZUIDs(images);


### PR DESCRIPTION
Instead of checking local storage for bynder session validity, rely on data from the instance setting as a more robust solution.
Fixes #3812 

[Screencast_20250930_174636.webm](https://github.com/user-attachments/assets/408562a8-788e-4cce-9aab-098a448cbdba)
