### PR TITLE
Schema: Show repeater subfield count in field list

### DIFF
--- a/src/apps/schema/src/app/components/Field/index.tsx
+++ b/src/apps/schema/src/app/components/Field/index.tsx
@@ -29,6 +29,7 @@ import {
 } from "../../../../../../shell/services/instance";
 import { TYPE_TEXT, SystemField, FieldType } from "../configs";
 import { notify } from "../../../../../../shell/store/notifications";
+import pluralizeWord from "../../../../../../utility/pluralizeWord";
 
 type Params = {
   id: string;
@@ -287,6 +288,13 @@ export const Field = ({
         </Tooltip>
         <Typography variant="body3" color="text.secondary">
           {TYPE_TEXT[field.datatype as FieldType]}
+          {field.datatype === "repeater" &&
+            ` (${
+              (field as ContentModelField).settings?.subFields?.length ?? 0
+            } ${pluralizeWord(
+              "field",
+              (field as ContentModelField).settings?.subFields?.length ?? 0
+            )})`}
         </Typography>
       </Box>
       <Box display="flex" alignItems="center" maxWidth="180px">

--- a/src/utility/pluralizeWord.ts
+++ b/src/utility/pluralizeWord.ts
@@ -1,3 +1,3 @@
 export default (word: string, count: number) => {
-  return count > 1 ? `${word}s` : word;
+  return count !== 1 ? `${word}s` : word;
 };


### PR DESCRIPTION
## Summary
- Displays `(X fields)` next to the Repeater type label in the schema field list
- Reads count from `field.settings.subFields`
- Fixes `pluralizeWord` utility to treat `0` as plural (`0 fields`, not `0 field`)

## Test plan
- [ ] Add a Repeater field with 0 subfields — label should show `Repeater (0 fields)`
- [ ] Add a Repeater field with 1 subfield — label should show `Repeater (1 field)`
- [ ] Add a Repeater field with 2+ subfields — label should show `Repeater (X fields)`
- [ ] Verify non-repeater fields are unaffected

## Preview

<img width="793" height="588" alt="image" src="https://github.com/user-attachments/assets/7b94c380-46a3-4d1b-a473-2d17e14e4173" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)