### PR TITLE
[#3809]: Blocks - Create Variant Button does not work when a user is on the info or code tabs 

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/BlockTabs/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/BlockTabs/index.tsx
@@ -188,12 +188,6 @@ export const BlockTabs = (props: any) => {
                 </Box>
               </Box>
             )}
-          {createVariantDialogOpen && (
-            <CreateVariantDialog
-              onClose={() => setCreateVariantDialogOpen(false)}
-              model={props?.model}
-            />
-          )}
         </>
       )}
       {value === 1 && (
@@ -213,6 +207,12 @@ export const BlockTabs = (props: any) => {
         </Box>
       )}
       {value === 2 && <CodeSample />}
+      {createVariantDialogOpen && (
+        <CreateVariantDialog
+          onClose={() => setCreateVariantDialogOpen(false)}
+          model={props?.model}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## RCA:
Dialog was nested inside tab component, causing it to unmount when switching tabs

## Fix:
Moved dialog to top-level parent component to maintain state across tab changes

https://github.com/user-attachments/assets/028c1265-5bee-4b55-8633-d67ec75f3a7a

