### PR TITLE
Content: Prevent app from crashing when switching to wysiwyg or inline editor with a tag with missing href value

### DIFF
--- a/src/shell/components/FieldTypeEditor/Editors/react-prosemirror-schema/marks.js
+++ b/src/shell/components/FieldTypeEditor/Editors/react-prosemirror-schema/marks.js
@@ -3,7 +3,7 @@ import { attributes, getElementAttrs } from "./nodes";
 const link = {
   attrs: {
     ...attributes(),
-    href: {},
+    href: { default: "" },
     target: { default: null },
   },
   inclusive: false,


### PR DESCRIPTION
Added a default href value to prevent the app from crashing when switching to the wysiwyg or inline editor from markdown view with an <a> tag that has an href value that is undefined/null.
Resolves #3990 