### PR TITLE
[Content] Ensure hooks are added before react renders

### DIFF
--- a/src/shell/components/RelationalFieldBase/ActiveItem/index.tsx
+++ b/src/shell/components/RelationalFieldBase/ActiveItem/index.tsx
@@ -162,7 +162,10 @@ export const ActiveItem = memo(
 
     // Ensure item is fetched if it wasn't included in the initial 100-item fetch
     useEffect(() => {
-      if (contentItem || !relatedModelData?.ZUID || !itemZUID) return;
+      if (contentItem || !relatedModelData?.ZUID || !itemZUID) {
+        return;
+      }
+
       dispatch(fetchItem(relatedModelData.ZUID, itemZUID));
     }, [contentItem]);
 

--- a/src/shell/components/RelationalFieldBase/ActiveItem/index.tsx
+++ b/src/shell/components/RelationalFieldBase/ActiveItem/index.tsx
@@ -160,6 +160,12 @@ export const ActiveItem = memo(
       };
     }, [contentItems, itemZUID, relatedModelData, users]);
 
+    // Ensure item is fetched if it wasn't included in the initial 100-item fetch
+    useEffect(() => {
+      if (contentItem || !relatedModelData?.ZUID || !itemZUID) return;
+      dispatch(fetchItem(relatedModelData.ZUID, itemZUID));
+    }, [contentItem]);
+
     const imageFieldName = useMemo(() => {
       if (!relatedModelFields?.length) return null;
 
@@ -240,12 +246,6 @@ export const ActiveItem = memo(
     if (isLoadingRelatedModel || isLoadingUsers) {
       return <ActiveItemLoading draggable={draggable} />;
     }
-
-    // Ensure item is fetched if it wasn't included in the initial 100-item fetch
-    useEffect(() => {
-      if (contentItem || !relatedModelData?.ZUID || !itemZUID) return;
-      dispatch(fetchItem(relatedModelData.ZUID, itemZUID));
-    }, [contentItem]);
 
     return (
       <>


### PR DESCRIPTION
Resolves an issue where an early render is sometimes causing the component to render with fewer hooks
Fixes #3854 