### PR TITLE
AI Drawer: Enable adding new lines by pressing shift + enter

### DIFF
--- a/src/shell/views/Shell/AIDrawer.tsx
+++ b/src/shell/views/Shell/AIDrawer.tsx
@@ -480,7 +480,7 @@ export const AIDrawer = () => {
             onChange={(e) => setPrompt(e.target.value)}
             value={prompt}
             onKeyPress={(e) => {
-              if (e.key === "Enter") {
+              if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
                 handlePrompt(prompt);
               }


### PR DESCRIPTION
Allow users to add new lines by pressing shift + enter
Resolves #3962 

[Screencast_20260130_110134.webm](https://github.com/user-attachments/assets/7d7efc97-9b67-40ca-b795-05139b4c8f23)
