### PR TITLE
Blocks - Refetch content model data when a block model is generated

### DIFF
--- a/src/apps/blocks/components/Sidebar.tsx
+++ b/src/apps/blocks/components/Sidebar.tsx
@@ -11,7 +11,9 @@ import { CreateModelDialogue } from "../../schema/src/app/components/CreateModel
 import noSearchResults from "../../../../public/images/noSearchResults.svg";
 
 export const Sidebar = () => {
-  const { data: models, isLoading } = useGetContentModelsQuery();
+  const { data: models, isLoading } = useGetContentModelsQuery(null, {
+    refetchOnMountOrArgChange: true,
+  });
   const history = useHistory();
   const [filter, setFilter] = useState("");
   const [isCreateModelDialogueOpen, setIsCreateModelDialogueOpen] =

--- a/src/shell/views/Shell/AIDrawer.tsx
+++ b/src/shell/views/Shell/AIDrawer.tsx
@@ -33,7 +33,10 @@ import ArrowDropDownRoundedIcon from "@mui/icons-material/ArrowDropDownRounded";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
 import LanguageRoundedIcon from "@mui/icons-material/LanguageRounded";
-import { useGetLangsMappingQuery } from "../../services/instance";
+import {
+  useGetLangsMappingQuery,
+  useGetContentModelsQuery,
+} from "../../services/instance";
 import {
   codeSystemInstruction,
   contentSystemInstruction,
@@ -111,6 +114,7 @@ export const AIDrawer = () => {
 
   const [geminiGenerate, { isLoading, isError, data: aiResponse }] =
     useGeminiGenerationMutation();
+  const { refetch: refetchContentModels } = useGetContentModelsQuery();
 
   const responsesEndRef = useRef(null);
 
@@ -149,6 +153,11 @@ export const AIDrawer = () => {
               value: response.payload.value,
             },
           });
+        }
+
+        // Makes sure that the subapp sidebar data is refreshed
+        if (response.type === "NAVIGATE") {
+          refetchContentModels();
         }
       });
     } catch (error) {

--- a/src/shell/views/Shell/AIDrawer.tsx
+++ b/src/shell/views/Shell/AIDrawer.tsx
@@ -33,10 +33,7 @@ import ArrowDropDownRoundedIcon from "@mui/icons-material/ArrowDropDownRounded";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import InfoRoundedIcon from "@mui/icons-material/InfoRounded";
 import LanguageRoundedIcon from "@mui/icons-material/LanguageRounded";
-import {
-  useGetLangsMappingQuery,
-  useGetContentModelsQuery,
-} from "../../services/instance";
+import { useGetLangsMappingQuery } from "../../services/instance";
 import {
   codeSystemInstruction,
   contentSystemInstruction,
@@ -114,7 +111,6 @@ export const AIDrawer = () => {
 
   const [geminiGenerate, { isLoading, isError, data: aiResponse }] =
     useGeminiGenerationMutation();
-  const { refetch: refetchContentModels } = useGetContentModelsQuery();
 
   const responsesEndRef = useRef(null);
 
@@ -389,7 +385,6 @@ export const AIDrawer = () => {
                       variant="contained"
                       sx={{ ml: "auto", mt: 0.5 }}
                       onClick={() => {
-                        refetchContentModels();
                         enqueueAction({
                           type: response.type,
                           payload: {

--- a/src/shell/views/Shell/AIDrawer.tsx
+++ b/src/shell/views/Shell/AIDrawer.tsx
@@ -154,13 +154,6 @@ export const AIDrawer = () => {
             },
           });
         }
-
-        // Makes sure that the subapp sidebar data is refreshed
-        if (response.type === "NAVIGATE") {
-          if (response.payload.path.includes("blocks")) {
-            refetchContentModels();
-          }
-        }
       });
     } catch (error) {
       console.error("Error parsing AI response", error);
@@ -396,6 +389,7 @@ export const AIDrawer = () => {
                       variant="contained"
                       sx={{ ml: "auto", mt: 0.5 }}
                       onClick={() => {
+                        refetchContentModels();
                         enqueueAction({
                           type: response.type,
                           payload: {

--- a/src/shell/views/Shell/AIDrawer.tsx
+++ b/src/shell/views/Shell/AIDrawer.tsx
@@ -157,7 +157,9 @@ export const AIDrawer = () => {
 
         // Makes sure that the subapp sidebar data is refreshed
         if (response.type === "NAVIGATE") {
-          refetchContentModels();
+          if (response.payload.path.includes("blocks")) {
+            refetchContentModels();
+          }
         }
       });
     } catch (error) {


### PR DESCRIPTION
Ensures that the content model data rtk cache is invalidated when a block model is generated via AI so that the subapp nav will immediately contain the newly-generated block.
Resolves #3923 

[Screencast_20251204_094345.webm](https://github.com/user-attachments/assets/d2772046-f927-482b-b764-794d7d5862d7)
