### PR TITLE
[Content] Prevent app from crashing when item versions is null or undefined

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
@@ -158,11 +158,14 @@ export const ItemEditHeaderActions = ({
     );
 
   useEffect(() => {
+    // Automatically opens the create redirect modal
+    // when there are changes to the url path part
     if (
       !isLoadingVersions &&
       !isFetchingVersions &&
       !isFetching &&
-      !!isCheckingPathUpdate
+      !!isCheckingPathUpdate &&
+      Array.isArray(itemVersions)
     ) {
       const publishedItemVersions = itemVersions
         ?.filter((ver) => !!ver?.publishAt)
@@ -180,7 +183,10 @@ export const ItemEditHeaderActions = ({
           );
         });
 
-      if (publishedItemVersions?.length < 2) return;
+      if (publishedItemVersions?.length < 2) {
+        return;
+      }
+
       const activeVersion = publishedItemVersions[0];
       const previousVersion = publishedItemVersions[1];
       const pathHasChanged =


### PR DESCRIPTION
Prevent app from crashing when item versions is null or undefined due to the api call to fetch a content item's versions fail
Resolves #3831 

[Screencast_20251016_115118.webm](https://github.com/user-attachments/assets/58afa838-970b-45aa-95f8-65971df16618)
