### PR TITLE
Content - Fix DisplayCard rendering placeholder for falsy values like 0

### DIFF
--- a/src/shell/components/FieldTypeIntegration/Shared/DisplayCard.tsx
+++ b/src/shell/components/FieldTypeIntegration/Shared/DisplayCard.tsx
@@ -36,7 +36,10 @@ const DisplayCard = ({
   showPlayIcon,
   loading,
 }: DisplayCardProps) => {
-  const renderValue = (value: unknown, placeholder: string) => {
+  const renderValue = (
+    value: string | number | boolean | null | undefined,
+    placeholder: string
+  ) => {
     if (value === null || value === undefined || value === "")
       return placeholder;
     return String(value);

--- a/src/shell/components/FieldTypeIntegration/Shared/DisplayCard.tsx
+++ b/src/shell/components/FieldTypeIntegration/Shared/DisplayCard.tsx
@@ -14,12 +14,12 @@ import { IntegrationTypes } from "../../../services/types";
 
 export type DisplayCardProps = {
   type: IntegrationTypes;
-  heading: string;
-  subHeading?: string;
+  heading: string | number | boolean | null;
+  subHeading?: string | number | boolean | null;
   thumbnail?: string;
   rootPath?: string | null;
-  detail?: string;
-  details?: Record<string, string | number>[];
+  detail?: string | number | boolean | null;
+  details?: Record<string, string | number | boolean | null>[];
   mediaVariant?: "rounded" | "square";
   showPlayIcon?: boolean;
   loading?: boolean;
@@ -36,6 +36,12 @@ const DisplayCard = ({
   showPlayIcon,
   loading,
 }: DisplayCardProps) => {
+  const renderValue = (value: unknown, placeholder: string) => {
+    if (value === null || value === undefined || value === "")
+      return placeholder;
+    return String(value);
+  };
+
   const [noImage, setNoImage] = useState(false);
   const isVideoType = ["video", "youtube", "mux"].includes(type);
   const isSpecialType = ["shopify", "youtube", "mux", "classy"].includes(type);
@@ -61,25 +67,19 @@ const DisplayCard = ({
 
   const headingValue = loading ? (
     <Skeleton width={type === "simple" ? "90%" : "55%"} height="26px" />
-  ) : typeof heading === "boolean" ? (
-    String(heading)
   ) : (
-    heading || "Add Heading"
+    renderValue(heading, "Add Heading")
   );
   const subHeadingValue = loading ? (
     <Skeleton width="90%" />
-  ) : typeof subHeading === "boolean" ? (
-    String(subHeading)
   ) : (
-    subHeading || "Add Subheading"
+    renderValue(subHeading, "Add Subheading")
   );
   const thumbnailValue = thumbnail || null;
   const detailValue = loading ? (
     <Skeleton width="70px" />
-  ) : typeof detail === "boolean" ? (
-    String(detail)
   ) : (
-    detail || "Add Detail"
+    renderValue(detail, "Add Detail")
   );
 
   const renderCard = () => {
@@ -138,47 +138,50 @@ const DisplayCard = ({
             alignItems="flex-start"
             sx={{ width: "100%" }}
           >
-            {details?.map((item: Record<string, string>, index: number) => (
-              <Box
-                width="100%"
-                display="flex"
-                flexDirection="row"
-                justifyContent="space-between"
-                alignItems="center"
-                key={`${item?.key}-${index}`}
-              >
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  fontWeight={400}
-                  flexGrow={1}
+            {details?.map(
+              (
+                item: Record<string, string | number | boolean | null>,
+                index: number
+              ) => (
+                <Box
+                  width="100%"
+                  display="flex"
+                  flexDirection="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                  key={`${item?.key}-${index}`}
                 >
-                  {loading ? (
-                    <Skeleton sx={{ width: "95%" }} />
-                  ) : (
-                    item?.key || "+ Add Detail"
-                  )}
-                </Typography>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  fontWeight={400}
-                >
-                  {loading ? (
-                    <Skeleton
-                      sx={{
-                        width: "100px",
-                        height: "16px",
-                      }}
-                    />
-                  ) : typeof item?.value === "boolean" ? (
-                    String(item?.value)
-                  ) : (
-                    item?.value || ""
-                  )}
-                </Typography>
-              </Box>
-            ))}
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    fontWeight={400}
+                    flexGrow={1}
+                  >
+                    {loading ? (
+                      <Skeleton sx={{ width: "95%" }} />
+                    ) : (
+                      renderValue(item?.key, "+ Add Detail")
+                    )}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    fontWeight={400}
+                  >
+                    {loading ? (
+                      <Skeleton
+                        sx={{
+                          width: "100px",
+                          height: "16px",
+                        }}
+                      />
+                    ) : (
+                      renderValue(item?.value, "")
+                    )}
+                  </Typography>
+                </Box>
+              )
+            )}
           </Box>
         </Box>
       );

--- a/src/shell/components/FieldTypeIntegration/Shared/DisplayCard.tsx
+++ b/src/shell/components/FieldTypeIntegration/Shared/DisplayCard.tsx
@@ -25,6 +25,14 @@ export type DisplayCardProps = {
   loading?: boolean;
 };
 
+const hasValue = (value: unknown): boolean =>
+  value !== null && value !== undefined && value !== "";
+
+const renderValue = (value: unknown, placeholder: string): string => {
+  if (!hasValue(value) || typeof value === "object") return placeholder;
+  return String(value as string | number | boolean);
+};
+
 const DisplayCard = ({
   type,
   heading,
@@ -36,15 +44,6 @@ const DisplayCard = ({
   showPlayIcon,
   loading,
 }: DisplayCardProps) => {
-  const renderValue = (
-    value: string | number | boolean | null | undefined,
-    placeholder: string
-  ) => {
-    if (value === null || value === undefined || value === "")
-      return placeholder;
-    return String(value);
-  };
-
   const [noImage, setNoImage] = useState(false);
   const isVideoType = ["video", "youtube", "mux"].includes(type);
   const isSpecialType = ["shopify", "youtube", "mux", "classy"].includes(type);
@@ -141,50 +140,45 @@ const DisplayCard = ({
             alignItems="flex-start"
             sx={{ width: "100%" }}
           >
-            {details?.map(
-              (
-                item: Record<string, string | number | boolean | null>,
-                index: number
-              ) => (
-                <Box
-                  width="100%"
-                  display="flex"
-                  flexDirection="row"
-                  justifyContent="space-between"
-                  alignItems="center"
-                  key={`${item?.key}-${index}`}
+            {details?.map((item, index) => (
+              <Box
+                width="100%"
+                display="flex"
+                flexDirection="row"
+                justifyContent="space-between"
+                alignItems="center"
+                key={`${item?.key}-${index}`}
+              >
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  fontWeight={400}
+                  flexGrow={1}
                 >
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    fontWeight={400}
-                    flexGrow={1}
-                  >
-                    {loading ? (
-                      <Skeleton sx={{ width: "95%" }} />
-                    ) : (
-                      renderValue(item?.key, "+ Add Detail")
-                    )}
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    fontWeight={400}
-                  >
-                    {loading ? (
-                      <Skeleton
-                        sx={{
-                          width: "100px",
-                          height: "16px",
-                        }}
-                      />
-                    ) : (
-                      renderValue(item?.value, "")
-                    )}
-                  </Typography>
-                </Box>
-              )
-            )}
+                  {loading ? (
+                    <Skeleton sx={{ width: "95%" }} />
+                  ) : (
+                    renderValue(item?.key, "+ Add Detail")
+                  )}
+                </Typography>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  fontWeight={400}
+                >
+                  {loading ? (
+                    <Skeleton
+                      sx={{
+                        width: "100px",
+                        height: "16px",
+                      }}
+                    />
+                  ) : (
+                    renderValue(item?.value, "")
+                  )}
+                </Typography>
+              </Box>
+            ))}
           </Box>
         </Box>
       );
@@ -268,7 +262,7 @@ const DisplayCard = ({
             >
               {headingValue}
             </Typography>
-            {type === "shopify" && !!detail && (
+            {type === "shopify" && hasValue(detail) && (
               <Typography
                 variant="body2"
                 noWrap


### PR DESCRIPTION
Fixes #4093

## ROOT CAUSE:
 - `heading || "Add Heading"` (and the same pattern for `subHeading`, `detail`, and `item.key/value`) used a JavaScript falsy-check fallback, causing valid-but-falsy values like `0`, `false`, and `""` to be treated as missing and replaced with placeholder text
 - `DisplayCardProps` typed `heading`, `subHeading`, and `detail` as `string` despite the component already branching on `typeof X === "boolean"` at runtime, giving a false sense of type safety

## FIXES:
 - Added a `renderValue(value, placeholder)` helper that only substitutes the placeholder for `null | undefined | ""`, and returns `String(value)` for everything else — covering numbers, booleans, and strings uniformly
 - Replaced all four falsy-fallback sites (`heading`, `subHeading`, `detail`, `item.key`, `item.value`) with `renderValue` calls, also removing the now-redundant `typeof X === "boolean"` branches
 - Updated `DisplayCardProps` types for `heading`, `subHeading`, `detail`, and `details` to reflect the actual runtime value types (`string | number | boolean | null`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)


### **NOTE**: This PR is required to resolve a failing test https://github.com/zesty-io/manager-ui/pull/4153