### PR TITLE
Content - remove redundant useEffect to resolve related field data

### DIFF
--- a/src/shell/components/RelationalFieldBase/index.tsx
+++ b/src/shell/components/RelationalFieldBase/index.tsx
@@ -72,12 +72,6 @@ export const RelationalFieldBase = ({
   }, [value]);
 
   useEffect(() => {
-    if (!!relatedModelZUID) {
-      dispatch(fetchItems(relatedModelZUID));
-    }
-  }, [relatedModelZUID]);
-
-  useEffect(() => {
     if (!!newlyCreatedItemZUID && initiatorZUID === fieldZUID) {
       const newItemZUIDs = [...itemZUIDs, newlyCreatedItemZUID];
 

--- a/src/shell/components/RelationalFieldBase/index.tsx
+++ b/src/shell/components/RelationalFieldBase/index.tsx
@@ -6,7 +6,6 @@ import {
   KeyboardArrowDownRounded,
   AddRounded,
 } from "@mui/icons-material";
-import { useDispatch } from "react-redux";
 
 import { ActiveItem } from "./ActiveItem";
 import { FieldSelectorDialog } from "./FieldSelectorDialog";
@@ -14,7 +13,6 @@ import {
   useGetContentModelQuery,
   useGetContentModelFieldsQuery,
 } from "../../services/instance";
-import { fetchItems } from "../../store/content";
 import { ActiveItemLoading } from "./ActiveItem/ActiveItemLoading";
 import { CreateNewItemDialog } from "./CreateNewItemDialog";
 import { useParams } from "../../hooks/useParams";
@@ -41,7 +39,6 @@ export const RelationalFieldBase = ({
   onChange,
   multiselect,
 }: RelationalFieldBaseProps) => {
-  const dispatch = useDispatch();
   const [params] = useParams();
   const [itemZUIDs, setItemZUIDs] = useState<string[]>(value?.split(",") || []);
   const [showAll, setShowAll] = useState(false);


### PR DESCRIPTION
Removed a redundant useEffect since `resolveFieldOptions` in the api middleware already exists and does what that same hook does which makes it redundant and unnecessarily make the same api request twice.
Resolves #3932   