### PR TITLE
Code - Fix broken image link

### DIFF
--- a/src/apps/code-editor/src/app/components/SideBar/index.tsx
+++ b/src/apps/code-editor/src/app/components/SideBar/index.tsx
@@ -286,7 +286,7 @@ export const SideBar: FC<SideBarProps> = ({
 const NoResults = ({ keyword }: { keyword: string }) => (
   <Stack gap={1.5} alignItems="center" justifyContent="center" p={1.5}>
     <img
-      src="/noSearchResults.svg"
+      src="/images/noSearchResults.svg"
       alt="No search results"
       width="70"
       height="64"


### PR DESCRIPTION
Fix an incorrect image source path for the no results component when filtering code subapp nav items.
Resolves #3917 

<img width="366" height="304" alt="image" src="https://github.com/user-attachments/assets/0558dd46-0ede-486b-8ff9-637e190cae33" />
