### PR TITLE
[Workflows] - Default workflow permissions do not have owner permissions by default

### DIFF
--- a/src/apps/settings/src/app/views/User/Workflows/authorized/forms-dialogs/StatusLabelForm.tsx
+++ b/src/apps/settings/src/app/views/User/Workflows/authorized/forms-dialogs/StatusLabelForm.tsx
@@ -304,6 +304,10 @@ const StatusLabelForm: FC<StatusLabelFormProps> = ({
 
   const usedColors = labels.map((label) => label.color);
 
+  const ownerRoleZUID = rolesMenuItems?.find(
+    (role) => role?.label?.toLocaleLowerCase() === "owner"
+  )?.value;
+
   const transformRoleValues = (value: string): string[] =>
     value ? value.split(",") : [];
 
@@ -458,7 +462,11 @@ const StatusLabelForm: FC<StatusLabelFormProps> = ({
               id="workflows-create-status-label-addPermissionRoles-select"
               name="addPermissionRoles"
               listData={rolesMenuItems}
-              defaultValue={values?.addPermissionRoles?.join(",")}
+              defaultValue={
+                !values?.name
+                  ? ownerRoleZUID
+                  : values?.addPermissionRoles?.join(",")
+              }
             />
           </FormInputFieldWrapper>
           <FormInputFieldWrapper
@@ -469,7 +477,11 @@ const StatusLabelForm: FC<StatusLabelFormProps> = ({
               id="workflows-create-status-label-removePermissionRoles-select"
               name="removePermissionRoles"
               listData={rolesMenuItems}
-              defaultValue={values?.removePermissionRoles?.join(",")}
+              defaultValue={
+                !values?.name
+                  ? ownerRoleZUID
+                  : values?.removePermissionRoles?.join(",")
+              }
             />
           </FormInputFieldWrapper>
           <FormControlLabel


### PR DESCRIPTION
- [x] Add owner as the default role value when creating a new status label

https://github.com/user-attachments/assets/5d04d444-4ee5-4723-9a9f-c1f2551eb111

