### PR TITLE
[Studio] - Support cross-region layout drag-and-drop

### DIFF
--- a/cypress/e2e/studio/studio-wrapper.spec.js
+++ b/cypress/e2e/studio/studio-wrapper.spec.js
@@ -40,16 +40,23 @@ describe("Studio Wrapper", () => {
 
     postBridgeMessage({
       type: "REORDER_OUTPUT",
-      codeId: nextCodeId,
-      selector: "[data-layout-id]",
-      orderedLayoutIds: ["2", "1"],
-      layoutStructure: [
-        { layoutId: "2", parentLayoutId: null },
-        { layoutId: "1", parentLayoutId: null },
+      regions: [
+        {
+          codeId: nextCodeId,
+          selector: "[data-layout-id]",
+          orderedLayoutIds: ["2", "1"],
+          layoutStructure: [
+            { layoutId: "2", parentLayoutId: null },
+            { layoutId: "1", parentLayoutId: null },
+          ],
+          outputHtml:
+            '<div data-layout-id="2">Two</div><div data-layout-id="1">One</div>',
+        },
       ],
-      outputHtml:
-        '<div data-layout-id="2">Two</div><div data-layout-id="1">One</div>',
+      primaryCodeId: nextCodeId,
+      selectedLayoutId: "2",
       selectedLayoutBreadcrumb: [{ layoutId: "2", label: "div" }],
+      selector: "[data-layout-id]",
     });
   };
 
@@ -74,17 +81,19 @@ describe("Studio Wrapper", () => {
 
     postBridgeMessage({
       type: "REORDER_OUTPUT",
-      codeId: nextCodeId,
-      selector: "[data-layout-id]",
-      orderedLayoutIds: ["1", "2", "4", "5", "3"],
-      layoutStructure: [
-        { layoutId: "1", parentLayoutId: null },
-        { layoutId: "2", parentLayoutId: "1" },
-        { layoutId: "4", parentLayoutId: "1" },
-        { layoutId: "5", parentLayoutId: "1" },
-        { layoutId: "3", parentLayoutId: "1" },
-      ],
-      outputHtml: `
+      regions: [
+        {
+          codeId: nextCodeId,
+          selector: "[data-layout-id]",
+          orderedLayoutIds: ["1", "2", "4", "5", "3"],
+          layoutStructure: [
+            { layoutId: "1", parentLayoutId: null },
+            { layoutId: "2", parentLayoutId: "1" },
+            { layoutId: "4", parentLayoutId: "1" },
+            { layoutId: "5", parentLayoutId: "1" },
+            { layoutId: "3", parentLayoutId: "1" },
+          ],
+          outputHtml: `
         <div data-layout-id="1">
           <div data-layout-id="2">seeya world</div>
           <div data-layout-id="4">goodbye world</div>
@@ -96,7 +105,12 @@ describe("Studio Wrapper", () => {
           </div>
         </div>
       `,
+        },
+      ],
+      primaryCodeId: nextCodeId,
+      selectedLayoutId: "4",
       selectedLayoutBreadcrumb: [{ layoutId: "4", label: "div" }],
+      selector: "[data-layout-id]",
     });
   };
 
@@ -428,16 +442,23 @@ describe("Studio Wrapper", () => {
       // Reorder: swap block 2 before block 1
       postBridgeMessage({
         type: "REORDER_OUTPUT",
-        codeId: webView.ZUID,
-        selector: "[data-layout-id]",
-        orderedLayoutIds: ["2", "1"],
-        layoutStructure: [
-          { layoutId: "2", parentLayoutId: null },
-          { layoutId: "1", parentLayoutId: null },
+        regions: [
+          {
+            codeId: webView.ZUID,
+            selector: "[data-layout-id]",
+            orderedLayoutIds: ["2", "1"],
+            layoutStructure: [
+              { layoutId: "2", parentLayoutId: null },
+              { layoutId: "1", parentLayoutId: null },
+            ],
+            outputHtml:
+              '<div data-layout-id="2">Two</div><div data-layout-id="1">One</div>',
+          },
         ],
-        outputHtml:
-          '<div data-layout-id="2">Two</div><div data-layout-id="1">One</div>',
+        primaryCodeId: webView.ZUID,
+        selectedLayoutId: "2",
         selectedLayoutBreadcrumb: [],
+        selector: "[data-layout-id]",
       });
 
       // Static edit on block 2 after reorder

--- a/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
@@ -40,7 +40,7 @@ import { useStudioBridge } from "./hooks/useStudioBridge";
 import { InteractionMode, LayoutBreadcrumbItem } from "./hooks/studioTypes";
 import { useStudioSelection } from "./hooks/useStudioSelection";
 import { getRefRegistry } from "../../../../../../engine/refRegistry";
-import { usePermission } from "../../../../../../shell/hooks/use-permissions";
+import { useMultiPermission } from "../../../../../../shell/hooks/use-permissions";
 import { MediaApp } from "../../../../../media/src/app";
 
 const drawerWidth = 440;
@@ -527,7 +527,7 @@ export const StudioWrapper = () => {
   );
 
   const {
-    pendingLayoutSave,
+    pendingLayoutCodeIds,
     isSavingLayout,
     handleDiscardPendingLayoutSave,
     handleSavePendingLayout,
@@ -542,25 +542,24 @@ export const StudioWrapper = () => {
     updateWebView,
     publishWebView,
     dispatch,
-    selectedLayoutCodeId: selectedLayout?.codeId,
     clearLayoutSelection,
     refreshPreviewFrame,
     withCodeIdBreadcrumbRoot,
     onSelectedLayoutBreadcrumbChange: setSelectedLayout,
   });
-  const pendingLayoutCodeId = pendingLayoutSave?.codeId || null;
-  const canUpdatePendingLayout = usePermission(
+  const hasPendingLayoutChanges = pendingLayoutCodeIds.length > 0;
+  const canUpdatePendingLayout = useMultiPermission(
     "UPDATE",
-    pendingLayoutCodeId || undefined
+    pendingLayoutCodeIds
   );
-  const canPublishPendingLayout = usePermission(
+  const canPublishPendingLayout = useMultiPermission(
     "PUBLISH",
-    pendingLayoutCodeId || undefined
+    pendingLayoutCodeIds
   );
 
   const requestProceedWithPendingLayoutSave = useCallback(
     (onProceed: () => void) => {
-      if (!pendingLayoutSave?.mappedSource) {
+      if (!hasPendingLayoutChanges) {
         onProceed();
         return;
       }
@@ -568,7 +567,7 @@ export const StudioWrapper = () => {
       pendingLayoutContinuationRef.current = onProceed;
       setShowPendingLayoutModal(true);
     },
-    [pendingLayoutSave?.mappedSource]
+    [hasPendingLayoutChanges]
   );
 
   const syncBridgeInteractionMode = useCallback(
@@ -624,7 +623,7 @@ export const StudioWrapper = () => {
         }
       }
 
-      if (nextMode === "content" && pendingLayoutSave?.mappedSource) {
+      if (nextMode === "content" && hasPendingLayoutChanges) {
         requestProceedWithPendingLayoutSave(applyInteractionModeChange);
         return;
       }
@@ -635,7 +634,7 @@ export const StudioWrapper = () => {
       clearLayoutSelection,
       clearSelection,
       interactionMode,
-      pendingLayoutSave?.mappedSource,
+      hasPendingLayoutChanges,
       postCommandToBridge,
       requestProceedWithPendingLayoutSave,
       selectedItem?.dirty,
@@ -1000,7 +999,7 @@ export const StudioWrapper = () => {
     applySelection: applyBridgeSelection,
     fieldNameByZuid,
     currentHoverStudioIdRef,
-    pendingLayoutHasMappedSource: Boolean(pendingLayoutSave?.mappedSource),
+    pendingLayoutHasMappedSource: hasPendingLayoutChanges,
     selectedLayoutCodeId: selectedLayout?.codeId,
     selectedItemDirty: selectedItem?.dirty,
     selectedItemZUID,
@@ -1146,7 +1145,7 @@ export const StudioWrapper = () => {
               />
             ) : null}
           </Box>
-          {pendingLayoutSave?.mappedSource ? (
+          {hasPendingLayoutChanges ? (
             <Box
               data-cy="StudioLayoutSaveBar"
               position="absolute"

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/useLayoutReorderState.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/useLayoutReorderState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { notify } from "../../../../../../../shell/store/notifications";
 import { LayoutBreadcrumbItem } from "./studioTypes";
 
@@ -16,8 +16,7 @@ const isLayoutBreadcrumbItem = (
       typeof (segment as LayoutBreadcrumbItem).label === "string"
   );
 
-type LayoutReorderState = {
-  codeId: string | null;
+type LayoutRegionState = {
   selector: string;
   orderedLayoutIds: string[];
   layoutStructure: LayoutStructureItem[];
@@ -25,11 +24,32 @@ type LayoutReorderState = {
   mappedSource: string;
 };
 
+type LayoutReorderState = {
+  regions: Record<string, LayoutRegionState>;
+  primaryCodeId: string;
+};
+
+// Apply a new layoutStructure to a cached template source. Used both for
+// single-region reorders and for the per-region post-processing of a cross-
+// region drag, where blocks may have moved between sibling/nested templates.
+//
+//  - donorSourceById: layoutId → outerHTML pulled from OTHER regions' cached
+//    templates. When a layoutId is referenced by the destination region's new
+//    structure but is missing from its cached template (because it was just
+//    dragged in from the donor region), the donor markup is injected here so
+//    the re-parent pass can place it correctly. With globally-unique
+//    layoutIds, donor lookups are unambiguous.
+//
+//  - Removal pass: any [data-layout-id] node whose id is NOT in the
+//    incoming layoutStructure is removed. This is how the SOURCE region of a
+//    cross-region drag loses the moved block. For single-region reorders the
+//    structure always covers every block, so the pass is a no-op.
 const mapSourceByLayoutStructure = (
   source: string,
-  layoutStructure: LayoutStructureItem[]
-) => {
-  if (!source || !layoutStructure?.length) return source;
+  layoutStructure: LayoutStructureItem[],
+  donorSourceById?: Map<string, string>
+): string => {
+  if (!source) return source;
 
   const parser = new DOMParser();
   const doc = parser.parseFromString(
@@ -39,6 +59,38 @@ const mapSourceByLayoutStructure = (
   const root = doc.getElementById("studio-root");
   if (!root) return source;
 
+  const expectedLayoutIds = new Set<string>();
+  layoutStructure.forEach(({ layoutId }) => {
+    if (layoutId) expectedLayoutIds.add(layoutId);
+  });
+
+  // Pass 1: inject donor nodes for layoutIds that are expected but missing.
+  if (donorSourceById && donorSourceById.size > 0) {
+    const existingLayoutIds = new Set<string>();
+    root.querySelectorAll("[data-layout-id]").forEach((node) => {
+      const id = node.getAttribute("data-layout-id") || "";
+      if (id) existingLayoutIds.add(id);
+    });
+
+    expectedLayoutIds.forEach((layoutId) => {
+      if (existingLayoutIds.has(layoutId)) return;
+      const donor = donorSourceById.get(layoutId);
+      if (!donor) return;
+      const holder = doc.createElement("div");
+      holder.innerHTML = donor;
+      const node = holder.firstElementChild;
+      if (node) root.appendChild(node);
+    });
+  }
+
+  // Pass 2: remove elements absent from the new structure.
+  Array.from(root.querySelectorAll("[data-layout-id]")).forEach((node) => {
+    const id = node.getAttribute("data-layout-id") || "";
+    if (!id || expectedLayoutIds.has(id)) return;
+    node.remove();
+  });
+
+  // Pass 3: re-parent elements according to layoutStructure.
   const elementByLayoutId = new Map<string, Element>();
   Array.from(root.querySelectorAll("[data-layout-id]")).forEach((node) => {
     const layoutId = node.getAttribute("data-layout-id");
@@ -59,17 +111,42 @@ const mapSourceByLayoutStructure = (
     a === "__root__" ? -1 : b === "__root__" ? 1 : 0
   );
 
+  // Anchor each parent's layout block at the position of its FIRST existing
+  // layout-id child, then insertBefore each entry in desired order. Using
+  // appendChild here would move every layout-id element to the end of the
+  // parent, pushing surrounding non-layout content (a `<h1>`, a Parsley
+  // `{{include ...}}` text node, etc.) out of its original place.
   orderedParentKeys.forEach((parentKey) => {
     const parentNode =
       parentKey === "__root__" ? root : elementByLayoutId.get(parentKey);
     const childIds = childIdsByParent.get(parentKey) || [];
-    if (!parentNode) return;
+    if (!parentNode || !childIds.length) return;
+
+    const existingHere = childIds
+      .map((id) => elementByLayoutId.get(id))
+      .filter(
+        (node): node is Element => !!node && node.parentNode === parentNode
+      );
+
+    // The node we want to insert AFTER. If the parent already has any
+    // expected layout-id children, anchor at the previousSibling of the
+    // first one (so the block stays in place). Otherwise insert at the
+    // start of the parent.
+    let afterNode: Node | null =
+      existingHere.length > 0 ? existingHere[0].previousSibling : null;
 
     childIds.forEach((layoutId) => {
       const childNode = elementByLayoutId.get(layoutId);
       if (!childNode || childNode === parentNode) return;
       if (childNode.contains(parentNode)) return;
-      parentNode.appendChild(childNode);
+      if (childNode.parentNode) childNode.parentNode.removeChild(childNode);
+
+      const reference =
+        afterNode && afterNode.parentNode === parentNode
+          ? afterNode.nextSibling
+          : parentNode.firstChild;
+      parentNode.insertBefore(childNode, reference);
+      afterNode = childNode;
     });
   });
 
@@ -92,6 +169,31 @@ const mapSourceByLayoutStructure = (
   });
 
   return root.innerHTML;
+};
+
+// Build a global donor map (layoutId → outerHTML) from every cached template,
+// so that whichever region needs an injected node can find it.
+const buildDonorSourceById = (
+  cachedSnapshots: Record<string, string>
+): Map<string, string> => {
+  const donorSourceById = new Map<string, string>();
+  Object.values(cachedSnapshots).forEach((source) => {
+    if (!source) return;
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(
+      `<div id="studio-donor-root">${source}</div>`,
+      "text/html"
+    );
+    const root = doc.getElementById("studio-donor-root");
+    if (!root) return;
+    root.querySelectorAll("[data-layout-id]").forEach((node) => {
+      const id = node.getAttribute("data-layout-id") || "";
+      if (id && !donorSourceById.has(id)) {
+        donorSourceById.set(id, node.outerHTML);
+      }
+    });
+  });
+  return donorSourceById;
 };
 
 // Apply the bridge's edited innerHTML to the cached template source while
@@ -179,7 +281,6 @@ type Args = {
   updateWebView: (args: any) => { unwrap: () => Promise<any> };
   publishWebView: (args: any) => { unwrap: () => Promise<any> };
   dispatch: (action: any) => any;
-  selectedLayoutCodeId?: string;
   clearLayoutSelection: () => void;
   refreshPreviewFrame: (onReloadComplete?: () => void) => void;
   withCodeIdBreadcrumbRoot: (
@@ -208,7 +309,6 @@ export const useLayoutReorderState = ({
   updateWebView,
   publishWebView,
   dispatch,
-  selectedLayoutCodeId,
   clearLayoutSelection,
   refreshPreviewFrame,
   withCodeIdBreadcrumbRoot,
@@ -218,6 +318,11 @@ export const useLayoutReorderState = ({
   const [pendingLayoutSave, setPendingLayoutSave] =
     useState<LayoutReorderState | null>(null);
   const [isSavingLayout, setIsSavingLayout] = useState(false);
+
+  const pendingLayoutCodeIds = useMemo(
+    () => Object.keys(pendingLayoutSave?.regions || {}),
+    [pendingLayoutSave]
+  );
 
   const clearPendingLayoutState = useCallback(() => {
     setPendingLayoutSave(null);
@@ -232,55 +337,108 @@ export const useLayoutReorderState = ({
     [clearLayoutSelection, clearPendingLayoutState, refreshPreviewFrame]
   );
 
-  const savePendingLayoutSource = useCallback(async () => {
-    if (!pendingLayoutSave?.codeId) return;
+  // Saves each pending region sequentially. Returns the list of saved results.
+  // On the first failure: throws (caller surfaces the error). Already-saved
+  // regions are removed from pendingLayoutSave so the user can retry the rest.
+  const savePendingLayoutSources = useCallback(async () => {
+    if (!pendingLayoutSave) return [];
+    const codeIds = Object.keys(pendingLayoutSave.regions);
+    if (!codeIds.length) return [];
 
-    const codeId = pendingLayoutSave.codeId;
-    const latestSource = templateSourceByCodeIdRef.current[codeId];
-    if (!latestSource) return;
+    const savedResults: Array<{
+      codeId: string;
+      webView: any;
+      updatedWebView: any;
+    }> = [];
 
-    const webView = webViews.find((view) => view.ZUID === codeId);
-    if (!webView) {
-      throw new Error("Unable to resolve code file for layout save.");
+    for (const codeId of codeIds) {
+      const latestSource = templateSourceByCodeIdRef.current[codeId];
+      if (typeof latestSource !== "string") {
+        throw new Error(
+          `Unable to resolve cached template for code file ${codeId}.`
+        );
+      }
+
+      const webView = webViews.find((view) => view.ZUID === codeId);
+      if (!webView) {
+        throw new Error(
+          `Unable to resolve code file ${codeId} for layout save.`
+        );
+      }
+
+      const sanitizedSource = stripLayoutIdsFromSource(latestSource);
+
+      try {
+        const updatedWebView = await updateWebView({
+          ZUID: codeId,
+          body: {
+            ...webView,
+            code: sanitizedSource,
+          },
+        }).unwrap();
+
+        savedResults.push({ codeId, webView, updatedWebView });
+
+        // Remove the now-saved region from pending state so a retry doesn't
+        // re-save it.
+        setPendingLayoutSave((prev) => {
+          if (!prev) return prev;
+          const { [codeId]: _saved, ...rest } = prev.regions;
+          if (!Object.keys(rest).length) return null;
+          return {
+            regions: rest,
+            primaryCodeId:
+              prev.primaryCodeId === codeId
+                ? Object.keys(rest)[0]
+                : prev.primaryCodeId,
+          };
+        });
+      } catch (err) {
+        (err as any).failedCodeId = codeId;
+        throw err;
+      }
     }
 
-    const sanitizedSource = stripLayoutIdsFromSource(latestSource);
-    const updatedWebView = await updateWebView({
-      ZUID: codeId,
-      body: {
-        ...webView,
-        code: sanitizedSource,
-      },
-    }).unwrap();
+    return savedResults;
+  }, [pendingLayoutSave, updateWebView, webViews]);
 
-    return {
-      codeId,
-      webView,
-      updatedWebView,
-    };
-  }, [pendingLayoutSave?.codeId, updateWebView, webViews]);
+  const formatSavedFileNames = useCallback(
+    (results: Array<{ codeId: string; webView: any }>) => {
+      const names = results.map(
+        ({ codeId, webView }) =>
+          codeFileNameById[codeId] || webView?.fileName || codeId
+      );
+      if (names.length === 0) return "";
+      if (names.length === 1) return names[0];
+      if (names.length === 2) return `${names[0]} and ${names[1]}`;
+      return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+    },
+    [codeFileNameById]
+  );
 
   const handleSavePendingLayout = useCallback(
     async (onComplete?: () => void) => {
-      if (!pendingLayoutSave?.codeId || !pendingLayoutSave.mappedSource) return;
+      if (!pendingLayoutSave) return;
+      if (!Object.keys(pendingLayoutSave.regions).length) return;
 
       setIsSavingLayout(true);
 
       try {
-        const result = await savePendingLayoutSource();
-        if (!result) return;
+        const results = await savePendingLayoutSources();
+        if (!results.length) return;
 
-        clearPendingLayoutState();
         refreshPreviewFrame(onComplete);
         dispatch(
           notify({
             kind: "success",
-            message: `Saved ${
-              codeFileNameById[result.codeId] || result.webView.fileName
-            }`,
+            message: `Saved ${formatSavedFileNames(results)}`,
           })
         );
       } catch (error: any) {
+        const failedCodeId = error?.failedCodeId;
+        const failedName = failedCodeId
+          ? codeFileNameById[failedCodeId] || failedCodeId
+          : null;
         dispatch(
           notify({
             kind: "warn",
@@ -288,7 +446,9 @@ export const useLayoutReorderState = ({
               error?.data?.error ||
               error?.error ||
               error?.message ||
-              "Failed to save layout.",
+              (failedName
+                ? `Failed to save ${failedName}.`
+                : "Failed to save layout."),
           })
         );
       } finally {
@@ -296,40 +456,49 @@ export const useLayoutReorderState = ({
       }
     },
     [
-      clearPendingLayoutState,
       codeFileNameById,
       dispatch,
+      formatSavedFileNames,
       pendingLayoutSave,
       refreshPreviewFrame,
-      savePendingLayoutSource,
+      savePendingLayoutSources,
     ]
   );
 
   const handleSaveAndPublishPendingLayout = useCallback(async () => {
-    if (!pendingLayoutSave?.codeId || !pendingLayoutSave.mappedSource) return;
+    if (!pendingLayoutSave) return;
+    if (!Object.keys(pendingLayoutSave.regions).length) return;
 
     setIsSavingLayout(true);
 
     try {
-      const result = await savePendingLayoutSource();
-      if (!result) return;
+      const results = await savePendingLayoutSources();
+      if (!results.length) return;
 
-      await publishWebView({
-        ZUID: result.codeId,
-        version: result.webView.version + 1,
-      }).unwrap();
+      for (const { codeId, webView } of results) {
+        try {
+          await publishWebView({
+            ZUID: codeId,
+            version: webView.version + 1,
+          }).unwrap();
+        } catch (err) {
+          (err as any).failedCodeId = codeId;
+          throw err;
+        }
+      }
 
-      clearPendingLayoutState();
       refreshPreviewFrame();
       dispatch(
         notify({
           kind: "success",
-          message: `Saved and published ${
-            codeFileNameById[result.codeId] || result.webView.fileName
-          }`,
+          message: `Saved and published ${formatSavedFileNames(results)}`,
         })
       );
     } catch (error: any) {
+      const failedCodeId = error?.failedCodeId;
+      const failedName = failedCodeId
+        ? codeFileNameById[failedCodeId] || failedCodeId
+        : null;
       dispatch(
         notify({
           kind: "warn",
@@ -337,20 +506,22 @@ export const useLayoutReorderState = ({
             error?.data?.error ||
             error?.error ||
             error?.message ||
-            "Failed to save and publish layout.",
+            (failedName
+              ? `Failed to save and publish ${failedName}.`
+              : "Failed to save and publish layout."),
         })
       );
     } finally {
       setIsSavingLayout(false);
     }
   }, [
-    clearPendingLayoutState,
     codeFileNameById,
     dispatch,
+    formatSavedFileNames,
     pendingLayoutSave,
     publishWebView,
     refreshPreviewFrame,
-    savePendingLayoutSource,
+    savePendingLayoutSources,
   ]);
 
   const handleTemplateSourceMap = useCallback((msg: any) => {
@@ -390,32 +561,38 @@ export const useLayoutReorderState = ({
       };
 
       setPendingLayoutSave((prev) => {
+        const prevRegion = prev?.regions?.[codeId];
         const hasPendingReorder = Boolean(
-          prev?.layoutStructure && prev.layoutStructure.length
+          prevRegion?.layoutStructure && prevRegion.layoutStructure.length
         );
         const layoutStructure: LayoutStructureItem[] = hasPendingReorder
-          ? prev!.layoutStructure
+          ? prevRegion!.layoutStructure
           : [];
         const orderedLayoutIds = hasPendingReorder
-          ? prev!.orderedLayoutIds
+          ? prevRegion!.orderedLayoutIds
           : [];
-        const selector = prev?.selector || "[data-layout-id]";
+        const selector = prevRegion?.selector || "[data-layout-id]";
         // Only re-run the reorder mapping when there is a pending reorder to
         // apply on top of the edit. A pure static edit leaves the structure
-        // untouched, so the patched source IS the mapped source — running
-        // mapSourceByLayoutStructure with a bogus single-entry structure would
-        // move the edited block to the root of the template.
+        // untouched, so the patched source IS the mapped source.
         const mappedSource = hasPendingReorder
           ? mapSourceByLayoutStructure(next, layoutStructure)
           : next;
 
-        return {
-          codeId,
+        const nextRegion: LayoutRegionState = {
           selector,
           orderedLayoutIds,
           layoutStructure,
-          outputHtml: prev?.outputHtml || "",
+          outputHtml: prevRegion?.outputHtml || "",
           mappedSource,
+        };
+
+        return {
+          regions: {
+            ...(prev?.regions || {}),
+            [codeId]: nextRegion,
+          },
+          primaryCodeId: prev?.primaryCodeId || codeId,
         };
       });
     },
@@ -424,81 +601,118 @@ export const useLayoutReorderState = ({
 
   const handleReorderOutput = useCallback(
     (msg: any) => {
-      const codeId = typeof msg.codeId === "string" ? msg.codeId : null;
-      const orderedLayoutIds = Array.isArray(msg.orderedLayoutIds)
-        ? msg.orderedLayoutIds.filter(
-            (layoutId: unknown): layoutId is string =>
-              typeof layoutId === "string"
+      const incomingRegions = Array.isArray(msg.regions)
+        ? msg.regions.filter(
+            (region: any) =>
+              region && typeof region === "object" && region.codeId
           )
         : [];
-      const layoutStructure = Array.isArray(msg.layoutStructure)
-        ? msg.layoutStructure.filter(
-            (entry: unknown): entry is LayoutStructureItem =>
-              Boolean(
-                entry &&
-                  typeof entry === "object" &&
-                  typeof (entry as LayoutStructureItem).layoutId === "string" &&
-                  (typeof (entry as LayoutStructureItem).parentLayoutId ===
-                    "string" ||
-                    (entry as LayoutStructureItem).parentLayoutId === null)
-              )
-          )
-        : [];
-      const sourceTemplate = codeId
-        ? templateSourceByCodeIdRef.current[codeId] || ""
-        : "";
-      const mappedSource = sourceTemplate
-        ? mapSourceByLayoutStructure(sourceTemplate, layoutStructure)
-        : "";
+      if (!incomingRegions.length) return;
 
-      if (codeId && mappedSource) {
-        templateSourceByCodeIdRef.current = {
-          ...templateSourceByCodeIdRef.current,
-          [codeId]: mappedSource,
+      // Snapshot every cached template BEFORE mutation so donor lookups are
+      // stable regardless of processing order.
+      const cachedSnapshots = { ...templateSourceByCodeIdRef.current };
+      const donorSourceById = buildDonorSourceById(cachedSnapshots);
+
+      const mappedRegions: Record<string, LayoutRegionState> = {};
+      const nextCachedSources: Record<string, string> = {};
+
+      incomingRegions.forEach((region: any) => {
+        const codeId = typeof region.codeId === "string" ? region.codeId : "";
+        if (!codeId) return;
+
+        const cached = cachedSnapshots[codeId] || "";
+        if (!cached) return;
+
+        const orderedLayoutIds = Array.isArray(region.orderedLayoutIds)
+          ? region.orderedLayoutIds.filter(
+              (layoutId: unknown): layoutId is string =>
+                typeof layoutId === "string"
+            )
+          : [];
+        const layoutStructure: LayoutStructureItem[] = Array.isArray(
+          region.layoutStructure
+        )
+          ? region.layoutStructure.filter(
+              (entry: unknown): entry is LayoutStructureItem =>
+                Boolean(
+                  entry &&
+                    typeof entry === "object" &&
+                    typeof (entry as LayoutStructureItem).layoutId ===
+                      "string" &&
+                    (typeof (entry as LayoutStructureItem).parentLayoutId ===
+                      "string" ||
+                      (entry as LayoutStructureItem).parentLayoutId === null)
+                )
+            )
+          : [];
+
+        const mappedSource = mapSourceByLayoutStructure(
+          cached,
+          layoutStructure,
+          donorSourceById
+        );
+
+        nextCachedSources[codeId] = mappedSource;
+        mappedRegions[codeId] = {
+          selector:
+            typeof region.selector === "string"
+              ? region.selector
+              : "[data-layout-id]",
+          orderedLayoutIds,
+          layoutStructure,
+          outputHtml:
+            typeof region.outputHtml === "string" ? region.outputHtml : "",
+          mappedSource,
         };
-      }
+      });
 
-      if (codeId && selectedLayoutCodeId === codeId) {
+      if (!Object.keys(mappedRegions).length) return;
+
+      templateSourceByCodeIdRef.current = {
+        ...templateSourceByCodeIdRef.current,
+        ...nextCachedSources,
+      };
+
+      const primaryCodeId =
+        typeof msg.primaryCodeId === "string" && msg.primaryCodeId
+          ? msg.primaryCodeId
+          : Object.keys(mappedRegions)[0] || "";
+
+      // The dragged block is always the selected one (only .studio-selected
+      // blocks are draggable). Re-root its breadcrumb to the destination
+      // region so the header reflects the new home, even on cross-region drag.
+      if (primaryCodeId) {
         const reorderedBreadcrumb = Array.isArray(msg.selectedLayoutBreadcrumb)
           ? msg.selectedLayoutBreadcrumb.filter(isLayoutBreadcrumbItem)
           : [];
 
         onSelectedLayoutBreadcrumbChange((current) => {
-          if (!current || current.codeId !== codeId) return current;
+          if (!current) return current;
           if (!reorderedBreadcrumb.length) return current;
-
           return {
-            ...current,
+            codeId: primaryCodeId,
+            layoutId: current.layoutId,
             breadcrumb: withCodeIdBreadcrumbRoot(
-              codeId,
+              primaryCodeId,
               reorderedBreadcrumb,
-              codeFileNameById[codeId]
+              codeFileNameById[primaryCodeId]
             ),
           };
         });
       }
 
-      setPendingLayoutSave(
-        mappedSource
-          ? {
-              codeId,
-              selector:
-                typeof msg.selector === "string"
-                  ? msg.selector
-                  : "[data-layout-id]",
-              orderedLayoutIds,
-              layoutStructure,
-              outputHtml:
-                typeof msg.outputHtml === "string" ? msg.outputHtml : "",
-              mappedSource,
-            }
-          : null
-      );
+      setPendingLayoutSave((prev) => ({
+        regions: {
+          ...(prev?.regions || {}),
+          ...mappedRegions,
+        },
+        primaryCodeId: primaryCodeId || prev?.primaryCodeId || "",
+      }));
     },
     [
       codeFileNameById,
       onSelectedLayoutBreadcrumbChange,
-      selectedLayoutCodeId,
       withCodeIdBreadcrumbRoot,
     ]
   );
@@ -542,25 +756,35 @@ export const useLayoutReorderState = ({
       };
 
       setPendingLayoutSave((prev) => {
+        const prevRegion = prev?.regions?.[codeId];
         const hasPendingReorder = Boolean(
-          prev?.layoutStructure && prev.layoutStructure.length
+          prevRegion?.layoutStructure && prevRegion.layoutStructure.length
         );
-        const layoutStructure = hasPendingReorder ? prev!.layoutStructure : [];
-        const orderedLayoutIds = hasPendingReorder
-          ? prev!.orderedLayoutIds
+        const layoutStructure = hasPendingReorder
+          ? prevRegion!.layoutStructure
           : [];
-        const selector = prev?.selector || "[data-layout-id]";
+        const orderedLayoutIds = hasPendingReorder
+          ? prevRegion!.orderedLayoutIds
+          : [];
+        const selector = prevRegion?.selector || "[data-layout-id]";
         const mappedSource = hasPendingReorder
           ? mapSourceByLayoutStructure(next, layoutStructure)
           : next;
 
-        return {
-          codeId,
+        const nextRegion: LayoutRegionState = {
           selector,
           orderedLayoutIds,
           layoutStructure,
-          outputHtml: prev?.outputHtml || "",
+          outputHtml: prevRegion?.outputHtml || "",
           mappedSource,
+        };
+
+        return {
+          regions: {
+            ...(prev?.regions || {}),
+            [codeId]: nextRegion,
+          },
+          primaryCodeId: prev?.primaryCodeId || codeId,
         };
       });
     },
@@ -569,6 +793,7 @@ export const useLayoutReorderState = ({
 
   return {
     pendingLayoutSave,
+    pendingLayoutCodeIds,
     isSavingLayout,
     handleDiscardPendingLayoutSave,
     handleSavePendingLayout,

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/useLayoutReorderState.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/useLayoutReorderState.ts
@@ -688,8 +688,7 @@ export const useLayoutReorderState = ({
           : [];
 
         onSelectedLayoutBreadcrumbChange((current) => {
-          if (!current) return current;
-          if (!reorderedBreadcrumb.length) return current;
+          if (!current || !reorderedBreadcrumb.length) return current;
           return {
             codeId: primaryCodeId,
             layoutId: current.layoutId,

--- a/src/shell/hooks/use-permissions.js
+++ b/src/shell/hooks/use-permissions.js
@@ -10,6 +10,44 @@ const getRole = (state) => state.userRole;
 const selectUser = createSelector([getUser], (user) => user);
 const selectRole = createSelector([getRole], (role) => role);
 
+export function hasPermission(user, role, action, zuid = instanceZUID) {
+  // "With great power comes great responsibility" - Benjamin Franklin Parker
+  if (user?.staff) {
+    return true;
+  }
+
+  if (role?.systemRole?.super) {
+    return true;
+  }
+
+  const granularRole =
+    role?.granularRoles?.find((r) => r.resourceZUID === zuid) ||
+    role?.granularRoles?.find((r) => r.resourceZUID === instanceZUID);
+
+  switch (action) {
+    case "CREATE":
+      return granularRole?.create ?? role?.systemRole?.create;
+
+    case "READ":
+      return granularRole?.read ?? role?.systemRole?.read;
+
+    case "UPDATE":
+      return granularRole?.update ?? role?.systemRole?.update;
+
+    case "DELETE":
+      return granularRole?.delete ?? role?.systemRole?.delete;
+
+    case "PUBLISH":
+      return granularRole?.publish ?? role?.systemRole?.publish;
+
+    case "CODE":
+      return ["Owner", "Admin", "Developer"].includes(role?.systemRole?.name);
+
+    default:
+      return false;
+  }
+}
+
 /**
  * TODO given a specific ZUID, determine whether that user is allowed to do a certain action
  * @param {string} action
@@ -20,54 +58,20 @@ export function usePermission(action, zuid = instanceZUID) {
   const user = useSelector(selectUser);
   const role = useSelector(selectRole);
 
-  // We only want to recalculate the permission inputs change
+  return useMemo(
+    () => hasPermission(user, role, action, zuid),
+    [user, role, action, zuid]
+  );
+}
+
+export function useMultiPermission(action, zuids) {
+  const user = useSelector(selectUser);
+  const role = useSelector(selectRole);
+  const key = zuids?.join("|") || "";
+
   return useMemo(() => {
-    // "With great power comes great responsibility" - Benjamin Franklin Parker
-    if (user.staff) {
-      return true;
-    }
-
-    // Check super
-    // super users are allowed all actions across all resources
-    if (role.systemRole.super) {
-      return true;
-    }
-
-    /*
-      If the user is not a super user, check granular roles.
-      First check specific resource, if not found check instance level.
-      TODO: Check additional granular roles for parent resources depending on resource type (e.g. content model when checking content item)
-    */
-    const granularRole =
-      role?.granularRoles?.find((r) => r.resourceZUID === zuid) ||
-      role?.granularRoles?.find((r) => r.resourceZUID === instanceZUID);
-
-    // Check system
-    switch (action) {
-      case "CREATE":
-        return granularRole?.create ?? role.systemRole.create;
-
-      case "READ":
-        return granularRole?.read ?? role.systemRole.read;
-
-      case "UPDATE":
-        return granularRole?.update ?? role.systemRole.update;
-
-      case "DELETE":
-        return granularRole?.delete ?? role.systemRole.delete;
-
-      case "PUBLISH":
-        return granularRole?.publish ?? role.systemRole.publish;
-
-      // check for specific product access
-      // NOTE this has been bolted on to the action check
-      // this should get refactored at some point to separate these concepts
-      case "CODE":
-        // List of role names with access to code editor
-        return ["Owner", "Admin", "Developer"].includes(role.systemRole.name);
-
-      default:
-        return false;
-    }
-  }, [user, role, action, zuid]);
+    if (!zuids?.length) return true;
+    return zuids.every((zuid) => hasPermission(user, role, action, zuid));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user, role, action, key]);
 }

--- a/src/shell/hooks/use-permissions.js
+++ b/src/shell/hooks/use-permissions.js
@@ -12,11 +12,7 @@ const selectRole = createSelector([getRole], (role) => role);
 
 export function hasPermission(user, role, action, zuid = instanceZUID) {
   // "With great power comes great responsibility" - Benjamin Franklin Parker
-  if (user?.staff) {
-    return true;
-  }
-
-  if (role?.systemRole?.super) {
+  if (user?.staff || role?.systemRole?.super) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

Lifts the single-code-region constraint on Studio layout drag-and-drop so a block can be dragged out of one webview and dropped into another in one gesture, with both files saved sequentially.

- `useLayoutReorderState`: pending state is now keyed by region (`{ regions: Record<codeId, RegionState>, primaryCodeId }`), with a save loop over every affected webview. `mapSourceByLayoutStructure` does a donor-injection pass (pulls a moved block's source from the donor template), a removal pass (drops blocks no longer in the structure), and an anchored re-parent pass that uses `insertBefore` against the first existing layout-id's `previousSibling` so surrounding non-layout content (`<h1>`, Parsley `{{include ...}}` directives, blank lines) keeps its position.
- `StudioWrapper`: `useMultiPermission` gates UPDATE/PUBLISH across every affected codeId; replaced the single-codeId `mappedSource` boolean with a derived `hasPendingLayoutChanges` flag.
- `use-permissions`: extracted `hasPermission` as a non-hook helper and added `useMultiPermission` for AND-across-zuids checks.


