### PR TITLE
[Schema]: Error fetching fields

### DIFF
--- a/src/apps/schema/src/app/components/ModelsTable.tsx
+++ b/src/apps/schema/src/app/components/ModelsTable.tsx
@@ -24,7 +24,9 @@ import {
 } from "../../../../../shell/components/Filters/DateFilter";
 
 const FieldsCell = ({ ZUID }: any) => {
-  const { data, isLoading } = useGetContentModelFieldsQuery(ZUID);
+  const { data, isLoading } = useGetContentModelFieldsQuery({
+    modelZUID: ZUID,
+  });
   if (isLoading) {
     return (
       <Box display="flex" height="100%" alignItems="center">


### PR DESCRIPTION
## Root Cause: 
- The useGetContentModelFieldsQuery hook was called with a string argument instead of the required object { modelZUID: id }.

## Fix:
- Updated the hook call to provide the correct query argument as an object.

https://github.com/user-attachments/assets/f6e431c6-27fc-40fe-a7c3-7a71caa5d894

