### PR TITLE
Maintenance: Add worktree support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage/
 skills-lock.json
 .agents
 .playwright-mcp
+.claude/worktrees

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,1 @@
+cypress.env.json

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,3 +1,4 @@
-# Glob patterns for files to copy from the repo root into each new worktree.
+# Files to copy from the repo root into each new worktree.
 # Used by the Claude Code worktree setup to make local env files available.
+cypress.env.json
 *.env*

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,1 +1,3 @@
-cypress.env.json
+# Glob patterns for files to copy from the repo root into each new worktree.
+# Used by the Claude Code worktree setup to make local env files available.
+*.env*


### PR DESCRIPTION
## Summary

- Ignores `.claude/worktrees` in `.gitignore` so worktree directories aren't tracked
- Adds `.worktreeinclude` to allow `cypress.env.json` to be available inside worktrees via sparse checkout