### PR TITLE
[Schema] Disable lock to a folder when an instance has no media folders yet

### DIFF
--- a/src/apps/schema/src/app/components/AddFieldModal/MediaRules.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/MediaRules.tsx
@@ -240,7 +240,7 @@ export const MediaRules = ({
                       }
 
                       if (rule.name === "group_id") {
-                        defaultValue = groups[0].value;
+                        defaultValue = groups?.length ? groups[0].value : null;
                       }
 
                       if (rule.name === "fileExtensions") {
@@ -260,6 +260,7 @@ export const MediaRules = ({
                       }
                     }}
                     checked={Boolean(fieldData[rule.name])}
+                    disabled={rule.name === "group_id" && !groups?.length}
                   />
                 }
                 label={


### PR DESCRIPTION
Resolved an issue where when creating a media field on schema and clicking Lock to a Folder on the rules tab causes an error when the instance has no media folders yet.
Resolves #3804

<img width="666" height="699" alt="image" src="https://github.com/user-attachments/assets/a9e673cb-fa31-4b67-a3e7-bbe6f55d2658" />
