### PR TITLE
[Global] - Set no instance permission to false when logging in with a valid user account

### DIFF
--- a/src/shell/components/load-instance/index.js
+++ b/src/shell/components/load-instance/index.js
@@ -46,6 +46,7 @@ export default connect((state) => {
           if (res.status !== 200) {
             setNoPermission(true);
           } else {
+            setNoPermission(false);
             document.title = `Manager - ${res.data?.name} - Zesty`;
             CONFIG.URL_PREVIEW_FULL = `${CONFIG.URL_PREVIEW_PROTOCOL}${res.data?.randomHashID}${CONFIG.URL_PREVIEW}`;
 


### PR DESCRIPTION
Sets the no permission flag to false after logging in with a different account which has access to the instance
Fixes #3859 

[Screencast_20251110_112625.webm](https://github.com/user-attachments/assets/503dba87-b680-49b5-9416-ff054a96f002)
