### PR TITLE
Content - Fix integration field search crash on non-string values

### DIFF
--- a/src/shell/components/FieldTypeIntegration/IntegrationFieldSelect/ItemSelectionDialog.tsx
+++ b/src/shell/components/FieldTypeIntegration/IntegrationFieldSelect/ItemSelectionDialog.tsx
@@ -301,7 +301,10 @@ const ItemSelectionDialog = ({
 
     const filtered = items.filter((item) => {
       const searchString = validKeys
-        ?.map((itemKey) => getKeyValue(item, itemKey)?.trim())
+        ?.map((itemKey) => {
+          const value = getKeyValue(item, itemKey);
+          return typeof value === "string" ? value.trim() : "";
+        })
         .join("\n")
         .toLowerCase();
 


### PR DESCRIPTION
## Summary
- `ItemSelectionDialog` filter called `.trim()` directly on `getKeyValue(item, itemKey)`, whose return type is `any`. When the configured keyPath resolved to a number, boolean, object, or array, `.trim()` threw `…trim is not a function` and broke the integration field search.
- Coerce non-string values to an empty string before the `.trim()` so they're excluded from the searchable text instead of crashing the dialog.

## Test plan
- [ ] Open a content item with an integration field whose keyPaths include a non-string value (e.g. numeric id)
- [ ] Open the "Add items" dialog and type in the search box — confirm no console error and results filter as expected
- [ ] Repeat with all-string keyPaths and confirm the search still matches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)