### PR TITLE
[#3820]: Content - Item duplication issue affecting localization of relational fields

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
@@ -98,8 +98,9 @@ export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
       .unwrap()
       .then((res) => {
         refetchContentModels();
-        Promise.resolve(dispatch(fetchItems(modelZUID))).then(
-          (fetchItemsResponse: any) => {
+        dispatch(fetchItems(modelZUID))
+          //@ts-ignore
+          .then((fetchItemsResponse: any) => {
             const createdItem = fetchItemsResponse?.data?.find(
               (item: ContentItem) => item?.meta?.ZUID === res.data.ZUID
             );
@@ -113,8 +114,7 @@ export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
                   : "content"
               }/${modelZUID}/${itemLangZUID}`
             );
-          }
-        );
+          });
         onClose();
       })
       .catch((error) => {

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
@@ -41,10 +41,8 @@ export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
   const item = useSelector(
     (state: AppState) => state.content[itemZUID] as ContentItem
   );
-  const languages = useSelector((state: AppState) => state.languages);
-  const langCode =
-    languages?.find((lang: Language) => lang?.ID === item?.meta?.langID)
-      ?.code || languages?.find((lang: Language) => lang?.default)?.code;
+  const langCode = useSelector((state: AppState) => state?.user?.selected_lang);
+
   const { data: models, refetch: refetchContentModels } =
     useGetContentModelsQuery();
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/DuplicateItemDialog.tsx
@@ -13,10 +13,9 @@ import { useSelector, useDispatch } from "react-redux";
 import { AppState } from "../../../../../../../../shell/store/types";
 import {
   ContentItem,
-  Data,
+  Language,
 } from "../../../../../../../../shell/services/types";
 import {
-  instanceApi,
   useCreateContentItemMutation,
   useGetContentModelFieldsQuery,
   useGetContentModelsQuery,
@@ -42,6 +41,10 @@ export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
   const item = useSelector(
     (state: AppState) => state.content[itemZUID] as ContentItem
   );
+  const languages = useSelector((state: AppState) => state.languages);
+  const langCode =
+    languages?.find((lang: Language) => lang?.ID === item?.meta?.langID)
+      ?.code || languages?.find((lang: Language) => lang?.default)?.code;
   const { data: models, refetch: refetchContentModels } =
     useGetContentModelsQuery();
 
@@ -94,16 +97,25 @@ export const DuplicateItemDialog = ({ onClose }: DuplicateItemProps) => {
     })
       .unwrap()
       .then((res) => {
-        dispatch(fetchItems(modelZUID));
         refetchContentModels();
-        onClose();
-        history.push(
-          `/${
-            models?.find((model) => model?.ZUID === modelZUID)?.type === "block"
-              ? "blocks"
-              : "content"
-          }/${modelZUID}/${res.data.ZUID}`
+        Promise.resolve(dispatch(fetchItems(modelZUID))).then(
+          (fetchItemsResponse: any) => {
+            const createdItem = fetchItemsResponse?.data?.find(
+              (item: ContentItem) => item?.meta?.ZUID === res.data.ZUID
+            );
+            const itemLangZUID =
+              createdItem?.siblings?.[langCode] || res?.data?.ZUID;
+            history.push(
+              `/${
+                models?.find((model) => model?.ZUID === modelZUID)?.type ===
+                "block"
+                  ? "blocks"
+                  : "content"
+              }/${modelZUID}/${itemLangZUID}`
+            );
+          }
         );
+        onClose();
       })
       .catch((error) => {
         console.error("Failed to duplicate item", error);

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/LanguageSelector.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/LanguageSelector.tsx
@@ -52,6 +52,7 @@ export const LanguageSelector = () => {
   const item = useSelector(
     (state: AppState) => state.content[itemZUID] as ContentItem
   );
+  const [activeLanguage, setActiveLanguage] = useState({ code: "en-US" });
 
   const onSelect = (langId: string) => {
     dispatch(selectLang(langId));
@@ -68,11 +69,12 @@ export const LanguageSelector = () => {
     }
   };
 
-  const activeLanguage = languages?.find(
-    (lang) => lang.ID === item?.meta?.langID
-  ) || {
-    code: "en-US",
-  };
+  useEffect(() => {
+    if (!isLoadingLanguages) {
+      const lang = languages?.find((lang) => lang.ID === item?.meta?.langID);
+      if (lang) setActiveLanguage(lang);
+    }
+  }, [item?.meta?.langID, languages, isLoadingLanguages]);
 
   if (isLoadingLanguages) {
     return (

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/LanguageSelector.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/LanguageSelector.tsx
@@ -52,7 +52,6 @@ export const LanguageSelector = () => {
   const item = useSelector(
     (state: AppState) => state.content[itemZUID] as ContentItem
   );
-  const [activeLanguage, setActiveLanguage] = useState({ code: "en-US" });
 
   const onSelect = (langId: string) => {
     dispatch(selectLang(langId));
@@ -69,14 +68,11 @@ export const LanguageSelector = () => {
     }
   };
 
-  useEffect(() => {
-    if (!isLoadingLanguages) {
-      const lang = languages?.find((lang) => lang.ID === item?.meta?.langID);
-      if (lang) {
-        setActiveLanguage(lang);
-      }
-    }
-  }, [item?.meta?.langID, languages, isLoadingLanguages]);
+  const activeLanguage = languages?.find(
+    (lang) => lang.ID === item?.meta?.langID
+  ) || {
+    code: "en-US",
+  };
 
   if (isLoadingLanguages) {
     return (

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/LanguageSelector.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/LanguageSelector.tsx
@@ -72,7 +72,9 @@ export const LanguageSelector = () => {
   useEffect(() => {
     if (!isLoadingLanguages) {
       const lang = languages?.find((lang) => lang.ID === item?.meta?.langID);
-      if (lang) setActiveLanguage(lang);
+      if (lang) {
+        setActiveLanguage(lang);
+      }
     }
   }, [item?.meta?.langID, languages, isLoadingLanguages]);
 


### PR DESCRIPTION
## Root Cause:
When an item is duplicated, the system incorrectly loads the default language version instead of the version corresponding to the user's currently active language. This causes a mismatch between the UI display and the intended language of the new item.

## Fix:
Updated the duplication logic to correctly identify and use the language-specific ZUID of the item being copied, ensuring the UI displays the proper language version upon duplication.



https://github.com/user-attachments/assets/1534422e-7851-4533-9a15-79232ae9d4d3



