### PR TITLE
Content: Show the not found screen when api call fails due to an invalid model

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemList/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/index.tsx
@@ -574,8 +574,23 @@ export const ItemList = () => {
     return clonedItems;
   }, [processedItems, search, sortModel, statusFilter, dateFilter, userFilter]);
 
-  if (modelError && "status" in modelError && modelError.status === 404) {
-    return <NotFound message={`Model "${modelZUID}" not found`} />;
+  if (modelError && "status" in modelError) {
+    let message = "";
+
+    switch (modelError.status) {
+      case 404:
+        message = `Model "${modelZUID}" not found`;
+        break;
+
+      case 400:
+        message = `Invalid model "${modelZUID}"`;
+        break;
+
+      default:
+        break;
+    }
+
+    return <NotFound message={message} />;
   }
 
   return (


### PR DESCRIPTION
Show the not found screen when api call fails due to an invalid zuid
Fixes #3960 

<img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/16796dd5-33ec-4c60-9961-4688f8c62302" />