### PR TITLE
[Studio] - Fade preview overlay during save refresh

### DIFF
--- a/cypress/e2e/content/comments.spec.js
+++ b/cypress/e2e/content/comments.spec.js
@@ -57,39 +57,49 @@ describe("Content Item: Comments", () => {
   it("Updates an existing comment", () => {
     const UPDATED_TEXT = "I am updating this comment now.";
 
+    // Register the intercept before the action that triggers it. If it is set
+    // up after the click, the request can fire before the route exists and
+    // cy.wait() flakes with "no request ever occurred".
+    cy.intercept("/v1/comments/*?showReplies=true&showResolved=true").as(
+      "getReplies"
+    );
+
     cy.getBySelector("CommentMenuButton").first().click(forceClick);
     cy.getBySelector("EditCommentButton").click();
     cy.get(commentBox).type(`{selectall}{backspace}${UPDATED_TEXT}`);
     cy.getBySelector("SubmitNewComment").click();
-    cy.intercept("/v1/comments/*?showReplies=true&showResolved=true").as(
-      "getReplies"
-    );
     cy.wait("@getReplies");
     cy.getBySelector("CommentItem").first().contains(UPDATED_TEXT);
   });
 
   it("Resolves a comment", () => {
-    cy.getBySelector("ResolveCommentButton").click(forceClick);
+    // Intercepts must be registered before the click that triggers the
+    // requests, otherwise they can fire first and cy.wait() flakes with
+    // "no request ever occurred".
     cy.intercept("/v1/comments/*?showReplies=true&showResolved=true").as(
       "getReplies"
     );
     cy.intercept("/v1/instances/*/comments?resource=*").as(
       "getCommentResourceData"
     );
+    cy.getBySelector("ResolveCommentButton").click(forceClick);
     cy.wait("@getReplies");
     cy.wait("@getCommentResourceData");
     cy.getBySelector("ResolveCommentButton").should("not.exist");
   });
 
   it("Reopens a comment when there is a new reply", () => {
-    cy.get(commentBox).type("Reopening ticket.");
-    cy.getBySelector("SubmitNewComment").click();
+    // Register intercepts before submitting the reply so the resulting
+    // requests are always captured (prevents a "no request ever occurred"
+    // flake).
     cy.intercept("/v1/comments/*?showReplies=true&showResolved=true").as(
       "getReplies"
     );
     cy.intercept("/v1/instances/*/comments?resource=*").as(
       "getCommentResourceData"
     );
+    cy.get(commentBox).type("Reopening ticket.");
+    cy.getBySelector("SubmitNewComment").click();
     cy.wait("@getReplies");
     cy.wait("@getCommentResourceData");
     cy.getBySelector("ResolveCommentButton").should("exist");

--- a/cypress/e2e/content/content.spec.js
+++ b/cypress/e2e/content/content.spec.js
@@ -517,7 +517,9 @@ describe("Content Specs", () => {
     it("can publish an item", () => {
       cy.get(
         "[data-cy='field:one_to_one'] [data-cy='active-relational-item-more-button']"
-      ).click();
+      )
+        .scrollIntoView()
+        .click();
       cy.getBySelector("active-relational-item-publish-now-button").click();
       cy.getBySelector("ConfirmPublishModal").should("exist");
       cy.getBySelector("CancelPublishButton").click();
@@ -526,7 +528,9 @@ describe("Content Specs", () => {
     it("can schedule publish an item", () => {
       cy.get(
         "[data-cy='field:one_to_one'] [data-cy='active-relational-item-more-button']"
-      ).click();
+      )
+        .scrollIntoView()
+        .click();
       cy.getBySelector(
         "active-relational-item-schedule-publish-button"
       ).click();
@@ -537,7 +541,9 @@ describe("Content Specs", () => {
     it("can remove the selected item", () => {
       cy.get(
         "[data-cy='field:one_to_one'] [data-cy='active-relational-item-more-button']"
-      ).click();
+      )
+        .scrollIntoView()
+        .click();
       cy.getBySelector("active-relational-item-remove-item-button").click();
       cy.get(
         "[data-cy='field:one_to_one'] [data-cy='active-relational-item']"
@@ -639,8 +645,8 @@ describe("Content Specs", () => {
     });
 
     it("is should not be able to add an item if required fields are missing", () => {
-      cy.getBySelector("AddRepeaterRowItemBtn").click();
-      cy.getBySelector("SaveRepeaterRowItemBtn").click();
+      cy.getBySelector("AddRepeaterRowItemBtn").scrollIntoView().click();
+      cy.getBySelector("SaveRepeaterRowItemBtn").scrollIntoView().click();
       cy.contains("Required Field. Please enter a value.").should("exist");
     });
 
@@ -694,7 +700,7 @@ describe("Content Specs", () => {
 
       cy.getBySelector("subfield:sort").find("input").clear().type("99");
 
-      cy.getBySelector("SaveRepeaterRowItemBtn").click();
+      cy.getBySelector("SaveRepeaterRowItemBtn").scrollIntoView().click();
       cy.getBySelector("field:repeater")
         .find(".MuiDataGrid-row")
         .should("have.length", 1);
@@ -705,7 +711,7 @@ describe("Content Specs", () => {
       const updatedValue = "I am now updated";
 
       // Add a new row item
-      cy.getBySelector("AddRepeaterRowItemBtn").click();
+      cy.getBySelector("AddRepeaterRowItemBtn").scrollIntoView().click();
       cy.getBySelector("subfield:single_line_text")
         .find("input")
         .clear()
@@ -714,7 +720,7 @@ describe("Content Specs", () => {
         .find("input")
         .clear()
         .type("https://zesty.io");
-      cy.getBySelector("SaveRepeaterRowItemBtn").click();
+      cy.getBySelector("SaveRepeaterRowItemBtn").scrollIntoView().click();
 
       // Verify old value
       cy.getBySelector("field:repeater")
@@ -733,7 +739,7 @@ describe("Content Specs", () => {
         .clear()
         .type(updatedValue);
       cy.wait(500);
-      cy.getBySelector("SaveRepeaterRowItemBtn").click();
+      cy.getBySelector("SaveRepeaterRowItemBtn").scrollIntoView().click();
 
       // Verify updated value
       cy.getBySelector("field:repeater")
@@ -801,7 +807,7 @@ describe("Content Specs", () => {
     });
 
     it("should bulk remove checked rows", () => {
-      cy.getBySelector("AddRepeaterRowItemBtn").click();
+      cy.getBySelector("AddRepeaterRowItemBtn").scrollIntoView().click();
       cy.getBySelector("subfield:single_line_text")
         .find("input")
         .clear()
@@ -810,7 +816,7 @@ describe("Content Specs", () => {
         .find("input")
         .clear()
         .type("https://zesty.io");
-      cy.getBySelector("SaveRepeaterRowItemBtn").click();
+      cy.getBySelector("SaveRepeaterRowItemBtn").scrollIntoView().click();
 
       cy.getBySelector("field:repeater")
         .find(".MuiDataGrid-row")

--- a/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
@@ -45,6 +45,10 @@ import { MediaApp } from "../../../../../media/src/app";
 
 const drawerWidth = 440;
 
+// Duration the dark refresh overlay takes to fade in/out. Kept in sync with
+// the `transition` on the overlay in StudioPreview.
+const REFRESH_FADE_MS = 200;
+
 const withCodeIdBreadcrumbRoot = (
   codeId: string,
   breadcrumb: LayoutBreadcrumbItem[],
@@ -218,6 +222,8 @@ export const StudioWrapper = () => {
     [buildIframeSrc, previewPath]
   );
   const [isNavigating, setIsNavigating] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedItemZUID = selectedElement?.itemZuid || pageItemZUID;
   const selectedModelZUID = selectedElement?.modelZuid || pageModelZUID;
 
@@ -492,13 +498,30 @@ export const StudioWrapper = () => {
     return () => iframeEl.removeEventListener("load", handleLoad);
   }, []);
 
+  useEffect(
+    () => () => {
+      if (refreshTimeoutRef.current) {
+        clearTimeout(refreshTimeoutRef.current);
+      }
+    },
+    []
+  );
+
   const refreshPreviewFrame = useCallback(
     (onReloadComplete?: () => void) => {
       previewReloadContinuationRef.current = onReloadComplete || null;
-      setIsNavigating(true);
-      if (iframeRef.current) {
-        iframeRef.current.src = iframeSrc;
+      // Fade the dark overlay in first, then reload the iframe underneath it
+      // so the blank reload is hidden and edits are blocked until it finishes.
+      setIsRefreshing(true);
+      if (refreshTimeoutRef.current) {
+        clearTimeout(refreshTimeoutRef.current);
       }
+      refreshTimeoutRef.current = setTimeout(() => {
+        refreshTimeoutRef.current = null;
+        if (iframeRef.current) {
+          iframeRef.current.src = iframeSrc;
+        }
+      }, REFRESH_FADE_MS);
     },
     [iframeSrc]
   );
@@ -988,6 +1011,13 @@ export const StudioWrapper = () => {
     onStaticEditImage: setImageEditState,
   });
 
+  const handlePreviewFrameLoad = useCallback(() => {
+    // The refreshed page has painted — drop the overlay, then run the
+    // existing bridge load handler.
+    setIsRefreshing(false);
+    handlePreviewLoad();
+  }, [handlePreviewLoad]);
+
   const renderInfoPanel = () => {
     if (!isResolved) {
       return (
@@ -1091,7 +1121,8 @@ export const StudioWrapper = () => {
               iframeRef={iframeRef}
               iframeSrc={iframeSrc}
               isNavigating={isNavigating}
-              onLoad={handlePreviewLoad}
+              isBusy={isRefreshing || studioSaving || isSavingLayout}
+              onLoad={handlePreviewFrameLoad}
             />
             {interactionMode === "content" ? (
               <StudioSidePanel

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioPreview.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioPreview.tsx
@@ -5,6 +5,7 @@ type StudioPreviewProps = {
   iframeRef: RefObject<HTMLIFrameElement>;
   iframeSrc: string;
   isNavigating: boolean;
+  isBusy: boolean;
   onLoad: () => void;
 };
 
@@ -12,6 +13,7 @@ export const StudioPreview = ({
   iframeRef,
   iframeSrc,
   isNavigating,
+  isBusy,
   onLoad,
 }: StudioPreviewProps) => (
   <Box position="relative" flex="1" minWidth={0}>
@@ -37,6 +39,7 @@ export const StudioPreview = ({
           position: "absolute",
           top: 12,
           right: 12,
+          zIndex: 3,
         }}
         display="flex"
         alignItems="center"
@@ -45,5 +48,25 @@ export const StudioPreview = ({
         <CircularProgress size={24} />
       </Box>
     ) : null}
+    {/* While a save reload is in flight, a dark overlay fades over the preview
+        to hide the blank reload and block edits against soon-to-be-stale
+        content. It fades back out once the refreshed page has loaded. */}
+    <Box
+      data-cy="StudioPreviewRefreshOverlay"
+      sx={{
+        position: "absolute",
+        inset: 0,
+        zIndex: 2,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        bgcolor: "grey.900",
+        opacity: isBusy ? 1 : 0,
+        pointerEvents: isBusy ? "auto" : "none",
+        transition: "opacity 0.2s ease",
+      }}
+    >
+      {isBusy ? <CircularProgress size={28} /> : null}
+    </Box>
   </Box>
 );


### PR DESCRIPTION
## Issue

Closes #4055

## Problem

Saving in Studio reloaded the WebEngine preview iframe directly (`iframe.src = iframeSrc`), blanking it white for a few seconds. During that window users could keep editing against content that was about to be replaced by the fresh server render.

## Change

Add a dark overlay (`grey.900`, matching the studio background) that fades over the preview while a save-driven refresh is in flight:

- **Hides the blank reload** — the iframe reloads behind the opaque overlay, so there's no white flash.
- **Blocks edits during the window** — the overlay captures pointer events from the moment Save is clicked until the refreshed page has loaded, so no clicks/drags/hovers reach the preview's bridge.
- Fades back out (200ms) once the refreshed page's `load` event fires.

Covers all three refresh paths: content saves, layout saves/publish, and layout discard. Navigation (path/language changes) keeps its existing spinner behavior.

## Notes

- `isBusy = isRefreshing || studioSaving || isSavingLayout` drives the overlay; `isRefreshing` is cleared via the iframe's `onLoad` handler.
- `data-cy="StudioPreviewFrame"` is unchanged, so existing Cypress specs are unaffected.

