### PR TITLE
Schema - Fix integration field config not persisting on update

### DIFF
--- a/cypress/e2e/schema/integration.spec.js
+++ b/cypress/e2e/schema/integration.spec.js
@@ -215,6 +215,45 @@ describe("Integration Field", () => {
       cy.get('[data-cy="toast"]').contains("Created Item");
     });
   });
+
+  describe("Reconfigure Display Options", () => {
+    it("Persists keyPath changes when updating an integration field", () => {
+      cy.intercept("**/get-url?url=*", {
+        statusCode: 200,
+        body: genericApi,
+      }).as("reconfigureGetUrl");
+
+      cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
+
+      cy.get('[data-cy="Field_text"]').click();
+
+      cy.wait("@reconfigureGetUrl");
+
+      cy.intercept("PUT", "**/content/models/*/fields/*").as("updateField");
+
+      cy.get('[data-cy="integrationConfigureButton"]').click();
+      cy.get('[data-cy="integrationFormDialog"]').should("exist");
+
+      cy.get('[data-cy="integrationConfigureOptionNextButton"]').click();
+
+      cy.get('[data-cy="integrationKeyPathSelector-subHeading"]').click();
+      cy.get(`.MuiAutocomplete-listbox li:contains("position")`).click(
+        forceClick
+      );
+
+      cy.get(
+        '[data-cy="integrationConfigureDisplayOptionsDoneButton"]'
+      ).click();
+
+      cy.get('[data-cy="FieldFormAddFieldBtn"]').click();
+
+      cy.wait("@updateField").then(({ request }) => {
+        expect(
+          request.body.settings.integrationFieldConfig.keyPaths.subHeading
+        ).to.equal("position");
+      });
+    });
+  });
 });
 
 function connectToEndpoint(endpoint, type, apiData) {

--- a/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
+++ b/src/apps/schema/src/app/components/AddFieldModal/views/FieldForm.tsx
@@ -319,11 +319,8 @@ const FieldFormContent = ({
     }
 
     if (type === "integration") {
-      body.settings.integrationFieldConfig = (
-        isUpdateField
-          ? fieldData?.settings?.integrationFieldConfig
-          : formData?.integrationFieldConfig
-      ) as IntegrationFieldConfig;
+      body.settings.integrationFieldConfig =
+        formData?.integrationFieldConfig as IntegrationFieldConfig;
     }
 
     if (isUpdateField) {

--- a/src/apps/schema/src/app/components/contexts/FieldFormProvider.tsx
+++ b/src/apps/schema/src/app/components/contexts/FieldFormProvider.tsx
@@ -103,6 +103,9 @@ export const FieldFormProvider = ({
           formFields.options = options as any;
         } else if (field.name === "tooltip") {
           formFields["tooltip"] = fieldData.settings?.tooltip || "";
+        } else if (field.name === "integrationFieldConfig") {
+          formFields["integrationFieldConfig"] =
+            fieldData.settings?.integrationFieldConfig;
         } else if (field.name === "defaultValue") {
           formFields["defaultValue"] =
             type === "number"


### PR DESCRIPTION
Closes #4087

## Summary
- Reconfiguring an integration field's Display Options would silently discard the user's changes — the PUT request still sent the original persisted config.
- Root cause was a pair of inverted reads:
  - `FieldFormProvider` never seeded `formData.integrationFieldConfig` from `fieldData.settings.integrationFieldConfig` in update mode, so the form started with \`undefined\`.
  - `FieldForm` then re-sent \`fieldData.settings.integrationFieldConfig\` (the unedited persisted value) on update instead of reading from `formData`.
- Seed the config into `formData` on update and always send from `formData` so reconfigure edits actually persist.