### PR TITLE
Schema - Fix Add HTTP Header button losing rows on rapid clicks

### DIFF
--- a/src/shell/components/FieldTypeIntegration/IntegrationFieldConfigure/ConnectToApi.tsx
+++ b/src/shell/components/FieldTypeIntegration/IntegrationFieldConfigure/ConnectToApi.tsx
@@ -334,15 +334,15 @@ const ConnectToApi = ({
             variant="outlined"
             startIcon={<AddCircleIcon />}
             onClick={() => {
-              const keyId: string = Date.now().toString();
+              const keyId: string = uuidv4();
               focusRef.current = keyId;
-              setHeadersLocal({
-                ...headersLocal,
+              setHeadersLocal((prev) => ({
+                ...prev,
                 [keyId]: {
                   key: "",
                   value: "",
                 },
-              });
+              }));
             }}
           >
             Add HTTP Header


### PR DESCRIPTION
## ROOT CAUSE:
 - `Date.now().toString()` generates identical keys when two clicks land in the same millisecond, causing the second row to silently overwrite the first (`ConnectToApi.tsx:337`)
 - `setHeadersLocal({...headersLocal, ...})` closes over a stale React snapshot; under React 18 batching, rapid successive clicks all spread the same captured state so only the last write survives (`ConnectToApi.tsx:339`)

## FIXES:
 - Replaced `Date.now().toString()` with `uuidv4()` (already imported) to guarantee a unique key per click regardless of timing
 - Switched to the functional updater form `setHeadersLocal(prev => ({...prev, ...}))` so each call reads the latest state instead of a stale closure snapshot

## SCREEN RECORDING:
Programmatic repro (`btn.click() × 3`) now produces 4 rows (1 initial + 3 added) instead of 2.

![fix-4094-add-header-rapid-clicks](fix-4094-add-header-rapid-clicks.gif)

Closes #4094

🤖 Generated with [Claude Code](https://claude.com/claude-code)