### PR TITLE
Content: Fix crash when publish API returns unexpected error shape

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
@@ -399,7 +399,6 @@ export const ItemEditHeaderActions = ({
               promise.value.error.data?.message ||
               "An error occurred while publishing. Please try again.";
             dispatch(notify({ message, kind: "error" }));
-            dispatch(notify({ message, kind: "error" }));
           }
         });
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
@@ -394,12 +394,11 @@ export const ItemEditHeaderActions = ({
         // Loop through all publish results and dispatch error notification if any failed
         publishPromises.forEach((promise: any) => {
           if ("error" in promise.value) {
-            dispatch(
-              notify({
-                message: promise.value.error.data?.error,
-                kind: "error",
-              })
-            );
+            const message =
+              promise.value.error.data?.error ??
+              promise.value.error.data?.message ??
+              "An error occurred while publishing. Please try again.";
+            dispatch(notify({ message, kind: "error" }));
           }
         });
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
@@ -395,9 +395,10 @@ export const ItemEditHeaderActions = ({
         publishPromises.forEach((promise: any) => {
           if ("error" in promise.value) {
             const message =
-              promise.value.error.data?.error ??
-              promise.value.error.data?.message ??
+              promise.value.error.data?.error ||
+              promise.value.error.data?.message ||
               "An error occurred while publishing. Please try again.";
+            dispatch(notify({ message, kind: "error" }));
             dispatch(notify({ message, kind: "error" }));
           }
         });


### PR DESCRIPTION
Resolves #4138

## Summary
- In `ItemEditHeaderActions.tsx`, the error notification after a failed publish API call used `promise.value.error.data?.error` as the message, which can be `undefined` when the API error body doesn't match the expected `{ data: { error: string } }` shape.
- The `notify()` guard in `notifications.ts` throws `"Cannot trigger notification without a message"` when given `undefined`, causing a secondary crash that obscures the original publish error.
- Added a fallback chain (`data?.error || data?.message || "An error occurred while publishing. Please try again."`) so `notify()` always receives a non-empty string regardless of the API error body shape.
- Also removed a duplicate `dispatch(notify(...))` call introduced by the auto-reviewer that would have shown the error notification twice per failure.

## Test plan
- [ ] Trigger a publish action and confirm the success notification still appears normally.
- [ ] Simulate a failed publish (e.g. network error or API 500) and confirm a non-empty error notification is shown instead of a secondary crash.
- [ ] Verify no regressions in other publish-related flows (scheduled publish, unpublish, retract).

## Screenshots
<!-- screenshot needed — this fix prevents a thrown exception and has no visible UI change under normal conditions -->