### PR TITLE
Blocks: Save changes on currently opened variant when Save button on preview is clicked

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/PreviewMode/PreviewMode.js
+++ b/src/apps/content-editor/src/app/components/Editor/PreviewMode/PreviewMode.js
@@ -121,17 +121,36 @@ export default function PreviewMode(props) {
     route,
   ]);
 
+  // Storing these as a ref to make sure we're always invoking the latest state
+  // of these functions
+  const onSaveRef = useRef(props.onSave);
+  const onCloseRef = useRef(props.onClose);
+
+  useEffect(() => {
+    onSaveRef.current = props.onSave;
+  }, [props.onSave]);
+
+  useEffect(() => {
+    onCloseRef.current = props.onClose;
+  }, [props.onClose]);
+
   // Listen for postMessages from iframe
   useEffect(() => {
     const handleMessage = (event) => {
       if (event.data.source === "zesty") {
         switch (event.data.action) {
           case "close":
-            props.onClose();
+            if (onCloseRef.current) {
+              onCloseRef.current();
+            }
             break;
+
           case "save":
-            props.onSave();
+            if (onSaveRef.current) {
+              onSaveRef.current();
+            }
             break;
+
           default:
             break;
         }


### PR DESCRIPTION
Keep a reference of the `onSave` and `onClose` to make sure that when invoked, the latest states of these functions are invoked.
Resolves #3939 

[Screencast_20260106_130048.webm](https://github.com/user-attachments/assets/6cfb7b18-5e8c-4e2b-b8e6-bd73ab9f9849)
