### PR TITLE
Code: Route to the correct page when clicking the edit content button

### DIFF
--- a/src/apps/code-editor/src/app/components/Differ/Differ.js
+++ b/src/apps/code-editor/src/app/components/Differ/Differ.js
@@ -27,6 +27,7 @@ export const Differ = memo(
       <>
         <TopBar
           contentModelZUID={props?.contentModelZUID}
+          contentModelType={props?.contentModelType}
           fileZUID={props?.fileZUID}
           fileType={props?.fileType}
           fileName={props?.fileName}

--- a/src/apps/code-editor/src/app/components/Editor/Editor.js
+++ b/src/apps/code-editor/src/app/components/Editor/Editor.js
@@ -24,6 +24,7 @@ export const Editor = function Editor(props) {
       />
       <TopBar
         contentModelZUID={props.contentModelZUID}
+        contentModelType={props.contentModelType}
         fileZUID={props.fileZUID}
         fileType={props.fileType}
         fileName={props.fileName}

--- a/src/apps/code-editor/src/app/components/TopBar/index.tsx
+++ b/src/apps/code-editor/src/app/components/TopBar/index.tsx
@@ -44,6 +44,7 @@ interface TopBarProps {
   isLive: boolean;
   code: string;
   contentModelZUID?: string;
+  contentModelType: string;
   isDirty: boolean;
   updatedAt?: string;
   updatedBy?: string;
@@ -187,9 +188,13 @@ const TopBar = memo(function TopBar(props: TopBarProps) {
                       <IconButton
                         size="small"
                         sx={{ color: "grey.400" }}
-                        onClick={() =>
-                          history.push(`/content/${props.contentModelZUID}`)
-                        }
+                        onClick={() => {
+                          if (props.contentModelType === "block") {
+                            history.push(`/blocks/${props.contentModelZUID}`);
+                          } else {
+                            history.push(`/content/${props.contentModelZUID}`);
+                          }
+                        }}
                       >
                         <VerticalSplitRoundedIcon fontSize="small" />
                       </IconButton>

--- a/src/apps/code-editor/src/app/components/Workspace/index.js
+++ b/src/apps/code-editor/src/app/components/Workspace/index.js
@@ -154,6 +154,7 @@ const Workspace = connect((state, props) => {
                     fileZUID={file?.ZUID}
                     fileType={file?.fileType}
                     contentModelZUID={file?.contentModelZUID}
+                    contentModelType={file?.type}
                     currentCode={file?.code}
                     publishedVersion={file?.publishedVersion}
                     status={props.status}
@@ -175,6 +176,7 @@ const Workspace = connect((state, props) => {
                     dispatch={props?.dispatch}
                     fileName={file.fileName}
                     contentModelZUID={file?.contentModelZUID}
+                    contentModelType={file?.type}
                     publishedVersion={file.publishedVersion}
                     fields={fields}
                     code={file?.code}


### PR DESCRIPTION
Properly routes to either the block variants overview or the content item multipage table view depending on the model's type.
Resolves #3946 

[Screencast_20260114_122431.webm](https://github.com/user-attachments/assets/eeadf38c-f6fe-4134-bf84-377339a75bfd)
