### PR TITLE
Schema: Show repeater field name as start adornment on sub-field API ID input

### DIFF
--- a/src/apps/schema/src/app/components/AddFieldModal/Details.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/Details.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import {
   Box,
   Button,
@@ -50,6 +50,7 @@ type DetailsProps = {
   isDeletingField?: boolean;
   isUndeletingField?: boolean;
   canDeactivate?: boolean;
+  repeaterFieldName?: string;
 };
 
 export const Details = ({
@@ -65,6 +66,7 @@ export const Details = ({
   isDeletingField,
   isUndeletingField,
   canDeactivate,
+  repeaterFieldName,
 }: DetailsProps) => {
   const { data: allModels, isLoading: isLoadingModels } =
     useGetContentModelsQuery();
@@ -208,6 +210,20 @@ export const Details = ({
           autocompleteConfig.maxHeight = 256;
         }
 
+        let startAdornment: React.ReactNode;
+
+        if (fieldConfig.name === "name" && repeaterFieldName) {
+          startAdornment = (
+            <Typography
+              variant="body2"
+              color="text.disabled"
+              sx={{ whiteSpace: "nowrap" }}
+            >
+              {repeaterFieldName}.
+            </Typography>
+          );
+        }
+
         return (
           <FieldFormInput
             key={index}
@@ -222,6 +238,7 @@ export const Details = ({
             autocompleteConfig={autocompleteConfig}
             integrationFieldConfig={integrationFieldConfig}
             isUpdateField={isUpdateField}
+            startAdornment={startAdornment}
           />
         );
       })}

--- a/src/apps/schema/src/app/components/AddFieldModal/FieldFormInput.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/FieldFormInput.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
   Button,
   IconButton,
+  InputAdornment,
   Stack,
   AutocompleteProps,
   InputProps,
@@ -117,6 +118,7 @@ type FieldFormInputProps = {
   autocompleteConfig?: AutocompleteConfig;
   integrationFieldConfig?: IntegrationFieldConfig;
   isUpdateField?: boolean;
+  startAdornment?: React.ReactNode;
 } & Pick<
   AutocompleteProps<DropdownOptions | Currency, false, false, false, "div">,
   "renderOption" | "filterOptions"
@@ -133,6 +135,7 @@ export const FieldFormInput = ({
   autocompleteConfig,
   integrationFieldConfig,
   isUpdateField,
+  startAdornment,
 }: FieldFormInputProps) => {
   const options =
     fieldConfig.type === "options" ||
@@ -394,6 +397,20 @@ export const FieldFormInput = ({
             inputProps={{
               min: 1,
             }}
+            InputProps={
+              startAdornment
+                ? {
+                    startAdornment: (
+                      <InputAdornment
+                        position="start"
+                        sx={{ "&.MuiInputAdornment-positionStart": { mr: 0 } }}
+                      >
+                        {startAdornment}
+                      </InputAdornment>
+                    ),
+                  }
+                : undefined
+            }
           />
         </>
       )}

--- a/src/apps/schema/src/app/components/AddFieldModal/views/RepeaterFields/SubFieldForm.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/views/RepeaterFields/SubFieldForm.tsx
@@ -48,6 +48,7 @@ type SubFieldFormProps = {
   fieldData?: ContentModelField;
   onSubmit: (payload: RepeaterSubField, createAnotherField?: boolean) => void;
   subFields: RepeaterSubField[];
+  repeaterFieldName?: string;
 };
 
 type ActiveTab = "details" | "rules" | "learn";
@@ -62,6 +63,7 @@ const SubFieldFormContent = ({
   onModalClose,
   onBackClick,
   onSubmit,
+  repeaterFieldName,
 }: SubFieldFormProps) => {
   const isUpdateField = !isEmpty(fieldData);
   const [activeTab, setActiveTab] = useState<ActiveTab>("details");
@@ -283,6 +285,7 @@ const SubFieldFormContent = ({
             formData={formData}
             isSubmitClicked={isSubmitClicked}
             errors={errors}
+            repeaterFieldName={repeaterFieldName}
           />
         )}
         {activeTab === "rules" && (

--- a/src/apps/schema/src/app/components/AddFieldModal/views/RepeaterFields/index.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/views/RepeaterFields/index.tsx
@@ -177,6 +177,7 @@ export const RepeaterFields = ({
               onModalClose={() => setOpenedView(null)}
               onBackClick={() => setOpenedView("selection")}
               onSubmit={handleAddField}
+              repeaterFieldName={name}
             />
           )}
           {openedView === "updateFieldForm" && (
@@ -201,6 +202,7 @@ export const RepeaterFields = ({
                   : undefined
               }
               onSubmit={handleUpdateField}
+              repeaterFieldName={name}
             />
           )}
         </Dialog>


### PR DESCRIPTION
## Summary
- Resolves #4065
- When adding or editing a sub-field inside a repeater, the "API / Parsley Code ID" input now shows the parent repeater field's API name (e.g. `clients.`) as a non-editable start adornment prefix
- Adornment uses `text.disabled` color from the theme with no gap between the prefix and the typed value

## Test plan
- [ ] Open a repeater field and add a new sub-field — verify the API ID input shows the repeater's name as a prefix (e.g. `clients.`)
- [ ] Edit an existing sub-field — verify the same adornment appears
- [ ] Verify the adornment color matches `text.disabled` from the theme
- [ ] Verify there is no gap between the adornment and the typed value
- [ ] Verify non-repeater field forms are unaffected

## Preview

<img width="664" height="697" alt="image" src="https://github.com/user-attachments/assets/56563ea7-06bc-49fb-90a5-2f5d11dd0ee1" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)