### PR TITLE
[Content]: Publish status chip in data table not displaying correctly

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -30,7 +30,7 @@ import {
   checkLock,
   lock,
   unlock,
-  fetchModelItemsPublishings,
+  fetchAllModelPublishings,
 } from "shell/store/content";
 import { selectLang } from "shell/store/user";
 import { PendingEditsModal } from "../../components/PendingEditsModal";
@@ -463,7 +463,7 @@ export default function ItemEdit() {
       if (isMounted.current) {
         await Promise.resolve(
           dispatch(
-            fetchModelItemsPublishings({
+            fetchAllModelPublishings({
               modelZUID,
             })
           )

--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -30,6 +30,7 @@ import {
   checkLock,
   lock,
   unlock,
+  fetchModelItemsPublishings,
 } from "shell/store/content";
 import { selectLang } from "shell/store/user";
 import { PendingEditsModal } from "../../components/PendingEditsModal";
@@ -55,7 +56,6 @@ import { FreestyleWrapper } from "./FreestyleWrapper";
 import { Meta } from "./Meta";
 import { FieldError } from "../../components/Editor/FieldError";
 import { AIGeneratorProvider } from "../../../../../../shell/components/withAi/AIGeneratorProvider";
-import { fetchItemPublishings } from "../../../../../../shell/store/content";
 import { Redirects } from "../Redirects";
 import RedirectsDialogContextProvider from "../../../../../seo/src/app/components/RedirectsDialogProvider";
 
@@ -461,7 +461,14 @@ export default function ItemEdit() {
       throw new Error(err);
     } finally {
       if (isMounted.current) {
-        await Promise.resolve(dispatch(fetchItemPublishings()));
+        await Promise.resolve(
+          dispatch(
+            fetchModelItemsPublishings({
+              modelZUID,
+            })
+          )
+        );
+
         setSaving(false);
       }
     }

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
@@ -40,7 +40,7 @@ import { AppState } from "../../../../../../../../shell/store/types";
 import { useMetaKey } from "../../../../../../../../shell/hooks/useMetaKey";
 import {
   fetchItemPublishing,
-  fetchItemPublishings,
+  fetchModelItemsPublishings,
 } from "../../../../../../../../shell/store/content";
 import { useGetUsersQuery } from "../../../../../../../../shell/services/accounts";
 import { formatDate } from "../../../../../../../../utility/formatDate";
@@ -386,7 +386,11 @@ export const ItemEditHeaderActions = ({
         ]);
 
         // Retain non rtk-query fetch of item publishing for legacy code
-        dispatch(fetchItemPublishings());
+        await dispatch(
+          fetchModelItemsPublishings({
+            modelZUID,
+          })
+        );
         refetchVersions();
       } finally {
         setIsCheckingPathUpdate(true);

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
@@ -39,8 +39,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { AppState } from "../../../../../../../../shell/store/types";
 import { useMetaKey } from "../../../../../../../../shell/hooks/useMetaKey";
 import {
+  fetchAllModelPublishings,
   fetchItemPublishing,
-  fetchModelItemsPublishings,
 } from "../../../../../../../../shell/store/content";
 import { useGetUsersQuery } from "../../../../../../../../shell/services/accounts";
 import { formatDate } from "../../../../../../../../utility/formatDate";
@@ -387,7 +387,7 @@ export const ItemEditHeaderActions = ({
 
         // Retain non rtk-query fetch of item publishing for legacy code
         await dispatch(
-          fetchModelItemsPublishings({
+          fetchAllModelPublishings({
             modelZUID,
           })
         );

--- a/src/apps/content-editor/src/app/views/ItemList/UpdateListActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/UpdateListActions.tsx
@@ -35,8 +35,8 @@ import { useDispatch } from "react-redux";
 import { usePermission } from "../../../../../../shell/hooks/use-permissions";
 import { ContentItem } from "../../../../../../shell/services/types";
 import {
+  fetchAllModelPublishings,
   fetchItem,
-  fetchModelItemsPublishings,
 } from "../../../../../../shell/store/content";
 
 type UpdateListActionsProps = {
@@ -369,7 +369,7 @@ export const UpdateListActions = ({ items }: UpdateListActionsProps) => {
               .unwrap()
               .then(async () => {
                 await dispatch(
-                  fetchModelItemsPublishings({
+                  fetchAllModelPublishings({
                     modelZUID,
                   })
                 );
@@ -417,7 +417,7 @@ export const UpdateListActions = ({ items }: UpdateListActionsProps) => {
               .unwrap()
               .then(async (response) => {
                 await dispatch(
-                  fetchModelItemsPublishings({
+                  fetchAllModelPublishings({
                     modelZUID,
                   })
                 );

--- a/src/apps/content-editor/src/app/views/ItemList/UpdateListActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/UpdateListActions.tsx
@@ -36,7 +36,7 @@ import { usePermission } from "../../../../../../shell/hooks/use-permissions";
 import { ContentItem } from "../../../../../../shell/services/types";
 import {
   fetchItem,
-  fetchItemPublishings,
+  fetchModelItemsPublishings,
 } from "../../../../../../shell/store/content";
 
 type UpdateListActionsProps = {
@@ -368,7 +368,11 @@ export const UpdateListActions = ({ items }: UpdateListActionsProps) => {
             })
               .unwrap()
               .then(async () => {
-                await dispatch(fetchItemPublishings());
+                await dispatch(
+                  fetchModelItemsPublishings({
+                    modelZUID,
+                  })
+                );
                 setItemsToPublish([]);
                 clearStagedChanges({});
                 setSelectedItems([]);
@@ -412,7 +416,11 @@ export const UpdateListActions = ({ items }: UpdateListActionsProps) => {
             })
               .unwrap()
               .then(async (response) => {
-                await dispatch(fetchItemPublishings());
+                await dispatch(
+                  fetchModelItemsPublishings({
+                    modelZUID,
+                  })
+                );
                 setItemsToSchedule([]);
                 clearStagedChanges({});
                 setSelectedItems([]);

--- a/src/apps/content-editor/src/app/views/ItemList/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/index.tsx
@@ -123,6 +123,9 @@ export const ItemList = () => {
   }, [params]);
   const userFilter = params.get("user");
 
+  const isFetchingData =
+    isModelFetching || isFieldsFetching || isLangsLoading || isUsersFetching;
+
   const fieldMap = useMemo(() => {
     if (!fields?.length) return new Map<string, any>();
     return new Map(
@@ -173,7 +176,7 @@ export const ItemList = () => {
   }, [modelZUID]);
 
   useEffect(() => {
-    if (activeLanguageCode && modelZUID) {
+    if (activeLanguageCode && modelZUID && !isFetchingData) {
       setIsModelItemsFetching(true);
       dispatch(
         fetchItems(modelZUID, {
@@ -184,15 +187,19 @@ export const ItemList = () => {
         // @ts-ignore
       ).then(() => {
         //Ensure fetchItems completes before calling fetchPublishings to guarantee proper item mapping.
-        dispatch(fetchModelItemsPublishings({ modelZUID }))
+        dispatch(
+          fetchModelItemsPublishings({
+            modelZUID,
+          })
+        )
           // @ts-ignore
-          .then((res) => {
+          .finally(() => {
             //Only set the loading status to false after fetchPublishing has finished to ensure the status is accurate.
             setIsModelItemsFetching(false);
           });
       });
     }
-  }, [modelZUID, activeLanguageCode]);
+  }, [modelZUID, activeLanguageCode, isFetchingData]);
 
   useEffect(() => {
     // if languages and no language param, set the user selected lang or first language as the active language

--- a/src/apps/content-editor/src/app/views/ItemList/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/index.tsx
@@ -35,8 +35,8 @@ import {
   ContentModelFieldDataType,
 } from "../../../../../../shell/services/types";
 import {
+  fetchAllModelPublishings,
   fetchItems,
-  fetchModelItemsPublishings,
 } from "../../../../../../shell/store/content";
 import { TableSortContext } from "./TableSortProvider";
 import { fetchFields } from "../../../../../../shell/store/fields";
@@ -178,25 +178,21 @@ export const ItemList = () => {
   useEffect(() => {
     if (activeLanguageCode && modelZUID && !isFetchingData) {
       setIsModelItemsFetching(true);
-      dispatch(
-        fetchItems(modelZUID, {
-          limit: 1000,
-          page: 1,
-          lang: activeLanguageCode,
-        })
-        // @ts-ignore
-      ).then(() => {
-        //Ensure fetchItems completes before calling fetchPublishings to guarantee proper item mapping.
+      Promise.all([
         dispatch(
-          fetchModelItemsPublishings({
+          fetchItems(modelZUID, {
+            limit: 1000,
+            page: 1,
+            lang: activeLanguageCode,
+          })
+        ),
+        dispatch(
+          fetchAllModelPublishings({
             modelZUID,
           })
-        )
-          // @ts-ignore
-          .finally(() => {
-            //Only set the loading status to false after fetchPublishing has finished to ensure the status is accurate.
-            setIsModelItemsFetching(false);
-          });
+        ),
+      ]).finally(() => {
+        setIsModelItemsFetching(false);
       });
     }
   }, [modelZUID, activeLanguageCode, isFetchingData]);

--- a/src/apps/content-editor/src/app/views/ItemList/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/index.tsx
@@ -36,7 +36,7 @@ import {
 } from "../../../../../../shell/services/types";
 import {
   fetchItems,
-  fetchItemPublishings,
+  fetchModelItemsPublishings,
 } from "../../../../../../shell/store/content";
 import { TableSortContext } from "./TableSortProvider";
 import { fetchFields } from "../../../../../../shell/store/fields";
@@ -173,9 +173,8 @@ export const ItemList = () => {
   }, [modelZUID]);
 
   useEffect(() => {
-    if (activeLanguageCode) {
+    if (activeLanguageCode && modelZUID) {
       setIsModelItemsFetching(true);
-      dispatch(fetchItemPublishings());
       dispatch(
         fetchItems(modelZUID, {
           limit: 1000,
@@ -184,7 +183,13 @@ export const ItemList = () => {
         })
         // @ts-ignore
       ).then(() => {
-        setIsModelItemsFetching(false);
+        //Ensure fetchItems completes before calling fetchPublishings to guarantee proper item mapping.
+        dispatch(fetchModelItemsPublishings({ modelZUID }))
+          // @ts-ignore
+          .then((res) => {
+            //Only set the loading status to false after fetchPublishing has finished to ensure the status is accurate.
+            setIsModelItemsFetching(false);
+          });
       });
     }
   }, [modelZUID, activeLanguageCode]);

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -977,7 +977,7 @@ export function fetchItemPublishings() {
   return (dispatch) => {
     return dispatch({
       type: "FETCH_RESOURCE",
-      uri: `${CONFIG.API_INSTANCE}/content/items/publishings?limit=20000`,
+      uri: `${CONFIG.API_INSTANCE}/content/items/publishings?limit=80000`,
       handler: (res) => {
         if (res.status === 200) {
           dispatch({
@@ -1016,7 +1016,6 @@ export function fetchModelItemsPublishings({
   showActiveOnly = false,
 }) {
   return (dispatch) => {
-    console.debug("dispatch", { dispatch });
     return dispatch({
       type: "FETCH_RESOURCE",
       uri: `${CONFIG.API_INSTANCE}/content/models/${modelZUID}/items/publishings?limit=${limit}&showDeleted=${showDeleted}&showDeletedItems=${showDeletedItems}&showActiveOnly=${showActiveOnly}`,

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -1010,67 +1010,61 @@ export function fetchItemPublishings() {
   };
 }
 
-export function fetchModelItemsPublishings({
+export function fetchAllModelPublishings({
   modelZUID,
-  limit = 10000, //set 10k limit as optimal threshold for 2-second response times
-  showDeleted = false,
-  showDeletedItems = false,
-  showActiveOnly = false,
+  limit = 10000, // 10k limit for optimal 2-second response times
+  showDeleted = null,
+  showDeletedItems = null,
+  showActiveOnly = null,
 }) {
-  const params = new URLSearchParams({
-    limit: limit.toString(),
-    showDeleted: showDeleted.toString(),
-    showDeletedItems: showDeletedItems.toString(),
-    showActiveOnly: showActiveOnly.toString(),
-  });
-
   return async (dispatch) => {
-    const allData = [];
-
     try {
-      //paginate requests to prevent large dataset performance issues
-      for (let page = 1; ; page++) {
-        params.set("page", page.toString());
+      const allData = [];
+      let currentPage = 1;
+      while (true) {
+        const params = new URLSearchParams({
+          limit,
+          page: currentPage,
+          ...(showDeleted && { showDeleted }),
+          ...(showDeletedItems && { showDeletedItems }),
+          ...(showActiveOnly && { showActiveOnly }),
+        });
 
         const uri = `${
           CONFIG.API_INSTANCE
         }/content/models/${modelZUID}/items/publishings?${params?.toString()}`;
-        const res = await dispatch({ type: "FETCH_RESOURCE", uri });
+        const response = await dispatch({ type: "FETCH_RESOURCE", uri });
 
-        if (res?.error) {
-          throw new Error(res.error);
+        if (response?.error) {
+          throw new Error(response.error);
         }
 
-        // stop if response data is empty
-        if (!res?.data?.length) {
+        if (!response?.data?.length) {
           break;
         }
 
-        allData.push(...res.data);
+        allData.push(...response.data);
 
-        // stop if response data less than the request limit
-        if (res.data.length < limit) {
+        // Stop if we've reached the last page
+        if (response.data.length < limit) {
           break;
         }
+        //set next page
+        currentPage++;
       }
-
-      // update store
-      if (allData.length) {
+      if (allData.length > 0) {
         dispatch({
           type: "FETCH_ITEMS_PUBLISHING",
           data: parsePublishState(allData),
         });
       }
-
-      return allData;
     } catch (error) {
       dispatch(
         notify({
           kind: "warn",
-          message: `Failed to fetch all model items publishings: ${error.message}`,
+          message: `Failed to fetch model items publishings: ${error.message}`,
         })
       );
-      return [];
     }
   };
 }

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -977,7 +977,8 @@ export function fetchItemPublishings() {
   return (dispatch) => {
     return dispatch({
       type: "FETCH_RESOURCE",
-      uri: `${CONFIG.API_INSTANCE}/content/items/publishings?limit=80000`,
+      // reduce initial limit since publishings will be fetched per model
+      uri: `${CONFIG.API_INSTANCE}/content/items/publishings?limit=10000`,
       handler: (res) => {
         if (res.status === 200) {
           dispatch({
@@ -1008,48 +1009,69 @@ export function fetchItemPublishings() {
     });
   };
 }
+
 export function fetchModelItemsPublishings({
   modelZUID,
-  limit = 10000,
+  limit = 10000, //set 10k limit as optimal threshold for 2-second response times
   showDeleted = false,
   showDeletedItems = false,
   showActiveOnly = false,
 }) {
-  return (dispatch) => {
-    return dispatch({
-      type: "FETCH_RESOURCE",
-      uri: `${CONFIG.API_INSTANCE}/content/models/${modelZUID}/items/publishings?limit=${limit}&showDeleted=${showDeleted}&showDeletedItems=${showDeletedItems}&showActiveOnly=${showActiveOnly}`,
-      handler: (res) => {
-        if (res.status === 200) {
-          dispatch({
-            type: "FETCH_ITEMS_PUBLISHING",
-            data: parsePublishState(res.data),
-          });
-          return res.data;
-        } else {
-          dispatch(
-            notify({
-              kind: "warn",
-              message: `${res.status}:Failed to fetch model items publishings${
-                res.error ? ": " + res.error : ""
-              }`,
-            })
-          );
-          return [];
+  const params = new URLSearchParams({
+    limit: limit.toString(),
+    showDeleted: showDeleted.toString(),
+    showDeletedItems: showDeletedItems.toString(),
+    showActiveOnly: showActiveOnly.toString(),
+  });
+
+  return async (dispatch) => {
+    const allData = [];
+
+    try {
+      //paginate requests to prevent large dataset performance issues
+      for (let page = 1; ; page++) {
+        params.set("page", page.toString());
+
+        const uri = `${
+          CONFIG.API_INSTANCE
+        }/content/models/${modelZUID}/items/publishings?${params?.toString()}`;
+        const res = await dispatch({ type: "FETCH_RESOURCE", uri });
+
+        if (res?.error) {
+          throw new Error(res.error);
         }
-      },
-      error: (err) => {
-        dispatch(
-          notify({
-            kind: "warn",
-            message: `Failed to fetch model items publishings: ${
-              err?.message || err || ""
-            }`,
-          })
-        );
-        return [];
-      },
-    });
+
+        // stop if response data is empty
+        if (!res?.data?.length) {
+          break;
+        }
+
+        allData.push(...res.data);
+
+        // stop if response data less than the request limit
+        if (res.data.length < limit) {
+          break;
+        }
+      }
+
+      // update store
+      if (allData.length) {
+        dispatch({
+          type: "FETCH_ITEMS_PUBLISHING",
+          data: parsePublishState(allData),
+        });
+      }
+
+      return allData;
+    } catch (error) {
+      dispatch(
+        notify({
+          kind: "warn",
+          message: `Failed to fetch all model items publishings: ${error.message}`,
+        })
+      );
+      return [];
+    }
   };
 }
 

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -977,7 +977,7 @@ export function fetchItemPublishings() {
   return (dispatch) => {
     return dispatch({
       type: "FETCH_RESOURCE",
-      uri: `${CONFIG.API_INSTANCE}/content/items/publishings?limit=100000`,
+      uri: `${CONFIG.API_INSTANCE}/content/items/publishings?limit=20000`,
       handler: (res) => {
         if (res.status === 200) {
           dispatch({
@@ -1004,6 +1004,51 @@ export function fetchItemPublishings() {
             }`,
           })
         );
+      },
+    });
+  };
+}
+export function fetchModelItemsPublishings({
+  modelZUID,
+  limit = 10000,
+  showDeleted = false,
+  showDeletedItems = false,
+  showActiveOnly = false,
+}) {
+  return (dispatch) => {
+    console.debug("dispatch", { dispatch });
+    return dispatch({
+      type: "FETCH_RESOURCE",
+      uri: `${CONFIG.API_INSTANCE}/content/models/${modelZUID}/items/publishings?limit=${limit}&showDeleted=${showDeleted}&showDeletedItems=${showDeletedItems}&showActiveOnly=${showActiveOnly}`,
+      handler: (res) => {
+        if (res.status === 200) {
+          dispatch({
+            type: "FETCH_ITEMS_PUBLISHING",
+            data: parsePublishState(res.data),
+          });
+          return res.data;
+        } else {
+          dispatch(
+            notify({
+              kind: "warn",
+              message: `${res.status}:Failed to fetch model items publishings${
+                res.error ? ": " + res.error : ""
+              }`,
+            })
+          );
+          return [];
+        }
+      },
+      error: (err) => {
+        dispatch(
+          notify({
+            kind: "warn",
+            message: `Failed to fetch model items publishings: ${
+              err?.message || err || ""
+            }`,
+          })
+        );
+        return [];
       },
     });
   };


### PR DESCRIPTION
## RCA: 
The initial implementation encountered API limitations when retrieving publishing records

## FIX:
- [x] Created a new API endpoint to fetch publishing records per model.
- [x] Replaced the front-end Redux action fetchItemPublishings with fetchModelItemsPublishings to use the new endpoint.

## Prerequisite:
This change is dependent on the instances-api PR being merged first.
PR: https://github.com/zesty-io/instances-api/pull/689