### PR TITLE
[Content] Block certain media actions from being performed if file has been deleted

### DIFF
--- a/src/apps/content-editor/src/app/components/FieldTypeMedia.tsx
+++ b/src/apps/content-editor/src/app/components/FieldTypeMedia.tsx
@@ -710,7 +710,7 @@ export const MediaItem = ({
         onDragEnd={handleDragEnd}
         onDragOver={handleDragOver}
         onClick={() => {
-          if (isURL) return;
+          if (isURL || !data) return;
 
           onPreview && onPreview(imageZUID);
         }}
@@ -829,7 +829,7 @@ export const MediaItem = ({
               ) : (
                 <></>
               )}
-              {!isURL && (
+              {!isURL && data && (
                 <Tooltip title="Edit File" placement="bottom" enterDelay={800}>
                   <IconButton size="small">
                     <EditRounded fontSize="small" />
@@ -868,7 +868,7 @@ export const MediaItem = ({
                   horizontal: "right",
                 }}
               >
-                {!isURL && !isBynderAsset && (
+                {!isURL && !isBynderAsset && data && (
                   <Box>
                     <MenuItem
                       onClick={(event) => {
@@ -907,17 +907,19 @@ export const MediaItem = ({
                     </MenuItem>
                   </Box>
                 )}
-                <MenuItem
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    handleCopyClick(isURL ? imageZUID : data?.url, false);
-                  }}
-                >
-                  <ListItemIcon>
-                    {isCopied ? <CheckRounded /> : <LinkRounded />}
-                  </ListItemIcon>
-                  <ListItemText>Copy File Url</ListItemText>
-                </MenuItem>
+                {data && (
+                  <MenuItem
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleCopyClick(isURL ? imageZUID : data?.url, false);
+                    }}
+                  >
+                    <ListItemIcon>
+                      {isCopied ? <CheckRounded /> : <LinkRounded />}
+                    </ListItemIcon>
+                    <ListItemText>Copy File Url</ListItemText>
+                  </MenuItem>
+                )}
                 <MenuItem
                   onClick={(event) => {
                     event.stopPropagation();


### PR DESCRIPTION
Block the ff actions if a selected file has been deleted:
- Preview File
- Edit File
- Rename File
- Replace File
- Copy ZUID
- Copy URL

Resolves #3830 

<img width="767" height="178" alt="image" src="https://github.com/user-attachments/assets/fa1fd297-f44c-45ff-8852-e57f71bacb34" />
