### PR TITLE
Schema - Fix Add HTTP Header button losing rows on double-click

### DIFF
--- a/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
@@ -30,7 +30,6 @@ import { FieldWrapper } from "../Shared/FieldWrapper";
 import { IntegrationRequestHeaders } from "../../../services/types";
 import { validateUrl } from "../utils";
 import useIntegrationField from "../useIntegrationField";
-import { v4 as uuidv4 } from "uuid";
 
 const CONNECTION_STATUSES: {
   [key: string]: {
@@ -94,7 +93,7 @@ const ConnectToApi = ({
   setActiveStep: (step: number) => void;
   closeForm?: () => void;
 }) => {
-  const focusRef = useRef<string>("url");
+  const focusRef = useRef<number | "url">("url");
   const { data, status, fetchApiData } = useIntegrationField();
 
   const [isValidUrl, setIsValidUrl] = useState(true);
@@ -103,27 +102,23 @@ const ConnectToApi = ({
   const [endpointLocal, setEndpointLocal] = useState<string>(endpoint || "");
 
   const [headersLocal, setHeadersLocal] = useState<
-    Record<string, { key: string; value: string }>
+    { key: string; value: string }[]
   >(() => {
     if (!headers || Object.keys(headers).length === 0) {
-      const id = uuidv4();
-      return { [id]: { key: "", value: "" } };
+      return [{ key: "", value: "" }];
     }
-
-    return Object.entries(headers).reduce((acc, [key, value]) => {
-      const id = uuidv4();
-      acc[id] = { key, value: String(value) };
-      return acc;
-    }, {} as Record<string, { key: string; value: string }>);
+    return Object.entries(headers).map(([key, value]) => ({
+      key,
+      value: String(value),
+    }));
   });
 
   const handleNext = () => {
-    const headersLocalValues = Object.values(headersLocal);
-    const headersWithKeys = headersLocalValues.filter((i) => !!i?.key);
-    const reqHeaders = !headersWithKeys?.length
+    const headersWithKeys = headersLocal.filter((h) => !!h.key);
+    const reqHeaders = !headersWithKeys.length
       ? null
-      : headersWithKeys?.reduce((acc: any, obj: any) => {
-          acc[obj.key] = obj.value;
+      : headersWithKeys.reduce((acc: any, { key, value }) => {
+          acc[key] = value;
           return acc;
         }, {});
 
@@ -141,13 +136,12 @@ const ConnectToApi = ({
   const handleApiConnect = useCallback(() => {
     setReqAborted(false);
     setApiData(null);
-    const headersLocalValues = Object.values(headersLocal);
-    const headersWithKeys = headersLocalValues.filter((i) => !!i?.key);
-    const options = !headersWithKeys?.length
+    const headersWithKeys = headersLocal.filter((h) => !!h.key);
+    const options = !headersWithKeys.length
       ? {}
       : {
-          headers: headersWithKeys?.reduce((acc: any, obj: any) => {
-            acc[obj.key] = obj.value;
+          headers: headersWithKeys.reduce((acc: any, { key, value }) => {
+            acc[key] = value;
             return acc;
           }, {}),
         };
@@ -244,90 +238,78 @@ const ConnectToApi = ({
             width="100%"
             data-cy="integrationHeadersContainer"
           >
-            {Object.entries(headersLocal)?.map((entry, i) => {
-              const entryId: string = entry[0];
-              const headerKey = entry[1]?.key || "";
-              const headerValue = entry[1]?.value || "";
-              return (
+            {headersLocal.map((header, i) => (
+              <Grid
+                data-cy={`integrationHeadersContainerRow-${i}`}
+                key={i}
+                container
+                size={16}
+                spacing={1}
+                columns={16}
+                width="100%"
+              >
+                <Grid size={8}>
+                  <TextField
+                    autoFocus={i === focusRef.current}
+                    className="keyInput"
+                    fullWidth
+                    size="small"
+                    placeholder="Key"
+                    value={header.key}
+                    onChange={(e: any) => {
+                      setHeadersLocal(
+                        headersLocal.map((h, idx) =>
+                          idx === i ? { ...h, key: e.target.value } : h
+                        )
+                      );
+                    }}
+                  />
+                </Grid>
                 <Grid
-                  data-cy={`integrationHeadersContainerRow-${i}`}
-                  key={`header-${entryId}`}
-                  container
-                  size={16}
-                  spacing={1}
-                  columns={16}
-                  width="100%"
+                  size={i > 0 ? 7 : 8}
+                  display="flex"
+                  flexDirection="row"
+                  justifyContent="space-between"
+                  alignItems="center"
                 >
-                  <Grid size={8}>
-                    <TextField
-                      autoFocus={entryId === focusRef?.current}
-                      className="keyInput"
-                      fullWidth
-                      size="small"
-                      placeholder="Key"
-                      value={headerKey}
-                      onChange={(e: any) => {
-                        setHeadersLocal({
-                          ...headersLocal,
-                          [entryId]: {
-                            ...headersLocal?.[entryId],
-                            key: e.target.value,
-                          },
-                        });
-                      }}
-                    />
-                  </Grid>
+                  <TextField
+                    className="valueInput"
+                    size="small"
+                    placeholder="Value"
+                    value={header.value}
+                    onChange={(e: any) => {
+                      setHeadersLocal(
+                        headersLocal.map((h, idx) =>
+                          idx === i ? { ...h, value: e.target.value } : h
+                        )
+                      );
+                    }}
+                    sx={{ flexGrow: 1 }}
+                  />
+                </Grid>
+                {i > 0 && (
                   <Grid
-                    size={i > 0 ? 7 : 8}
+                    size={1}
                     display="flex"
                     flexDirection="row"
-                    justifyContent="space-between"
+                    justifyContent="center"
                     alignItems="center"
                   >
-                    <TextField
-                      className="valueInput"
-                      size="small"
-                      placeholder="Value"
-                      value={headerValue}
-                      onChange={(e: any) => {
-                        setHeadersLocal({
-                          ...headersLocal,
-                          [entryId]: {
-                            ...headersLocal?.[entryId],
-                            value: e.target.value,
-                          },
-                        });
+                    <IconButton
+                      data-cy="removeHeaderButton"
+                      sx={{ flexGrow: 0 }}
+                      onClick={() => {
+                        setHeadersLocal((prev) =>
+                          prev.filter((_, idx) => idx !== i)
+                        );
                       }}
-                      sx={{ flexGrow: 1 }}
-                    />
-                  </Grid>
-                  {i > 0 && (
-                    <Grid
-                      size={1}
-                      display="flex"
-                      flexDirection="row"
-                      justifyContent="center"
-                      alignItems="center"
                     >
-                      <IconButton
-                        data-cy="removeHeaderButton"
-                        sx={{ flexGrow: 0 }}
-                        onClick={() => {
-                          setHeadersLocal((prev) => {
-                            if (!prev[entryId]) return prev;
-                            const updated = { ...prev };
-                            delete updated[entryId];
-                            return updated;
-                          });
-                        }}
-                      >
-                        <CloseOutlinedIcon />
-                      </IconButton>
-                    </Grid>
-                  )}
-                </Grid>
-              );
-            })}
+                      <CloseOutlinedIcon />
+                    </IconButton>
+                  </Grid>
+                )}
+              </Grid>
+            ))}
           </Grid>
           <Button
             data-cy="addHeaderButton"
@@ -335,12 +317,8 @@ const ConnectToApi = ({
             variant="outlined"
             startIcon={<AddCircleIcon />}
             onClick={() => {
-              const keyId: string = uuidv4();
-              focusRef.current = keyId;
-              setHeadersLocal((prev) => ({
-                ...prev,
-                [keyId]: { key: "", value: "" },
-              }));
+              focusRef.current = headersLocal.length;
+              setHeadersLocal((prev) => [...prev, { key: "", value: "" }]);
             }}
           >
             Add HTTP Header

--- a/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
@@ -335,15 +335,12 @@ const ConnectToApi = ({
             variant="outlined"
             startIcon={<AddCircleIcon />}
             onClick={() => {
-              const keyId: string = Date.now().toString();
+              const keyId: string = uuidv4();
               focusRef.current = keyId;
-              setHeadersLocal({
-                ...headersLocal,
-                [keyId]: {
-                  key: "",
-                  value: "",
-                },
-              });
+              setHeadersLocal((prev) => ({
+                ...prev,
+                [keyId]: { key: "", value: "" },
+              }));
             }}
           >
             Add HTTP Header

--- a/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
@@ -94,7 +94,7 @@ const ConnectToApi = ({
   setActiveStep: (step: number) => void;
   closeForm?: () => void;
 }) => {
-  const focusRef = useRef<string | "url">("url");
+  const focusRef = useRef<string>("url");
   const { data, status, fetchApiData } = useIntegrationField();
 
   const [isValidUrl, setIsValidUrl] = useState(true);

--- a/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import {
   Button,
   Box,
@@ -30,6 +30,7 @@ import { FieldWrapper } from "../Shared/FieldWrapper";
 import { IntegrationRequestHeaders } from "../../../services/types";
 import { validateUrl } from "../utils";
 import useIntegrationField from "../useIntegrationField";
+import { v4 as uuidv4 } from "uuid";
 
 const CONNECTION_STATUSES: {
   [key: string]: {
@@ -93,7 +94,7 @@ const ConnectToApi = ({
   setActiveStep: (step: number) => void;
   closeForm?: () => void;
 }) => {
-  const focusRef = useRef<number | "url">("url");
+  const focusRef = useRef<string | "url">("url");
   const { data, status, fetchApiData } = useIntegrationField();
 
   const [isValidUrl, setIsValidUrl] = useState(true);
@@ -102,19 +103,21 @@ const ConnectToApi = ({
   const [endpointLocal, setEndpointLocal] = useState<string>(endpoint || "");
 
   const [headersLocal, setHeadersLocal] = useState<
-    { key: string; value: string }[]
+    Record<string, { key: string; value: string }>
   >(() => {
     if (!headers || Object.keys(headers).length === 0) {
-      return [{ key: "", value: "" }];
+      const id = uuidv4();
+      return { [id]: { key: "", value: "" } };
     }
-    return Object.entries(headers).map(([key, value]) => ({
-      key,
-      value: String(value),
-    }));
+    return Object.entries(headers).reduce((acc, [key, value]) => {
+      const id = uuidv4();
+      acc[id] = { key, value: String(value) };
+      return acc;
+    }, {} as Record<string, { key: string; value: string }>);
   });
 
   const handleNext = () => {
-    const headersWithKeys = headersLocal.filter((h) => !!h.key);
+    const headersWithKeys = Object.values(headersLocal).filter((h) => !!h.key);
     const reqHeaders = !headersWithKeys.length
       ? null
       : headersWithKeys.reduce((acc: any, { key, value }) => {
@@ -136,7 +139,7 @@ const ConnectToApi = ({
   const handleApiConnect = useCallback(() => {
     setReqAborted(false);
     setApiData(null);
-    const headersWithKeys = headersLocal.filter((h) => !!h.key);
+    const headersWithKeys = Object.values(headersLocal).filter((h) => !!h.key);
     const options = !headersWithKeys.length
       ? {}
       : {
@@ -238,10 +241,10 @@ const ConnectToApi = ({
             width="100%"
             data-cy="integrationHeadersContainer"
           >
-            {headersLocal.map((header, i) => (
+            {Object.entries(headersLocal).map(([entryId, header], i) => (
               <Grid
                 data-cy={`integrationHeadersContainerRow-${i}`}
-                key={i}
+                key={`header-${entryId}`}
                 container
                 size={16}
                 spacing={1}
@@ -250,18 +253,17 @@ const ConnectToApi = ({
               >
                 <Grid size={8}>
                   <TextField
-                    autoFocus={i === focusRef.current}
+                    autoFocus={entryId === focusRef.current}
                     className="keyInput"
                     fullWidth
                     size="small"
                     placeholder="Key"
                     value={header.key}
-                    onChange={(e: any) => {
-                      setHeadersLocal(
-                        headersLocal.map((h, idx) =>
-                          idx === i ? { ...h, key: e.target.value } : h
-                        )
-                      );
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      setHeadersLocal((prev) => ({
+                        ...prev,
+                        [entryId]: { ...prev[entryId], key: e.target.value },
+                      }));
                     }}
                   />
                 </Grid>
@@ -277,12 +279,11 @@ const ConnectToApi = ({
                     size="small"
                     placeholder="Value"
                     value={header.value}
-                    onChange={(e: any) => {
-                      setHeadersLocal(
-                        headersLocal.map((h, idx) =>
-                          idx === i ? { ...h, value: e.target.value } : h
-                        )
-                      );
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      setHeadersLocal((prev) => ({
+                        ...prev,
+                        [entryId]: { ...prev[entryId], value: e.target.value },
+                      }));
                     }}
                     sx={{ flexGrow: 1 }}
                   />
@@ -299,9 +300,12 @@ const ConnectToApi = ({
                       data-cy="removeHeaderButton"
                       sx={{ flexGrow: 0 }}
                       onClick={() => {
-                        setHeadersLocal((prev) =>
-                          prev.filter((_, idx) => idx !== i)
-                        );
+                        setHeadersLocal((prev) => {
+                          if (!prev[entryId]) return prev;
+                          const updated = { ...prev };
+                          delete updated[entryId];
+                          return updated;
+                        });
                       }}
                     >
                       <CloseOutlinedIcon />
@@ -317,8 +321,12 @@ const ConnectToApi = ({
             variant="outlined"
             startIcon={<AddCircleIcon />}
             onClick={() => {
-              focusRef.current = headersLocal.length;
-              setHeadersLocal((prev) => [...prev, { key: "", value: "" }]);
+              const keyId: string = uuidv4();
+              focusRef.current = keyId;
+              setHeadersLocal((prev) => ({
+                ...prev,
+                [keyId]: { key: "", value: "" },
+              }));
             }}
           >
             Add HTTP Header

--- a/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, ChangeEvent, ReactNode } from "react";
 import {
   Button,
   Box,
@@ -34,11 +34,11 @@ import { v4 as uuidv4 } from "uuid";
 
 const CONNECTION_STATUSES: {
   [key: string]: {
-    icon: React.ReactNode;
+    icon: ReactNode;
     title: string;
     subTitle: string;
     buttonLabel: string;
-    buttonIcon: React.ReactNode;
+    buttonIcon: ReactNode;
     variant: "contained" | "outlined";
     color: "primary" | "inherit";
   };
@@ -120,10 +120,13 @@ const ConnectToApi = ({
     const headersWithKeys = Object.values(headersLocal).filter((h) => !!h.key);
     const reqHeaders = !headersWithKeys.length
       ? null
-      : headersWithKeys.reduce((acc: any, { key, value }) => {
-          acc[key] = value;
-          return acc;
-        }, {});
+      : headersWithKeys.reduce<Record<string, string>>(
+          (acc, { key, value }) => {
+            acc[key] = value;
+            return acc;
+          },
+          {}
+        );
 
     setApiData(data);
     setHeaders(reqHeaders);
@@ -143,10 +146,13 @@ const ConnectToApi = ({
     const options = !headersWithKeys.length
       ? {}
       : {
-          headers: headersWithKeys.reduce((acc: any, { key, value }) => {
-            acc[key] = value;
-            return acc;
-          }, {}),
+          headers: headersWithKeys.reduce<Record<string, string>>(
+            (acc, { key, value }) => {
+              acc[key] = value;
+              return acc;
+            },
+            {}
+          ),
         };
     fetchApiData(endpointLocal, options);
   }, [endpointLocal, headersLocal]);
@@ -202,7 +208,7 @@ const ConnectToApi = ({
             autoFocus={focusRef?.current === "url"}
             placeholder="https://api.example.com/endpoint"
             value={endpointLocal}
-            onInput={(e: any) => {
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const validUrl = !!e.target.value && validateUrl(e.target.value);
               setIsValidUrl(validUrl);
               setEndpointLocal(e.target.value);
@@ -259,7 +265,7 @@ const ConnectToApi = ({
                     size="small"
                     placeholder="Key"
                     value={header.key}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
                       setHeadersLocal((prev) => ({
                         ...prev,
                         [entryId]: { ...prev[entryId], key: e.target.value },
@@ -279,7 +285,7 @@ const ConnectToApi = ({
                     size="small"
                     placeholder="Value"
                     value={header.value}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
                       setHeadersLocal((prev) => ({
                         ...prev,
                         [entryId]: { ...prev[entryId], value: e.target.value },


### PR DESCRIPTION
## Summary
The root cause was a **stale closure** on `headersLocal` inside the click handler: the handler captured a snapshot of headers at render time, so a second click in the same render cycle spread `{...staleHeaders, [uuid2]: ...}`, silently overwriting the row added by the first click.

Two complementary fixes:
- **Functional state updater** — uses `(prev) => ({...prev, [id]: ...})` so each click composes from the latest state rather than a stale closure capture. This is the primary fix.
- **`uuidv4()` for row keys** — replaces `Date.now().toString()` as defense-in-depth: two `Date.now()` calls in the same millisecond produce the same key, masking the stale-closure bug as a silent overwrite. Unique UUIDs surface any future key collision as a visible problem.

## Test plan
- [x] Open Schema app, navigate to an integration field, and open the API configuration
- [x] Double-click "Add HTTP Header" rapidly — confirm both rows appear instead of one being lost
- [x] Verify headers still save and persist correctly



🤖 Generated with [Claude Code](https://claude.com/claude-code)

### **NOTE**: This PR is required to resolve a failing test https://github.com/zesty-io/manager-ui/pull/4153