### PR TITLE
Content: Allow siblings in multi-lang instances to have the same path part

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/ItemRoute.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/ItemRoute.tsx
@@ -73,10 +73,15 @@ export const ItemRoute = ({
                      * Exclude currently viewed item zuid, as it's currently saved path would match.
                      * Check if other results have a matching path, if so then it is already taken and
                      * can not be used.
+                     * Check if the matched result is a sibling of the currently viewed item, if so then
+                     * it is fine to have the same path.
                      * Result paths come with leading and trailing slashes
                      */
                     return (
                       _item.meta.ZUID !== item?.meta?.ZUID &&
+                      !Object.values(_item.siblings || {}).includes(
+                        item?.meta?.ZUID
+                      ) &&
                       _item.web.path === fullPath
                     );
                   }


### PR DESCRIPTION
Allows siblings in multi-lang instances to have the same path part
Fixes #3985 

[Screencast_20260216_082211.webm](https://github.com/user-attachments/assets/0d07f647-c20d-4af4-bce4-8ef12bebe4cc)
