### PR TITLE
Content: Also delete siblings of a deleted content item in a multi-lang instance

### DIFF
--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -128,7 +128,23 @@ export function content(state = {}, action) {
 
     case "REMOVE_ITEM":
       let removed = { ...state };
+      const itemToRemove = removed[action.itemZUID];
+      // Get the item ZUIDs of all the siblings for multi-lang instances
+      const siblingItems = itemToRemove?.siblings
+        ? Object.values(itemToRemove.siblings)?.filter(
+            (item) => item !== action.itemZUID
+          )
+        : [];
+
+      // Remove the actual item
       delete removed[action.itemZUID];
+      // Remove siblings in a diff language for multi-lang instances
+      if (siblingItems.length) {
+        siblingItems.forEach((itemZUID) => {
+          delete removed[itemZUID];
+        });
+      }
+
       return removed;
 
     case "SET_ITEM_WEB":


### PR DESCRIPTION
When deleting a content item in a multi-lang instance, also delete the siblings that are on a different language from the cache.
Resolves #3980 

[Screencast_20260205_090332.webm](https://github.com/user-attachments/assets/d9eaac20-155a-4830-9fa0-a962a9e3b03b)
