### PR TITLE
Remove dead and broken getContentItemByPath query

### DIFF
--- a/src/shell/services/instance.ts
+++ b/src/shell/services/instance.ts
@@ -178,17 +178,6 @@ export const instanceApi = createApi({
       query: (ZUID) => `search/items?q=${ZUID}&order=created&dir=DESC&limit=1`,
       transformResponse: (response: { data: any[] }) => response?.data?.[0],
     }),
-    getContentItemByPath: builder.query<ContentItem, string>({
-      query: (path) => ({
-        url: `search/items`,
-        params: {
-          q: "/page/",
-          limit: 1,
-        },
-      }),
-      transformResponse: (response: { data: any[] }) => response?.data?.[0],
-      keepUnusedDataFor: 0,
-    }),
     getContentItems: builder.query<any, any[]>({
       async queryFn(args, _queryApi, _extraOptions, fetchWithBQ) {
         try {
@@ -942,7 +931,6 @@ export const {
   useDeleteItemPublishingMutation,
   useGetContentItemQuery,
   useLazyGetContentItemQuery,
-  useGetContentItemByPathQuery,
   useGetContentItemsQuery,
   useGetContentModelQuery,
   useGetContentModelsQuery,


### PR DESCRIPTION
## Summary
- The `getContentItemByPath` RTK Query endpoint in `src/shell/services/instance.ts` accepted a `path` argument but ignored it entirely, hardcoding the request to `search/items?q=/page/&limit=1` — it would have silently returned an arbitrary item if anyone wired it up.
- It was also completely unused: the only references in the repo were the definition and the exported `useGetContentItemByPathQuery` hook.
- `StudioWrapper` resolves items by path via `resolveItemByPath` in `src/apps/studio/utils/pathResolver.ts`, which dispatches `searchItems(path, { field: "path" })` against the content store — not this query.

## Test plan
- [ ] App builds and typechecks cleanly
- [ ] Studio still resolves `?path=` correctly (loads page item + model for a known path)
- [ ] Studio handles an unknown `?path=` by showing the "Preview only" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)