### PR TITLE
[Content] Show error message when related items failed to publish

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
@@ -356,7 +356,7 @@ export const ItemEditHeaderActions = ({
         await Promise.all(deleteScheduledPromises);
 
         // Proceed with publishing
-        await Promise.allSettled([
+        const publishPromises = await Promise.allSettled([
           createPublishing({
             modelZUID,
             itemZUID,
@@ -378,6 +378,18 @@ export const ItemEditHeaderActions = ({
             })
           ),
         ]);
+
+        // Map through all publish results and dispatch error notification if any failed
+        publishPromises.forEach((promise: any) => {
+          if ("error" in promise.value) {
+            dispatch(
+              notify({
+                message: promise.value.error.data?.error,
+                kind: "error",
+              })
+            );
+          }
+        });
 
         // Retain non rtk-query fetch of item publishing for legacy code
         dispatch(fetchItemPublishings());

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
@@ -379,7 +379,7 @@ export const ItemEditHeaderActions = ({
           ),
         ]);
 
-        // Map through all publish results and dispatch error notification if any failed
+        // Loop through all publish results and dispatch error notification if any failed
         publishPromises.forEach((promise: any) => {
           if ("error" in promise.value) {
             dispatch(


### PR DESCRIPTION
Shows an error message to let users know if a content item's related items failed to publish due to missing workflow statuses
Resolves #3539 

[Screencast_20251015_131802.webm](https://github.com/user-attachments/assets/f29c665f-be91-4a9a-8837-724b039ad78c)
