### PR TITLE
Create redirects lag

### DIFF
--- a/src/apps/content-editor/src/app/views/Redirects/ContentRedirectModal.tsx
+++ b/src/apps/content-editor/src/app/views/Redirects/ContentRedirectModal.tsx
@@ -32,6 +32,7 @@ export type ContentRedirectModalProps = {
   loading: boolean;
   currentItem: ContentItemProps | null;
   options: ContentItemProps[];
+  onSearch: (value: string) => void;
 };
 
 export const validateUrl = (url: string) => {
@@ -55,6 +56,7 @@ export const ContentRedirectModal: FC<ContentRedirectModalProps> = ({
   loading,
   currentItem,
   options,
+  onSearch,
 }) => {
   const dispatch = useDispatch();
   const [targetInternal, setTargetInternal] = useState<ContentItemProps>(null);
@@ -240,6 +242,7 @@ export const ContentRedirectModal: FC<ContentRedirectModalProps> = ({
                     value={targetInternal}
                     defaultValue={targetPath}
                     onChange={setTargetInternal}
+                    onSearch={onSearch}
                   />
                 ) : (
                   <PathField

--- a/src/apps/content-editor/src/app/views/Redirects/ContentRedirects.tsx
+++ b/src/apps/content-editor/src/app/views/Redirects/ContentRedirects.tsx
@@ -26,6 +26,7 @@ import { useDeleteRedirectMutation } from "../../../../../../shell/services/inst
 import DescriptionIcon from "@mui/icons-material/Description";
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import { ListOptionSkeleton } from "../../../../../seo/src/app/components/RedirectsDialogProvider/CreateRedirects/SearchField";
+import { useContentItems } from "../../../../../seo/src/app/components/RedirectsDialogProvider/useContentItems";
 
 const REDIRECTED = {
   button: "Stop Redirecting",
@@ -51,8 +52,8 @@ export type ChangeRedirectProps = {
 
 export type ContentRedirectsProps = {
   itemZUID: string;
-  isLoading: boolean;
-  options: ContentItemProps[] | [];
+  // isLoading: boolean;
+  // options: ContentItemProps[] | [];
   redirects?: Redirects[] | [];
 };
 
@@ -157,10 +158,11 @@ const RedirectItem = ({
 
 const ContentRedirects: FC<ContentRedirectsProps> = ({
   itemZUID,
-  isLoading,
-  options = [],
+  // isLoading,
+  // options = [],
   redirects = [],
 }) => {
+  const { options, isLoading, setSearchTerm } = useContentItems();
   const [isOpen, setIsOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isRedirected, setIsRedirected] = useState(false);
@@ -264,6 +266,7 @@ const ContentRedirects: FC<ContentRedirectsProps> = ({
           options={options}
           loading={isLoading}
           currentItem={currentItem}
+          onSearch={setSearchTerm}
         />
       )}
       {isDeleteModalOpen && (

--- a/src/apps/content-editor/src/app/views/Redirects/index.tsx
+++ b/src/apps/content-editor/src/app/views/Redirects/index.tsx
@@ -48,13 +48,13 @@ export const Redirects = () => {
   }>();
   const {
     data: redirects,
-    isLoading: isLoadingRedirects,
+    isLoading,
     isFetching: isFetchingRedirects,
   } = useGetRedirectsQuery();
-  const { options, isLoading: isLoadingOptions } = useContentItems();
+  // const { options, isLoading: isLoadingOptions } = useContentItems();
   const { web } = useSelector((state: AppState) => state.content[itemZUID]);
 
-  const isLoading = isLoadingRedirects || isLoadingOptions;
+  // const isLoading = isLoadingRedirects || isLoadingOptions;
 
   const redirectsHere = useMemo(() => {
     if (!redirects?.length || !web?.path) return [];
@@ -287,8 +287,8 @@ export const Redirects = () => {
 
                 <ContentRedirects
                   itemZUID={itemZUID}
-                  isLoading={isLoading}
-                  options={options}
+                  // isLoading={isLoading}
+                  // options={options}
                   redirects={redirects}
                 />
               </>

--- a/src/apps/seo/src/app/components/RedirectsDialogProvider/CreateRedirects/CreateForm.tsx
+++ b/src/apps/seo/src/app/components/RedirectsDialogProvider/CreateRedirects/CreateForm.tsx
@@ -94,7 +94,7 @@ const CreateForm: FC<CreateFormProps> = ({
     updateRedirect,
   } = useRedirectsDialog();
 
-  const { options, isLoading } = useContentItems();
+  const { options, isLoading, setSearchTerm } = useContentItems();
 
   const isDisabled =
     !paths?.map((item) => item?.path?.trim())?.filter(Boolean)?.length ||
@@ -465,6 +465,7 @@ const CreateForm: FC<CreateFormProps> = ({
                 defaultValue={targetPath}
                 onChange={setTargetInternal}
                 readOnly={isInternal}
+                onSearch={setSearchTerm}
               />
             ) : (
               <PathField

--- a/src/apps/seo/src/app/components/RedirectsDialogProvider/CreateRedirects/SearchField.tsx
+++ b/src/apps/seo/src/app/components/RedirectsDialogProvider/CreateRedirects/SearchField.tsx
@@ -1,16 +1,15 @@
 import * as React from "react";
 import TextField from "@mui/material/TextField";
 import Autocomplete from "@mui/material/Autocomplete";
-import { List, RowComponentProps } from "react-window";
+import { List } from "react-window";
 import Typography from "@mui/material/Typography";
-import { Box, Paper, createFilterOptions, Skeleton } from "@mui/material";
+import { Box, Paper, Skeleton } from "@mui/material";
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 
 import SearchIcon from "@mui/icons-material/Search";
 import { ContentItemProps, TARGET_ERRORS } from "../constants";
 import { InputAdornment } from "@mui/material";
 import DescriptionIcon from "@mui/icons-material/Description";
-import { useContentItems } from "../useContentItems";
 import { debounce } from "lodash";
 
 export const ListOption = React.memo(
@@ -137,25 +136,21 @@ const SearchField: React.FC<SearchFieldProps> = ({
   readOnly = false,
   onSearch,
 }) => {
-  // const { options, setSearchTerm } = useContentItems();
   const textInputRef = React.useRef(null);
   const [open, setOpen] = React.useState(false);
-  const filterOptions = createFilterOptions({
-    matchFrom: "any",
-    stringify: (option: any) =>
-      `${option?.label}\n${option?.path}\n${option?.ZUID}`,
-  });
 
   const handleDebouncedInput = React.useCallback(
     debounce((value: string) => {
-      // console.log("debounced input", value);
       onSearch(value);
     }, 500),
     []
   );
 
   React.useEffect(() => {
-    if (!defaultValue) return;
+    if (!defaultValue) {
+      return;
+    }
+
     if (!loading && !!options) {
       const foundValue = options?.find((item) => item?.ZUID === defaultValue);
       onChange(foundValue);
@@ -194,7 +189,6 @@ const SearchField: React.FC<SearchFieldProps> = ({
           loading={loading}
           loadingText={<ListOptionSkeleton count={4} />}
           value={value}
-          // filterOptions={filterOptions}
           filterOptions={(x) => x}
           onInputChange={(evt, value) => handleDebouncedInput(value)}
           onClickCapture={(e) => {

--- a/src/apps/seo/src/app/components/RedirectsDialogProvider/CreateRedirects/SearchField.tsx
+++ b/src/apps/seo/src/app/components/RedirectsDialogProvider/CreateRedirects/SearchField.tsx
@@ -10,110 +10,113 @@ import SearchIcon from "@mui/icons-material/Search";
 import { ContentItemProps, TARGET_ERRORS } from "../constants";
 import { InputAdornment } from "@mui/material";
 import DescriptionIcon from "@mui/icons-material/Description";
+import { useContentItems } from "../useContentItems";
+import { debounce } from "lodash";
 
-export const ListOption: React.FC<
-  ContentItemProps & { isListItem?: boolean }
-> = ({
-  label,
-  path,
-  ZUID,
-  langCode,
-  isPublished,
-  isListItem = true,
-  type,
-  onDelete = () => {},
-  ...props
-}) => {
-  return (
-    <Box
-      key={ZUID}
-      {...props}
-      display="flex"
-      flexDirection="row"
-      justifyContent="space-between"
-      alignItems="center"
-      flexGrow={1}
-      columnGap="12px"
-      {...(isListItem
-        ? { px: "16px", py: "8px" }
-        : { pl: "8px", width: "100%", height: "52px" })}
-    >
-      {type === "pageset" ? (
-        <DescriptionIcon fontSize="small" color="action" />
-      ) : (
-        <FormatListBulletedIcon fontSize="small" color="action" />
-      )}
+export const ListOption = React.memo(
+  ({
+    label,
+    path,
+    ZUID,
+    langCode,
+    isPublished,
+    isListItem = true,
+    type,
+    onDelete = () => {},
+    ...props
+  }: ContentItemProps & { isListItem?: boolean }) => {
+    return (
       <Box
+        key={ZUID}
+        {...props}
         display="flex"
-        flexDirection="column"
+        flexDirection="row"
         justifyContent="space-between"
-        alignItems="stretch"
+        alignItems="center"
         flexGrow={1}
-        sx={{
-          overflow: "hidden",
-          position: "relative",
-          boxSizing: "border-box",
-        }}
+        columnGap="12px"
+        {...(isListItem
+          ? { px: "16px", py: "8px" }
+          : { pl: "8px", width: "100%", height: "52px" })}
       >
-        <Typography
-          variant="body2"
-          color="text.primary"
-          noWrap
-          textOverflow="ellipsis"
-          overflow="hidden"
-          fontWeight={500}
-          px="2px"
+        {type === "pageset" ? (
+          <DescriptionIcon fontSize="small" color="action" />
+        ) : (
+          <FormatListBulletedIcon fontSize="small" color="action" />
+        )}
+        <Box
+          display="flex"
+          flexDirection="column"
+          justifyContent="space-between"
+          alignItems="stretch"
+          flexGrow={1}
+          sx={{
+            overflow: "hidden",
+            position: "relative",
+            boxSizing: "border-box",
+          }}
         >
-          {`(${langCode}) ${label?.trim()}`}
-        </Typography>
-        <Typography
-          variant="body2"
-          color="info.dark"
-          noWrap
-          textOverflow="ellipsis"
-          maxWidth="100%"
-          overflow="hidden"
-          px="2px"
-        >
-          {path}
-        </Typography>
+          <Typography
+            variant="body2"
+            color="text.primary"
+            noWrap
+            textOverflow="ellipsis"
+            overflow="hidden"
+            fontWeight={500}
+            px="2px"
+          >
+            {`(${langCode}) ${label?.trim()}`}
+          </Typography>
+          <Typography
+            variant="body2"
+            color="info.dark"
+            noWrap
+            textOverflow="ellipsis"
+            maxWidth="100%"
+            overflow="hidden"
+            px="2px"
+          >
+            {path}
+          </Typography>
+        </Box>
       </Box>
-    </Box>
-  );
-};
+    );
+  }
+);
 
-const ListboxComponent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLElement>
->(function ListboxComponent(props, ref) {
-  const { children, ...other } = props;
-  const items = React.Children.toArray(children);
+const ListboxComponent = React.memo(
+  React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLElement>>(
+    function ListboxComponent(props, ref) {
+      const { children, ...other } = props;
+      const items = React.Children.toArray(children);
 
-  const rowHeight = 56;
+      const rowHeight = 56;
 
-  const Row = ({ index, style, data }: any) => {
-    return <li style={style}>{data[index]}</li>;
-  };
+      const Row = ({ index, style, data }: any) => {
+        return <li style={style}>{data[index]}</li>;
+      };
 
-  return (
-    <div
-      ref={ref}
-      data-cy="RedirectsTargetOptionsContainer"
-      style={{ width: "100%", height: `${rowHeight * 5}px` }}
-      {...other}
-    >
-      <ul>
-        <List
-          rowCount={items.length}
-          rowHeight={rowHeight}
-          overscanCount={5}
-          rowProps={{ data: items }}
-          rowComponent={Row}
-        />
-      </ul>
-    </div>
-  );
-});
+      return (
+        <div
+          ref={ref}
+          data-cy="RedirectsTargetOptionsContainer"
+          style={{ width: "100%", height: `${rowHeight * 5}px` }}
+          {...other}
+        >
+          <ul>
+            <List
+              rowCount={items.length}
+              rowHeight={rowHeight}
+              overscanCount={5}
+              rowProps={{ data: items }}
+              rowComponent={Row}
+            />
+          </ul>
+        </div>
+      );
+    }
+  )
+);
 
 type SearchFieldProps = {
   options: ContentItemProps[];
@@ -122,6 +125,7 @@ type SearchFieldProps = {
   defaultValue?: string;
   onChange: (value: ContentItemProps) => void;
   readOnly?: boolean;
+  onSearch: (value: string) => void;
 };
 
 const SearchField: React.FC<SearchFieldProps> = ({
@@ -131,7 +135,9 @@ const SearchField: React.FC<SearchFieldProps> = ({
   defaultValue,
   onChange,
   readOnly = false,
+  onSearch,
 }) => {
+  // const { options, setSearchTerm } = useContentItems();
   const textInputRef = React.useRef(null);
   const [open, setOpen] = React.useState(false);
   const filterOptions = createFilterOptions({
@@ -139,6 +145,14 @@ const SearchField: React.FC<SearchFieldProps> = ({
     stringify: (option: any) =>
       `${option?.label}\n${option?.path}\n${option?.ZUID}`,
   });
+
+  const handleDebouncedInput = React.useCallback(
+    debounce((value: string) => {
+      // console.log("debounced input", value);
+      onSearch(value);
+    }, 500),
+    []
+  );
 
   React.useEffect(() => {
     if (!defaultValue) return;
@@ -180,7 +194,9 @@ const SearchField: React.FC<SearchFieldProps> = ({
           loading={loading}
           loadingText={<ListOptionSkeleton count={4} />}
           value={value}
-          filterOptions={filterOptions}
+          // filterOptions={filterOptions}
+          filterOptions={(x) => x}
+          onInputChange={(evt, value) => handleDebouncedInput(value)}
           onClickCapture={(e) => {
             if (!!value) {
               setOpen(true);

--- a/src/apps/seo/src/app/components/RedirectsDialogProvider/useContentItems.ts
+++ b/src/apps/seo/src/app/components/RedirectsDialogProvider/useContentItems.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
   useGetAllPublishingsQuery,
   useGetContentModelsQuery,
@@ -14,12 +14,13 @@ import { ContentItemProps } from "./constants";
 import { PublishingsMap } from "./CreateRedirects/CreateForm";
 
 const useContentItems = () => {
+  const [searchTerm, setSearchTerm] = useState("");
   const { data: contentItems, isLoading: isLoadingContentItems } =
     useSearchContentQuery({
-      query: "",
+      query: searchTerm,
       order: "created",
       dir: "desc",
-      limit: 10000,
+      limit: 10,
     });
 
   const { data: publishings, isLoading: isLoadingPublishings } =
@@ -77,6 +78,7 @@ const useContentItems = () => {
   }, [models, isLoadingModels]);
 
   const options = useMemo(() => {
+    console.log("recalculate options");
     if (isLoading) return [];
 
     const parseContentItems = contentItems
@@ -113,6 +115,7 @@ const useContentItems = () => {
   return {
     options,
     isLoading,
+    setSearchTerm,
   };
 };
 

--- a/src/apps/seo/src/app/components/RedirectsDialogProvider/useContentItems.ts
+++ b/src/apps/seo/src/app/components/RedirectsDialogProvider/useContentItems.ts
@@ -15,12 +15,12 @@ import { PublishingsMap } from "./CreateRedirects/CreateForm";
 
 const useContentItems = () => {
   const [searchTerm, setSearchTerm] = useState("");
-  const { data: contentItems, isLoading: isLoadingContentItems } =
+  const { data: contentItems, isFetching: isFetchingContentItems } =
     useSearchContentQuery({
       query: searchTerm,
       order: "created",
       dir: "desc",
-      limit: 10,
+      limit: 5,
     });
 
   const { data: publishings, isLoading: isLoadingPublishings } =
@@ -34,7 +34,7 @@ const useContentItems = () => {
   const isLoading =
     !!isLoadingPublishings ||
     !!isLoadingLanguages ||
-    !!isLoadingContentItems ||
+    !!isFetchingContentItems ||
     !!isLoadingModels;
 
   const publishingMap: PublishingsMap = useMemo(() => {
@@ -78,7 +78,6 @@ const useContentItems = () => {
   }, [models, isLoadingModels]);
 
   const options = useMemo(() => {
-    console.log("recalculate options");
     if (isLoading) return [];
 
     const parseContentItems = contentItems


### PR DESCRIPTION
Issues this PR is trying to resolve:

- When the create redirect modal is opened, it hits the search endpoint with a 10k limit which is pretty huge. This sometimes causes the instances api service to crash and restart
- Once the dropdown opens the UI lags so bad
- Typing to filter is very laggy

Things done so far:

- Changed the search query limit to 5
- Instead of doing a client side filter, I changed it to hit the search endpoint when a keyword is typed in, then the results are mapped as the options
- Memoized some components in the autocomplete

Issues that need to be resolved:

- When editing a redirect, there are instances where it fails to load the data of the previous value since it currently does a client side filter to find the value from the options, but since the options has been limited to 5, it sometimes fails to display the selected item

Things to note:

- Regarding the issue with the 10k limit that's sometimes causing the instances api service to crash, there's also [another ticket](https://github.com/zesty-io/manager-ui/issues/3873) where the same query is being performed but on a different component which also causes the same problem.