### PR TITLE
Content: Prevent repeater field from being marked as required

### DIFF
--- a/src/apps/schema/src/app/components/configs.ts
+++ b/src/apps/schema/src/app/components/configs.ts
@@ -767,7 +767,7 @@ const FORM_CONFIG: Record<FieldType, FormConfig> = {
     rules: [...INPUT_RANGE_RULES],
   },
   repeater: {
-    details: [...COMMON_FIELDS.slice(0, 5)],
+    details: [...COMMON_FIELDS.slice(0, 4)],
     rules: [],
   },
 };

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -466,6 +466,7 @@ export function saveItem({
       (field) =>
         field.required &&
         field?.name !== "og_image" &&
+        field?.datatype !== "repeater" &&
         (item.data[field.name] === "" || item.data[field.name] === null)
     );
 
@@ -677,7 +678,8 @@ export function createItem({ modelZUID, itemZUID, skipPathPartValidation }) {
                 "tc_title",
                 "tc_description",
               ].includes(field.name) &&
-              field.required
+              field.required &&
+              field.datatype !== "repeater"
             ) {
               if (!item.data[field.name] && item.data[field.name] != 0) {
                 return true;

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -466,7 +466,6 @@ export function saveItem({
       (field) =>
         field.required &&
         field?.name !== "og_image" &&
-        field?.datatype !== "repeater" &&
         (item.data[field.name] === "" || item.data[field.name] === null)
     );
 
@@ -678,8 +677,7 @@ export function createItem({ modelZUID, itemZUID, skipPathPartValidation }) {
                 "tc_title",
                 "tc_description",
               ].includes(field.name) &&
-              field.required &&
-              field.datatype !== "repeater"
+              field.required
             ) {
               if (!item.data[field.name] && item.data[field.name] != 0) {
                 return true;


### PR DESCRIPTION
## Summary
- Removes the "Required field" checkbox from the repeater field form config in Schema so it can no longer be marked as required

## Test plan
- [ ] Add a repeater field to a model — confirm the "Required field" checkbox is no longer shown in the field settings
- [ ] On a model with an existing repeater field marked as required, create a new content item and leave the repeater empty — confirm save/create succeeds without a validation error
- [ ] Confirm required validation still works correctly for all other field types

🤖 Generated with [Claude Code](https://claude.com/claude-code)