### PR TITLE
Studio - Ensure drop indicators win against page CSS

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioBridge.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioBridge.ts
@@ -27,27 +27,27 @@ const bridgeInjectedCss = `
   .studio-dragging * {
     visibility: hidden !important;
   }
-  .studio-drop-before {
+  [data-layout-id].studio-drop-before {
     box-shadow:
       inset 0 4px 0 #ff9800,
       0 0 0 1px rgba(255, 152, 0, 0.35);
   }
-  .studio-drop-before-horizontal {
+  [data-layout-id].studio-drop-before-horizontal {
     box-shadow:
       inset 4px 0 0 #ff9800,
       0 0 0 1px rgba(255, 152, 0, 0.35);
   }
-  .studio-drop-after {
+  [data-layout-id].studio-drop-after {
     box-shadow:
       inset 0 -4px 0 #ff9800,
       0 0 0 1px rgba(255, 152, 0, 0.35);
   }
-  .studio-drop-after-horizontal {
+  [data-layout-id].studio-drop-after-horizontal {
     box-shadow:
       inset -4px 0 0 #ff9800,
       0 0 0 1px rgba(255, 152, 0, 0.35);
   }
-  .studio-drop-inside {
+  [data-layout-id].studio-drop-inside {
     background-color: rgba(255, 152, 0, 0.18);
     outline: 2px dashed #ff9800;
     outline-offset: 2px;


### PR DESCRIPTION
## Summary
- Bumps drop-indicator selector specificity from `.studio-drop-*` (0,0,1,0) to `[data-layout-id].studio-drop-*` (0,0,2,0) so the bridge's orange box-shadow indicators beat same-specificity page rules (e.g. a template's own `.item { box-shadow: ... }`) without resorting to `!important`.
- Reorder targets always carry `data-layout-id` (that's the bridge's reorder selector), so every indicator class still matches.

## Background
Drop indicators were rendering correctly in terms of which classes the bridge applied, but the visible orange bar would never appear on templates whose own CSS set `box-shadow` on the draggable item at the same specificity. Because the page's stylesheet was later in the cascade, it won the tie and the indicator stayed hidden.

## Test plan
- [ ] Open Studio → toggle Layout mode on a page whose template defines `box-shadow` on layout items.
- [ ] Drag a layout block and confirm the orange drop indicator (vertical bar for horizontal layouts, horizontal bar for vertical layouts) appears at the drop edge.
- [ ] Regression check: drop indicators still render on templates that don't set their own `box-shadow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)