### PR TITLE
[3845]: Schema - Application Crashes When Adding New Relational Fields

### DIFF
--- a/src/apps/content-editor/src/app/ContentEditor.js
+++ b/src/apps/content-editor/src/app/ContentEditor.js
@@ -34,6 +34,8 @@ import { StagedChangesProvider } from "./views/ItemList/StagedChangesContext";
 import { SelectedItemsProvider } from "./views/ItemList/SelectedItemsContext";
 import { TableSortProvider } from "./views/ItemList/TableSortProvider";
 import { useParams } from "../../../../shell/hooks/useParams";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 
 // Makes sure that other apps using legacy theme does not get affected with the palette
 
@@ -98,40 +100,42 @@ export default function ContentEditor() {
       ) : (
         <div className={cx(styles.Content)}>
           <div className={styles.ContentWrap}>
-            <Switch>
-              {/* <Route path="/content/releases" component={ReleaseApp} /> */}
-              <Route exact path="/content" component={Analytics} />
-              <Route exact path="/content/link/new" component={LinkCreate} />
-              <Route
-                exact
-                path="/content/:modelZUID/new"
-                component={ItemCreate}
-              />
-              <Route path="/content/link/:linkZUID" component={LinkEdit} />
-              <Route
-                exact
-                path="/content/:modelZUID/import"
-                component={CSVImport}
-              />
-              <Route
-                path="/content/:modelZUID/:itemZUID"
-                component={ItemEdit}
-              />
-              <Route
-                exact
-                path="/content/:modelZUID"
-                render={() => (
-                  <StagedChangesProvider>
-                    <SelectedItemsProvider>
-                      <TableSortProvider>
-                        <ItemList />
-                      </TableSortProvider>
-                    </SelectedItemsProvider>
-                  </StagedChangesProvider>
-                )}
-              />
-              <Route path="*" component={NotFound} />
-            </Switch>
+            <DndProvider backend={HTML5Backend}>
+              <Switch>
+                {/* <Route path="/content/releases" component={ReleaseApp} /> */}
+                <Route exact path="/content" component={Analytics} />
+                <Route exact path="/content/link/new" component={LinkCreate} />
+                <Route
+                  exact
+                  path="/content/:modelZUID/new"
+                  component={ItemCreate}
+                />
+                <Route path="/content/link/:linkZUID" component={LinkEdit} />
+                <Route
+                  exact
+                  path="/content/:modelZUID/import"
+                  component={CSVImport}
+                />
+                <Route
+                  path="/content/:modelZUID/:itemZUID"
+                  component={ItemEdit}
+                />
+                <Route
+                  exact
+                  path="/content/:modelZUID"
+                  render={() => (
+                    <StagedChangesProvider>
+                      <SelectedItemsProvider>
+                        <TableSortProvider>
+                          <ItemList />
+                        </TableSortProvider>
+                      </SelectedItemsProvider>
+                    </StagedChangesProvider>
+                  )}
+                />
+                <Route path="*" component={NotFound} />
+              </Switch>
+            </DndProvider>
           </div>
         </div>
       )}

--- a/src/apps/content-editor/src/app/components/Editor/Editor.js
+++ b/src/apps/content-editor/src/app/components/Editor/Editor.js
@@ -9,8 +9,6 @@ import { cloneDeep, isEqual } from "lodash";
 import { useGetContentModelFieldsQuery } from "../../../../../../shell/services/instance";
 import { DYNAMIC_META_FIELD_NAMES } from "../../views/ItemEdit/Meta";
 import { FieldsLoader } from "./FieldsLoader";
