### PR TITLE
Content: Check if param.value is a string before calling .startsWith

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemList/TableCells/SingleRelationshipCell.tsx
+++ b/src/apps/content-editor/src/app/views/ItemList/TableCells/SingleRelationshipCell.tsx
@@ -11,9 +11,10 @@ export const SingleRelationshipCell = ({
   params: GridRenderCellParams;
 }) => {
   const dispatch = useDispatch();
+
   useEffect(() => {
     // If value starts with '7-', that means it was unable to find the item in the store so we need to fetch it
-    if (params.value?.startsWith("7-")) {
+    if (typeof params.value === "string" && params.value?.startsWith("7-")) {
       dispatch(searchItems(params.value));
     }
   }, [params.value, dispatch]);


### PR DESCRIPTION
## Summary
- Adds a `typeof params.value === "string"` guard in `SingleRelationshipCell` before calling `.startsWith("7-")`, preventing a runtime error when `params.value` is a non-string type (e.g. `null`, `undefined`, or a number).

## Test plan
- [ ] Open a content list that includes a single-relationship field
- [ ] Verify related items still resolve and display correctly
- [ ] Verify no console errors when a relationship cell has a non-string value

## Preview
<img width="375" height="372" alt="image" src="https://github.com/user-attachments/assets/75148ed2-b32b-420b-93ea-2ddfb04abeac" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)