### PR TITLE
Schema - Show all possible parent options when creating a new model

### DIFF
--- a/src/apps/schema/src/app/components/SelectModelParentInput.tsx
+++ b/src/apps/schema/src/app/components/SelectModelParentInput.tsx
@@ -50,14 +50,19 @@ export const SelectModelParentInput = ({
           ?.filter((item) => item.contentModelZUID !== id)
           ?.sort((a, b) => a.label.localeCompare(b.label));
       } else {
-        return _navItems
-          ?.filter(
-            (item) =>
-              item.contentModelZUID !== id &&
-              currentItem &&
-              currentItem.ZUID !== item.parentZUID
-          )
-          ?.sort((a, b) => a.label.localeCompare(b.label));
+        if (!currentItem) {
+          // This would mean that we're creating a NEW model, therefore we would want to show all options
+          return _navItems?.sort((a, b) => a.label.localeCompare(b.label));
+        } else {
+          return _navItems
+            ?.filter(
+              (item) =>
+                item.contentModelZUID !== id &&
+                currentItem &&
+                currentItem.ZUID !== item.parentZUID
+            )
+            ?.sort((a, b) => a.label.localeCompare(b.label));
+        }
       }
     }
 


### PR DESCRIPTION
Resolves an issue where parent model options are sometimes empty
Fixes #3921 

[Screencast_20251209_131342.webm](https://github.com/user-attachments/assets/e176cc66-bcb3-4707-8001-d752bee2084e)
