### PR TITLE
[Content] - Fix 404 on Take Offline after language switch

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/PublishState.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/PublishState.tsx
@@ -127,10 +127,6 @@ export const PublishState = ({ reloadItem }: Props) => {
         },
       },
     ],
-    // modelZUID/itemZUID must be in deps: when the language is switched the
-    // route params change without remounting this component, so the memoized
-    // renderCell closures would otherwise keep deleting against the previous
-    // locale's itemZUID and get a 404 (issue #4140).
     [modelZUID, itemZUID]
   );
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/PublishState.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/PublishState.tsx
@@ -127,7 +127,11 @@ export const PublishState = ({ reloadItem }: Props) => {
         },
       },
     ],
-    []
+    // modelZUID/itemZUID must be in deps: when the language is switched the
+    // route params change without remounting this component, so the memoized
+    // renderCell closures would otherwise keep deleting against the previous
+    // locale's itemZUID and get a 404 (issue #4140).
+    [modelZUID, itemZUID]
   );
 
   return (


### PR DESCRIPTION
## Problem

Closes #4140

When switching languages on a content item's publishings tab (e.g. AU → NZ), the UI correctly updates to show the new locale's publishing record, but clicking **Take Offline** (or **Cancel**) on the new version fails with a `404 Not Found`. A hard refresh works around it.

## Root cause

`PublishState` renders its DataGrid columns from a `useMemo` with an **empty dependency array**. The `renderCell` closures for the Take Offline / Cancel buttons close over `itemZUID` (from `useParams`).

The language switcher (`LanguageSelector`) preserves the current subpath when navigating, so switching language on `/content/:model/:item/publishings` pushes `/content/:model/:siblingItem/publishings` — the **same** React Router v5 route. React reuses the existing `PublishState` instance and only the route param changes; the component never remounts.

As a result:
- `useGetItemPublishingsQuery` refetches with the new `itemZUID` → grid shows the **new** locale's publishing records (correct `publishingZUID`).
- The memoized column closures still hold the **previous** locale's `itemZUID`.

So Take Offline issued `DELETE /content/models/:model/items/{previousItemZUID}/publishings/{newPublishingZUID}` — a publishing ZUID that doesn't belong to that item → backend 404. This is the "structural mismatch" described in the issue. A hard refresh remounts the component and rebuilds the memo, which is why the workaround succeeds.

## Fix

Key the `columns` memo on `[modelZUID, itemZUID]` so the delete closures always target the active locale's item. `deletePublishing` is a stable RTK Query trigger and `reloadItem` only needs to reflect the current params (which it does whenever the memo rebuilds on a param change), so the memo stays effective and isn't rebuilt on every render.