-import { DndProvider } from "react-dnd";
-import { HTML5Backend } from "react-dnd-html5-backend";
 
 export const MaxLengths = {
   text: 150,
@@ -394,38 +392,36 @@ export default memo(function Editor({
 
   return (
     <div className={styles.Fields}>
-      <DndProvider backend={HTML5Backend}>
-        {activeFields?.map((field) => {
-          return (
-            <div key={`${field.ZUID}`} id={field.ZUID} className={styles.Field}>
-              <Field
-                ZUID={field.ZUID}
-                contentModelZUID={field.contentModelZUID}
-                active={active === field.ZUID}
-                name={field.name}
-                label={field.label}
-                description={field.description}
-                required={field.required}
-                relatedFieldZUID={field.relatedFieldZUID}
-                relatedModelZUID={field.relatedModelZUID}
-                datatype={field.datatype}
-                options={field.options}
-                settings={field.settings}
-                onChange={onChange}
-                onSave={onSave}
-                value={item?.data?.[field.name]}
-                version={item?.meta?.version}
-                langID={item?.meta?.langID}
-                errors={fieldErrors[field.name]}
-                maxLength={
-                  field.settings?.maxCharLimit ?? MaxLengths[field.datatype]
-                }
-                minLength={field.settings?.minCharLimit ?? 0}
-              />
-            </div>
-          );
-        })}
-      </DndProvider>
+      {activeFields?.map((field) => {
+        return (
+          <div key={`${field.ZUID}`} id={field.ZUID} className={styles.Field}>
+            <Field
+              ZUID={field.ZUID}
+              contentModelZUID={field.contentModelZUID}
+              active={active === field.ZUID}
+              name={field.name}
+              label={field.label}
+              description={field.description}
+              required={field.required}
+              relatedFieldZUID={field.relatedFieldZUID}
+              relatedModelZUID={field.relatedModelZUID}
+              datatype={field.datatype}
+              options={field.options}
+              settings={field.settings}
+              onChange={onChange}
+              onSave={onSave}
+              value={item?.data?.[field.name]}
+              version={item?.meta?.version}
+              langID={item?.meta?.langID}
+              errors={fieldErrors[field.name]}
+              maxLength={
+                field.settings?.maxCharLimit ?? MaxLengths[field.datatype]
+              }
+              minLength={field.settings?.minCharLimit ?? 0}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 });

--- a/src/apps/schema/src/app/index.tsx
+++ b/src/apps/schema/src/app/index.tsx
@@ -7,6 +7,8 @@ import { AllModels } from "./views/AllModels";
 import { SearchModels } from "./views/SearchModels";
 import { SchemaCreateWizard } from "./components/SchemaCreateWizard";
 import { ResizableContainer } from "../../../../shell/components/ResizeableContainer";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 
 export const SchemaApp = () => {
   return (
@@ -30,17 +32,19 @@ export const SchemaApp = () => {
       >
         <Sidebar />
       </ResizableContainer>
-      <Switch>
-        <Route exact path="/schema" render={() => <AllModels />} />
-        <Route path="/schema/search" render={() => <SearchModels />} />
-        <Route
-          exact
-          path="/schema/start"
-          render={() => <SchemaCreateWizard />}
-        />
-        <Redirect from="/schema/new" to="/schema" />
-        <Route path="/schema/:id" render={() => <Model />} />
-      </Switch>
+      <DndProvider backend={HTML5Backend}>
+        <Switch>
+          <Route exact path="/schema" render={() => <AllModels />} />
+          <Route path="/schema/search" render={() => <SearchModels />} />
+          <Route
+            exact
+            path="/schema/start"
+            render={() => <SchemaCreateWizard />}
+          />
+          <Redirect from="/schema/new" to="/schema" />
+          <Route path="/schema/:id" render={() => <Model />} />
+        </Switch>
+      </DndProvider>
     </Box>
   );
 };


### PR DESCRIPTION
Root Cause:
Missing drag-and-drop (DND) provider context, causing crashes when adding relational fields.

Solution:
Added the required DND provider to the schema application to enable proper drag-and-drop functionality


https://github.com/user-attachments/assets/b5f96185-8f66-4842-9781-469087a45363

