### PR TITLE
Content: Skip og_image fallback when disable_seo_preview is enabled

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/SocialMediaPreview/useImageURL.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/SocialMediaPreview/useImageURL.ts
@@ -2,7 +2,10 @@ import { useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { useLocation, useParams } from "react-router";
 
-import { useGetContentModelFieldsQuery } from "../../../../../../../../shell/services/instance";
+import {
+  useGetContentModelFieldsQuery,
+  useGetInstanceSettingsQuery,
+} from "../../../../../../../../shell/services/instance";
 import { useLazyGetFileQuery } from "../../../../../../../../shell/services/mediaManager";
 import { AppState } from "../../../../../../../../shell/store/types";
 import { fileExtension } from "../../../../../../../media/src/app/utils/fileUtils";
@@ -13,6 +16,10 @@ export const useImageURL: () => string = () => {
     itemZUID: string;
   }>();
   const { data: modelFields } = useGetContentModelFieldsQuery({ modelZUID });
+  const { data: instanceSettings } = useGetInstanceSettingsQuery();
+  const skipImageFallback =
+    instanceSettings?.find((setting) => setting.key === "disable_seo_preview")
+      ?.value === "1";
   const [getFile] = useLazyGetFileQuery();
   const location = useLocation();
   const isCreateItemPage = location?.pathname?.split("/")?.pop() === "new";
@@ -23,7 +30,13 @@ export const useImageURL: () => string = () => {
   const [imageURL, setImageURL] = useState<string>(null);
 
   const contentImages = useMemo(() => {
-    if (!modelFields?.length || !Object.keys(item?.data ?? {})?.length) return;
+    if (
+      skipImageFallback ||
+      !modelFields?.length ||
+      !Object.keys(item?.data ?? {})?.length
+    ) {
+      return;
+    }
 
     const mediaFieldsWithImageOnTheName: string[] = [];
     const otherMediaFields: string[] = [];
@@ -50,7 +63,7 @@ export const useImageURL: () => string = () => {
     });
 
     return [...mediaFieldsWithImageOnTheName, ...otherMediaFields];
-  }, [modelFields, item?.data]);
+  }, [skipImageFallback, modelFields, item?.data]);
 
   useEffect(() => {
     if (!!item?.data?.og_image) {

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/index.tsx
@@ -154,9 +154,6 @@ export const Meta = forwardRef(
       useState<(typeof FlowType)[keyof typeof FlowType]>(null);
     const metaDescriptionButtonRef = useRef(null);
     const metaTitleButtonRef = useRef(null);
-    const showSEOPreview =
-      instanceSettings?.find((setting) => setting.key === "disable_seo_preview")
-        ?.value !== "1" && model?.type !== "dataset";
 
     // @ts-expect-error untyped
     const siteName = useMemo(() => dispatch(fetchGlobalItem())?.site_name, []);
@@ -608,7 +605,14 @@ export const Meta = forwardRef(
               isAIAssistedFlow={flowType === FlowType.AIGenerated}
               required={REQUIRED_FIELDS.includes("metaDescription")}
             />
-            <MetaImage onChange={handleOnChange} />
+            <MetaImage
+              onChange={handleOnChange}
+              skipImageFallback={
+                instanceSettings?.find(
+                  (setting) => setting.key === "disable_seo_preview"
+                )?.value === "1"
+              }
+            />
             {"og_title" in metaFields && (
               <OGTitle
                 value={data.og_title as string}
@@ -735,7 +739,7 @@ export const Meta = forwardRef(
             }}
           >
             <Box maxWidth={620}>
-              {showSEOPreview && (
+              {model?.type !== "dataset" && (
                 <>
                   <SocialMediaPreview />
                   <Divider sx={{ my: 1.5 }} />

--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/MetaImage.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/settings/MetaImage.tsx
@@ -22,8 +22,9 @@ import { fetchFields } from "../../../../../../../../shell/store/fields";
 
 type MetaImageProps = {
   onChange: (value: string, name: string) => void;
+  skipImageFallback?: boolean;
 };
-export const MetaImage = ({ onChange }: MetaImageProps) => {
+export const MetaImage = ({ onChange, skipImageFallback }: MetaImageProps) => {
   const dispatch = useDispatch();
   const location = useLocation();
   const isCreateItemPage = location?.pathname?.split("/")?.pop() === "new";
@@ -60,7 +61,14 @@ export const MetaImage = ({ onChange }: MetaImageProps) => {
     localStorage.getItem("cvrt") && localStorage.getItem("cvad");
 
   const contentImages = useMemo(() => {
-    if (!modelFields?.length || !Object.keys(item?.data ?? {})?.length) return;
+    if (
+      skipImageFallback ||
+      !modelFields?.length ||
+      !Object.keys(item?.data ?? {})?.length
+    ) {
+      return;
+    }
+
     const mediaFieldsWithImageOnTheName: string[] = [];
     const otherMediaFields: string[] = [];
 
@@ -86,7 +94,7 @@ export const MetaImage = ({ onChange }: MetaImageProps) => {
     });
 
     return [...mediaFieldsWithImageOnTheName, ...otherMediaFields];
-  }, [modelFields, item?.data]);
+  }, [skipImageFallback, modelFields, item?.data]);
 
   useEffect(() => {
     if (!contentImages?.length) {


### PR DESCRIPTION
Resolves #3941

## Summary
- When `disable_seo_preview` instance setting is active (`value === "1"`), the Meta Image field on the SEO tab now only shows the value stored in `og_image` — it no longer falls back to scanning other media/image fields on the content model
- The social preview panel (`SocialMediaPreview`) was previously hidden entirely when `disable_seo_preview` was on; it now always renders for non-dataset models regardless of that setting
- `skipImageFallback` prop is threaded from `Meta/index.tsx` → `MetaImage.tsx` and the same guard is applied inside `useImageURL.ts` to keep both components consistent

## Test plan
- [ ] On an instance with `disable_seo_preview = "1"`, open a content item's SEO tab and verify the Meta Image section shows only the `og_image` field value with no fallback image appearing from other media fields
- [ ] Verify the social preview panel renders on non-dataset models even when `disable_seo_preview` is enabled
- [ ] On an instance without `disable_seo_preview` (or set to `"0"`), confirm the fallback behavior is unchanged — other image fields still populate the Meta Image preview as before
- [ ] Verify dataset-type models still do not show the SEO preview panel

## Preview
[Screencast_20260604_120606.webm](https://github.com/user-attachments/assets/bde0dcaa-5633-4510-9801-05e35d2e0ab7)
