### PR TITLE
[Content] Disable Create Items button when user hasn't mapped the imported csv in the fields yet

### DIFF
--- a/src/apps/content-editor/src/app/views/CSVImport/CSVImportBody.js
+++ b/src/apps/content-editor/src/app/views/CSVImport/CSVImportBody.js
@@ -374,7 +374,8 @@ class CSVImportBody extends Component {
             disabled={
               this.state.complete ||
               this.state.inFlight ||
-              !this.state.fieldMaps
+              !this.state.fieldMaps ||
+              !this.state.mappedItems?.length
             }
             onClick={this.handleCreateItems}
             startIcon={<AddIcon />}


### PR DESCRIPTION
Disable Create Items button when user hasn't mapped the imported csv in the fields yet
Resolves #3894 

[Screencast_20251119_124809.webm](https://github.com/user-attachments/assets/387a2b43-5b97-444a-8f4b-6321de74503c)
