### PR TITLE
Content: Fix crash when item is undefined in ItemParent useEffect

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/ItemParent.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/ItemParent.tsx
@@ -221,7 +221,13 @@ export const ItemParent = ({ onChange }: ItemParentProps) => {
           });
       }
     }
-  }, [rawNavData, item]);
+  }, [
+    rawNavData,
+    item?.web?.parentZUID,
+    item?.meta?.ZUID,
+    item?.web?.path,
+    item?.meta?.langID,
+  ]);
 
   useEffect(() => {
     const normalizedSearch = searchText.toLowerCase();

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/ItemParent.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/ItemParent.tsx
@@ -143,8 +143,9 @@ export const ItemParent = ({ onChange }: ItemParentProps) => {
   }, 1000);
 
   useEffect(() => {
-    let { parentZUID } = item?.web;
-    const { ZUID: itemZUID } = item?.meta;
+    if (!item?.web || !item?.meta) return;
+    let { parentZUID } = item.web;
+    const { ZUID: itemZUID } = item.meta;
 
     // If it's a new item chase down the parentZUID within navigation
     // This way we avoid an API request

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/ItemParent.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/ItemParent.tsx
@@ -221,7 +221,7 @@ export const ItemParent = ({ onChange }: ItemParentProps) => {
           });
       }
     }
-  }, [rawNavData]);
+  }, [rawNavData, item]);
 
   useEffect(() => {
     const normalizedSearch = searchText.toLowerCase();


### PR DESCRIPTION
Resolves #4011

## Summary
- `ItemParent.tsx` was destructuring `parentZUID` from `item?.web` directly inside a `useEffect`, which throws a `TypeError` when `item` is `undefined` (e.g. during initial load or race conditions)
- Added an early-return guard (`if (!item?.web || !item?.meta) return`) so the effect safely bails out until `item` is available

## Test plan
- [ ] Open a content item in the editor and verify the Meta > Settings panel loads without crashing
- [ ] Simulate a race condition by navigating to a content item URL directly (hard refresh) and confirm no TypeError appears in the console
- [ ] Verify the parent ZUID selector still populates correctly once `item` resolves

## Screenshots
<!-- screenshot needed — this fix prevents a runtime crash and has no visual UI change -->