### PR TITLE
[ManagerUI] - reordering media elements in a media field not working

### DIFF
--- a/src/apps/content-editor/src/app/components/FieldTypeMedia.tsx
+++ b/src/apps/content-editor/src/app/components/FieldTypeMedia.tsx
@@ -81,7 +81,6 @@ export const FieldTypeMedia = forwardRef(
     }: FieldTypeMediaProps,
     ref
   ) => {
-    const dndContainerRef = useRef(null);
     const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
     const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
     const [localImageZUIDs, setLocalImageZUIDs] = useState<string[]>(images);
@@ -487,8 +486,6 @@ export const FieldTypeMedia = forwardRef(
     return (
       <>
         <Stack
-          id={name}
-          ref={dndContainerRef}
           data-cy="mediaItem-container"
           gap={1}
           sx={{
@@ -496,7 +493,7 @@ export const FieldTypeMedia = forwardRef(
               hasError ? `1px solid ${theme.palette.error.main}` : "none",
           }}
         >
-          <DndContextProvider containerRef={dndContainerRef}>
+          <DndContextProvider>
             {sortedImages.map((image, index) => {
               const isBynderAsset = image?.includes("bynder.com");
 
@@ -750,15 +747,11 @@ export const MediaItem = ({
         alignItems="center"
         sx={{
           border: (theme) => `1px solid ${theme.palette.border}`,
-          borderRadius: "8px",
-          "&:hover": {
-            backgroundColor: "action.hover",
-            cursor: "pointer",
-          },
+          borderRadius: 2,
           backgroundColor: "background.paper",
-          ...(isDragging && {
-            opacity: 0.01,
-          }),
+          overflow: "hidden",
+          opacity: isDragging ? 0 : 1,
+          transform: "translate(0, 0)",
         }}
         position="relative"
       >

--- a/src/shell/components/DndContextProvider.tsx
+++ b/src/shell/components/DndContextProvider.tsx
@@ -1,27 +1,14 @@
-import { memo, MutableRefObject, useEffect, useState } from "react";
+import { memo } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
 const DndContextProvider = memo(
-  ({
-    containerRef,
-    children,
-  }: {
-    containerRef: MutableRefObject<any>;
-    children: React.ReactNode;
-  }) => {
-    const [context, setContext] = useState(null);
-
-    useEffect(() => {
-      if (!containerRef?.current) return;
-      setContext(containerRef?.current);
-    }, [containerRef?.current]);
-
-    return context ? (
-      <DndProvider backend={HTML5Backend} options={{ rootElement: context }}>
+  ({ children }: { children: React.ReactNode }) => {
+    return (
+      <DndProvider backend={HTML5Backend} context={window}>
         {children}
       </DndProvider>
-    ) : null;
+    );
   }
 );
 

--- a/src/shell/components/RelationalFieldBase/index.tsx
+++ b/src/shell/components/RelationalFieldBase/index.tsx
@@ -6,8 +6,6 @@ import {
   KeyboardArrowDownRounded,
   AddRounded,
 } from "@mui/icons-material";
-import { DndProvider } from "react-dnd";
-import { HTML5Backend } from "react-dnd-html5-backend";
 import { useDispatch } from "react-redux";
 
 import { ActiveItem } from "./ActiveItem";
@@ -21,6 +19,7 @@ import { ActiveItemLoading } from "./ActiveItem/ActiveItemLoading";
 import { CreateNewItemDialog } from "./CreateNewItemDialog";
 import { useParams } from "../../hooks/useParams";
 import { CreateContentItemDialogContext } from "../../contexts/CreateContentItemDialogProvider";
+import DndContextProvider from "../DndContextProvider";
 
 type RelationalFieldBaseProps = {
   name: string;
@@ -121,7 +120,7 @@ export const RelationalFieldBase = ({
             <ActiveItemLoading key={index} draggable />
           ))
         ) : (
-          <DndProvider backend={HTML5Backend}>
+          <DndContextProvider>
             {itemZUIDs?.slice(0, showAll ? undefined : 5)?.map((val, index) => (
               <ActiveItem
                 key={val}
@@ -146,7 +145,7 @@ export const RelationalFieldBase = ({
                 }}
               />
             ))}
-          </DndProvider>
+          </DndContextProvider>
         )}
       </Stack>
       {itemZUIDs?.length > 5 && (


### PR DESCRIPTION
- [ ] Fixed reordering issues by replacing the incompatible DndProvider `options` prop with a `context` prop
- [ ] Replaced DndProvider wrapper with custom DndContextProvider component to prevent instance conflicts



https://github.com/user-attachments/assets/18f3b245-5890-430a-95c2-eeea86811bf2

