### PR TITLE
Blocks: Hide header tabs when navigating to an AI-generated block

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/index.tsx
@@ -104,7 +104,9 @@ export const ItemEditHeader = ({
   const history = useHistory();
   const [showDuplicateItemDialog, setShowDuplicateItemDialog] = useState(false);
   const { data: installedApps } = useGetInstalledAppsQuery();
-  const { data: contentModels } = useGetContentModelsQuery();
+  const { data: contentModels } = useGetContentModelsQuery(null, {
+    refetchOnMountOrArgChange: true,
+  });
 
   const item = useSelector(
     (state: AppState) =>
@@ -239,7 +241,7 @@ export const ItemEditHeader = ({
             <PublishStatus currentVersion={item?.web?.version} />
           </Stack>
         </Box>
-        {type !== "block" && (
+        {!!type && type !== "block" && (
           <Box
             display="flex"
             justifyContent="space-between"


### PR DESCRIPTION
Refetch the content models on load so that when clicking on the Navigate button when generating a block the newly created model is loaded into RTK query's cache
Resolves #3969 

[Screencast_20260128_094042.webm](https://github.com/user-attachments/assets/d6e5fb65-928d-4c4b-8980-90858c6b76ee)
