### PR TITLE
Content: Show analytics table row data

### DIFF
--- a/src/apps/content-editor/src/app/views/Analytics/views/AnalyticsDashboard/ItemsTable/ItemsTable.tsx
+++ b/src/apps/content-editor/src/app/views/Analytics/views/AnalyticsDashboard/ItemsTable/ItemsTable.tsx
@@ -301,7 +301,13 @@ export const ItemsTableContent = ({
             ".MuiDataGrid-columnHeader": {
               backgroundColor: "grey.100",
             },
-            ".MuiDataGrid-row": { cursor: "pointer" },
+            ".MuiDataGrid-row": {
+              cursor: "pointer",
+
+              "& .MuiDataGrid-cell": {
+                alignContent: "center",
+              },
+            },
             // hide empty skeleton rows
             ".MuiDataGrid-row:has(.MuiDataGrid-cell:first-child:empty)": {
               display: "none",

--- a/src/apps/content-editor/src/app/views/Analytics/views/AnalyticsDashboard/ItemsTable/ItemsTable.tsx
+++ b/src/apps/content-editor/src/app/views/Analytics/views/AnalyticsDashboard/ItemsTable/ItemsTable.tsx
@@ -303,7 +303,9 @@ export const ItemsTableContent = ({
             },
             ".MuiDataGrid-row": { cursor: "pointer" },
             // hide empty skeleton rows
-            ".MuiDataGrid-row:has(> :first-child:empty)": { display: "none" },
+            ".MuiDataGrid-row:has(.MuiDataGrid-cell:first-child:empty)": {
+              display: "none",
+            },
           }}
         />
       )}

--- a/src/apps/content-editor/src/app/views/Analytics/views/AnalyticsDashboard/ItemsTable/ViewsCell.tsx
+++ b/src/apps/content-editor/src/app/views/Analytics/views/AnalyticsDashboard/ItemsTable/ViewsCell.tsx
@@ -25,9 +25,16 @@ export const ViewsCell = ({
     limit: 1,
   });
   const foundItem = item?.[0]?.web?.path === path ? item?.[0] : null;
-  if (isFetching || !path)
+
+  if (isFetching || !path) {
     return (
-      <Box width="100%" textAlign="right">
+      <Box
+        width="100%"
+        textAlign="right"
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+      >
         <Skeleton
           height="12px"
           width="100%"
@@ -37,6 +44,7 @@ export const ViewsCell = ({
         <img src={lineChartSkeleton3} height="13px" width="73px" />
       </Box>
     );
+  }
 
   const paddedSessionsByDay = !screenPageViewsByDay.length
     ? [0, 0]


### PR DESCRIPTION
Updated the css selector that hides empty skeleton loaders so that it doesn't affect rows with actual data
Resolves #3952 

[Screencast_20260113_112541.webm](https://github.com/user-attachments/assets/02109f51-1d41-4ae0-a764-cde66cc534eb)
