### PR TITLE
Content - Fix integration field search crash on non-string values

### DIFF
--- a/src/shell/components/FieldTypeIntegration/IntegrationFieldSelect/ItemSelectionDialog.tsx
+++ b/src/shell/components/FieldTypeIntegration/IntegrationFieldSelect/ItemSelectionDialog.tsx
@@ -301,7 +301,10 @@ const ItemSelectionDialog = ({
 
     const filtered = items.filter((item) => {
       const searchString = validKeys
-        ?.map((itemKey) => getKeyValue(item, itemKey)?.trim())
+        ?.map((itemKey) => {
+          const value = getKeyValue(item, itemKey);
+          return typeof value === "string" ? value.trim() : "";
+        })
         .join("\n")
         .toLowerCase();
 


### PR DESCRIPTION
## Summary
- `ItemSelectionDialog`'s search filter called `.trim()` directly on `getKeyValue(item, itemKey)`, whose return type is `any`. When a configured keyPath resolved to a number, boolean, object, or array, `.trim()` threw `…trim is not a function` and crashed the dialog as soon as the user typed in the search box.
- Coerce non-string values to an empty string before the `.trim()` so they're excluded from the searchable text instead of crashing the filter.

## Test plan
- [ ] Open a content item with an integration field whose keyPaths resolve to a non-string value (e.g. numeric `itemId`)
- [ ] Open the "Add items" dialog and type in the search box — no console error, results filter correctly
- [ ] Confirm pasting a known string ID still matches as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)