### PR TITLE
Blocks: Support rendering of block variants without names

### DIFF
--- a/cypress/e2e/blocks/tests/blocks.spec.js
+++ b/cypress/e2e/blocks/tests/blocks.spec.js
@@ -85,6 +85,19 @@ describe("All Blocks Tests", () => {
       timeout: 15_000,
     }).should("exist");
   });
+
+  it("creates a variant with no variant name", () => {
+    AllBlocksPage.visit();
+    cy.contains(CypressTestBlock).click(TIMEOUT);
+    cy.getBySelector("create-variant-button-header").click();
+    cy.getBySelector("variant-name-input").clear();
+    cy.getBySelector("create-variant-confirm-button").click();
+    cy.contains(new RegExp(`${CypressTestBlock}:\\s*`), {
+      timeout: 15_000,
+    }).should("exist");
+    cy.contains(CypressTestBlock).click(TIMEOUT);
+    cy.getBySelector("block-variant-card").should("have.length", 2);
+  });
 });
 
 function deleteTestDataModels() {

--- a/src/apps/blocks/components/CreateVariantDialog.tsx
+++ b/src/apps/blocks/components/CreateVariantDialog.tsx
@@ -104,7 +104,7 @@ export const CreateVariantDialog = ({
           Cancel
         </Button>
         <Button
-          disabled={!variantName || isFieldsLoading}
+          disabled={isFieldsLoading}
           onClick={handleVariantCreate}
           loading={isLoading}
           variant="contained"

--- a/src/apps/blocks/views/BlockModel.tsx
+++ b/src/apps/blocks/views/BlockModel.tsx
@@ -213,6 +213,7 @@ const BlockVariantCard = ({ item, onClick }: BlockVariantCardProps) => {
   const [noImage, setNoImage] = useState(false);
   return (
     <Box
+      data-cy="block-variant-card"
       key={item.meta.ZUID}
       width={265}
       sx={{

--- a/src/apps/blocks/views/BlockModel.tsx
+++ b/src/apps/blocks/views/BlockModel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useHistory, useParams } from "react-router";
 import {
   Box,
@@ -49,6 +49,18 @@ export const BlockModel = () => {
   useEffect(() => {
     setShowCreateVariantDialog(!!params?.get("createVariant"));
   }, [params]);
+
+  const filteredData = useMemo(() => {
+    if (!data) return [];
+
+    const normalizedSearch = search.toLowerCase().trim();
+
+    if (!normalizedSearch) return data;
+
+    return data?.filter?.((item) =>
+      item.web.metaTitle?.toLowerCase().includes(normalizedSearch)
+    );
+  }, [data, search]);
 
   const model = models?.find((model) => model.ZUID === modelZUID);
 
@@ -135,19 +147,15 @@ export const BlockModel = () => {
               overflowY: "scroll",
             }}
           >
-            {data
-              ?.filter?.((item) =>
-                item.web.metaTitle.toLowerCase().includes(search.toLowerCase())
-              )
-              ?.map((item) => (
-                <BlockVariantCard
-                  key={item.meta.ZUID}
-                  item={item}
-                  onClick={() => {
-                    history.push(`/blocks/${modelZUID}/${item.meta.ZUID}`);
-                  }}
-                />
-              ))}
+            {filteredData.map((item) => (
+              <BlockVariantCard
+                key={item.meta.ZUID}
+                item={item}
+                onClick={() => {
+                  history.push(`/blocks/${modelZUID}/${item.meta.ZUID}`);
+                }}
+              />
+            ))}
           </Box>
         ) : (
           <Box
@@ -247,7 +255,7 @@ const BlockVariantCard = ({ item, onClick }: BlockVariantCardProps) => {
         height={52}
       >
         <Typography noWrap variant="body2">
-          {item.web.metaTitle}
+          {item.web.metaTitle ?? ""}
         </Typography>
       </Box>
     </Box>

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/BlockTabs/BlockVariantCard.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/BlockTabs/BlockVariantCard.tsx
@@ -99,9 +99,9 @@ export const BlockVariantCard = ({ block }: { block: ContentItem }) => {
           <Typography
             variant="body1"
             fontWeight={700}
-            sx={{ wordBreak: "break-word" }}
+            sx={{ wordBreak: "break-word", minHeight: "24px" }}
           >
-            {block?.web?.metaTitle}
+            {block?.web?.metaTitle ?? ""}
           </Typography>
           <Typography
             variant="body3"

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/BlockTabs/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/BlockTabs/index.tsx
@@ -8,7 +8,7 @@ import {
   TextField,
   InputAdornment,
 } from "@mui/material";
-import { useRef, useState } from "react";
+import { useRef, useState, useMemo } from "react";
 
 import {
   VerticalSplitRounded,
@@ -34,6 +34,26 @@ export const BlockTabs = (props: any) => {
   const searchRef = useRef(null);
   const [search, setSearch] = useState("");
   const [createVariantDialogOpen, setCreateVariantDialogOpen] = useState(false);
+
+  const sortedBlocks = useMemo(() => {
+    if (!data) return [];
+
+    return data.slice().sort((a, b) => {
+      return (a.web.metaTitle ?? "")?.localeCompare(b.web.metaTitle ?? "");
+    });
+  }, [data]);
+
+  const filteredBlocks = useMemo(() => {
+    if (!sortedBlocks) return [];
+
+    const normalizedSearch = search.toLowerCase().trim();
+
+    if (!normalizedSearch) return sortedBlocks;
+
+    return sortedBlocks?.filter?.((item) =>
+      item.web.metaTitle?.toLowerCase().includes(normalizedSearch)
+    );
+  }, [sortedBlocks, search]);
 
   return (
     <>
@@ -115,9 +135,7 @@ export const BlockTabs = (props: any) => {
               ),
             }}
           />
-          {!!data?.filter((block) =>
-            block.web?.metaTitle.toLowerCase().includes(search.toLowerCase())
-          )?.length && (
+          {!!filteredBlocks.length && (
             <List
               disablePadding
               sx={{
@@ -130,64 +148,51 @@ export const BlockTabs = (props: any) => {
                 overflowY: "auto",
               }}
             >
-              {data
-                ?.filter((block) =>
-                  block.web?.metaTitle
-                    .toLowerCase()
-                    .includes(search.toLowerCase())
-                )
-                ?.slice()
-                ?.sort((a, b) => {
-                  return a.web?.metaTitle.localeCompare(b.web?.metaTitle);
-                })
-                ?.map((block) => (
-                  <BlockVariantCard key={block.meta.ZUID} block={block} />
-                ))}
+              {filteredBlocks.map((block) => (
+                <BlockVariantCard key={block.meta.ZUID} block={block} />
+              ))}
             </List>
           )}
-          {search &&
-            !data?.filter((block) =>
-              block.web?.metaTitle.toLowerCase().includes(search.toLowerCase())
-            )?.length && (
-              <Box display="flex" gap={2}>
-                <Box
-                  component="img"
-                  src={noSearchResults}
-                  width={120}
-                  height={110}
-                ></Box>
-                <Box>
-                  <Typography variant="h4" maxWidth={458}>
-                    Your search{" "}
-                    <strong
-                      style={{
-                        wordBreak: "break-all",
-                      }}
-                    >
-                      "{search}"
-                    </strong>{" "}
-                    could not find any results
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    mt={1}
-                    mb={3}
-                    maxWidth={458}
+          {search && !filteredBlocks.length && (
+            <Box display="flex" gap={2}>
+              <Box
+                component="img"
+                src={noSearchResults}
+                width={120}
+                height={110}
+              ></Box>
+              <Box>
+                <Typography variant="h4" maxWidth={458}>
+                  Your search{" "}
+                  <strong
+                    style={{
+                      wordBreak: "break-all",
+                    }}
                   >
-                    Try adjusting your search. We suggest check all words are
-                    spelled correctly or try using different keywords.
-                  </Typography>
-                  <Button
-                    variant="contained"
-                    startIcon={<SearchRounded />}
-                    onClick={() => searchRef?.current?.focus()}
-                  >
-                    Search Again
-                  </Button>
-                </Box>
+                    "{search}"
+                  </strong>{" "}
+                  could not find any results
+                </Typography>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  mt={1}
+                  mb={3}
+                  maxWidth={458}
+                >
+                  Try adjusting your search. We suggest check all words are
+                  spelled correctly or try using different keywords.
+                </Typography>
+                <Button
+                  variant="contained"
+                  startIcon={<SearchRounded />}
+                  onClick={() => searchRef?.current?.focus()}
+                >
+                  Search Again
+                </Button>
               </Box>
-            )}
+            </Box>
+          )}
         </>
       )}
       {value === 1 && (

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -682,9 +682,17 @@ export function createItem({ modelZUID, itemZUID, skipPathPartValidation }) {
             return false;
           });
 
-    const hasMissingRequiredSEOFields = skipPathPartValidation
-      ? !item?.web?.metaTitle
-      : !item?.web?.metaTitle || !item?.web?.pathPart;
+    // Block items do not require SEO fields
+    let hasMissingRequiredSEOFields = false;
+
+    if (model?.type !== "block") {
+      if (skipPathPartValidation) {
+        hasMissingRequiredSEOFields = !item?.web?.metaTitle;
+      } else {
+        hasMissingRequiredSEOFields =
+          !item?.web?.metaTitle || !item?.web?.pathPart;
+      }
+    }
 
     // Check minlength is satisfied
     const lackingCharLength = fields?.filter(


### PR DESCRIPTION
Fixes #3989

### Changes:
- Prevents app from crashing when a block variant doesn't have a meta title/variant name
- Allow users to create block variants with no variant name in the UI

### Preview:

[Screencast_20260319_092154.webm](https://github.com/user-attachments/assets/2ee8e219-7a8b-4cb7-ad7a-90ddfcc67c66)
