### PR TITLE
[#3818]: Content - Publish status chip in data table not displaying correctly

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemList/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/index.tsx
@@ -34,7 +34,10 @@ import {
   ContentItemWithDirtyAndPublishing,
   ContentModelFieldDataType,
 } from "../../../../../../shell/services/types";
-import { fetchItems } from "../../../../../../shell/store/content";
+import {
+  fetchItems,
+  fetchItemPublishings,
+} from "../../../../../../shell/store/content";
 import { TableSortContext } from "./TableSortProvider";
 import { fetchFields } from "../../../../../../shell/store/fields";
 import { debounce } from "lodash";
@@ -180,6 +183,7 @@ export const ItemList = () => {
         })
         // @ts-ignore
       ).then(() => {
+        dispatch(fetchItemPublishings());
         setIsModelItemsFetching(false);
       });
     }

--- a/src/apps/content-editor/src/app/views/ItemList/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/index.tsx
@@ -175,6 +175,7 @@ export const ItemList = () => {
   useEffect(() => {
     if (activeLanguageCode) {
       setIsModelItemsFetching(true);
+      dispatch(fetchItemPublishings());
       dispatch(
         fetchItems(modelZUID, {
           limit: 1000,
@@ -183,7 +184,6 @@ export const ItemList = () => {
         })
         // @ts-ignore
       ).then(() => {
-        dispatch(fetchItemPublishings());
         setIsModelItemsFetching(false);
       });
     }


### PR DESCRIPTION
RCA:
- Item publishings were not loading upon model initialization or language change.

FIX:
- Implemented a call to fetchItemPublishings during model load and after any language switch.


https://github.com/user-attachments/assets/b0dad085-5483-4257-a868-d3c0eaa03985

