### PR TITLE
[Studio] - Add Layers Panel for content and layout modes

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
@@ -34,6 +34,7 @@ import {
 import { StudioHeader } from "./components/StudioWrapper/StudioHeader";
 import { StudioPreview } from "./components/StudioWrapper/StudioPreview";
 import { StudioSidePanel } from "./components/StudioWrapper/StudioSidePanel";
+import { StudioLayersPanel } from "./components/StudioWrapper/StudioLayersPanel";
 import {
   StudioSaveChange,
   StudioSaveChangesModal,
@@ -46,6 +47,7 @@ import {
 import { useStudioBridge } from "./hooks/useStudioBridge";
 import { InteractionMode, LayoutBreadcrumbItem } from "./hooks/studioTypes";
 import { useStudioSelection } from "./hooks/useStudioSelection";
+import { useStudioLayersTree } from "./hooks/useStudioLayersTree";
 import { getRefRegistry } from "../../../../../../engine/refRegistry";
 import { useMultiPermission } from "../../../../../../shell/hooks/use-permissions";
 import { MediaApp } from "../../../../../media/src/app";
@@ -147,6 +149,9 @@ export const StudioWrapper = () => {
       selector?: string;
       layoutId?: string;
       codeId?: string;
+      targetLayoutId?: string;
+      targetCodeId?: string;
+      position?: string;
       isLeafImg?: boolean;
       imgIndex?: number;
       newSrc?: string;
@@ -1100,6 +1105,36 @@ export const StudioWrapper = () => {
     bridgeUpdatedFieldZuidRef.current = fieldZuid;
   }, []);
 
+  const {
+    hasTree: hasLayersTree,
+    flatRows: layersFlatRows,
+    selectedNodeId: selectedLayersNodeId,
+    handleLayersTree,
+    resetTree: resetLayersTree,
+    toggleNode: toggleLayersNode,
+    handleNodeSelect: handleLayersNodeSelect,
+    canDrop: canDropLayersNode,
+    handleNodeDrop: handleLayersNodeDrop,
+  } = useStudioLayersTree({
+    interactionMode,
+    postCommandToBridge,
+    applyBridgeSelection,
+    applyLayoutSelection,
+    codeFileNameById,
+    fieldsState,
+    selectedElement,
+    selectedLayout,
+    dndDisabled: isSavingLayout || isRefreshing,
+  });
+
+  // The tree describes the current document — drop it whenever the iframe
+  // starts reloading or navigating; the fresh page re-emits it on load.
+  useEffect(() => {
+    if (isRefreshing || isNavigating) {
+      resetLayersTree();
+    }
+  }, [isNavigating, isRefreshing, resetLayersTree]);
+
   const { handlePreviewLoad } = useStudioBridge({
     dispatch,
     interactionMode,
@@ -1108,6 +1143,7 @@ export const StudioWrapper = () => {
     handleTemplateSourceMap,
     handleReorderOutput,
     handleLayoutContentUpdate,
+    handleLayersTree,
     applyLayoutSelection,
     clearLayoutSelection,
     applySelection: applyBridgeSelection,
@@ -1226,6 +1262,15 @@ export const StudioWrapper = () => {
             logoSrc={contentOneLogoOnly}
           />
           <Box display="flex" flex="1" minHeight={0} width="100%">
+            <StudioLayersPanel
+              hasTree={hasLayersTree}
+              flatRows={layersFlatRows}
+              selectedNodeId={selectedLayersNodeId}
+              onToggle={toggleLayersNode}
+              onSelect={handleLayersNodeSelect}
+              canDrop={canDropLayersNode}
+              onDrop={handleLayersNodeDrop}
+            />
             <StudioPreview
               iframeRef={iframeRef}
               iframeSrc={iframeSrc}
@@ -1236,6 +1281,7 @@ export const StudioWrapper = () => {
             {interactionMode === "content" ? (
               <StudioSidePanel
                 headerTitle={headerTitle}
+                selectedItemLabel={selectedItemLabel}
                 pageItemVersion={pageItemVersion}
                 unresolvedPath={unresolvedPath}
                 panelMode={panelMode}

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersPanel.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersPanel.tsx
@@ -1,0 +1,190 @@
+import { DragEvent, useCallback, useEffect, useRef, useState } from "react";
+import { Box, Typography } from "@mui/material";
+import { StudioLayersTreeItem } from "./StudioLayersTreeItem";
+import { LayersFlatRow } from "../../hooks/useStudioLayersTree";
+import { LayersDropPosition, LayersTreeNode } from "../../hooks/studioTypes";
+
+// Mirrors the canvas drag behavior: the outer bands of a row mean
+// before/after, the middle means drop inside.
+const EDGE_RATIO = 0.35;
+
+type StudioLayersPanelProps = {
+  hasTree: boolean;
+  flatRows: LayersFlatRow[];
+  selectedNodeId: string | null;
+  onToggle: (nodeId: string) => void;
+  onSelect: (node: LayersTreeNode) => void;
+  canDrop: (
+    sourceId: string,
+    targetId: string,
+    position: LayersDropPosition
+  ) => boolean;
+  onDrop: (
+    sourceId: string,
+    targetId: string,
+    position: LayersDropPosition
+  ) => void;
+};
+
+export const StudioLayersPanel = ({
+  hasTree,
+  flatRows,
+  selectedNodeId,
+  onToggle,
+  onSelect,
+  canDrop,
+  onDrop,
+}: StudioLayersPanelProps) => {
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const dragSourceIdRef = useRef<string | null>(null);
+  const [dropIntent, setDropIntent] = useState<{
+    targetId: string;
+    position: LayersDropPosition;
+  } | null>(null);
+
+  // Keep the canvas selection visible in the tree. Depends on flatRows too so
+  // it retries once the selected row is actually rendered.
+  useEffect(() => {
+    if (!selectedNodeId || !listRef.current) return;
+    const rowEl = listRef.current.querySelector(
+      `[data-node-id="${CSS.escape(selectedNodeId)}"]`
+    );
+    rowEl?.scrollIntoView({ block: "nearest" });
+  }, [selectedNodeId, flatRows]);
+
+  const handleRowDragStart = useCallback(
+    (nodeId: string, evt: DragEvent<HTMLElement>) => {
+      dragSourceIdRef.current = nodeId;
+      evt.stopPropagation();
+      if (evt.dataTransfer) {
+        evt.dataTransfer.effectAllowed = "move";
+        evt.dataTransfer.setData("text/plain", nodeId);
+      }
+    },
+    []
+  );
+
+  const handleRowDragOver = useCallback(
+    (nodeId: string, evt: DragEvent<HTMLElement>) => {
+      const sourceId = dragSourceIdRef.current;
+      if (!sourceId) return;
+
+      const rect = evt.currentTarget.getBoundingClientRect();
+      const topBand = rect.top + rect.height * EDGE_RATIO;
+      const bottomBand = rect.bottom - rect.height * EDGE_RATIO;
+      const position: LayersDropPosition =
+        evt.clientY < topBand
+          ? "before"
+          : evt.clientY > bottomBand
+          ? "after"
+          : "inside";
+
+      if (!canDrop(sourceId, nodeId, position)) {
+        setDropIntent((prev) => (prev?.targetId === nodeId ? null : prev));
+        return;
+      }
+
+      evt.preventDefault();
+      evt.stopPropagation();
+      setDropIntent((prev) =>
+        prev?.targetId === nodeId && prev.position === position
+          ? prev
+          : { targetId: nodeId, position }
+      );
+    },
+    [canDrop]
+  );
+
+  const handleRowDragLeave = useCallback((nodeId: string) => {
+    setDropIntent((prev) => (prev?.targetId === nodeId ? null : prev));
+  }, []);
+
+  const handleRowDrop = useCallback(
+    (nodeId: string, evt: DragEvent<HTMLElement>) => {
+      const sourceId = dragSourceIdRef.current;
+      dragSourceIdRef.current = null;
+      setDropIntent(null);
+      if (!sourceId) return;
+
+      const rect = evt.currentTarget.getBoundingClientRect();
+      const topBand = rect.top + rect.height * EDGE_RATIO;
+      const bottomBand = rect.bottom - rect.height * EDGE_RATIO;
+      const position: LayersDropPosition =
+        evt.clientY < topBand
+          ? "before"
+          : evt.clientY > bottomBand
+          ? "after"
+          : "inside";
+
+      if (!canDrop(sourceId, nodeId, position)) return;
+      evt.preventDefault();
+      onDrop(sourceId, nodeId, position);
+    },
+    [canDrop, onDrop]
+  );
+
+  const handleRowDragEnd = useCallback(() => {
+    dragSourceIdRef.current = null;
+    setDropIntent(null);
+  }, []);
+
+  return (
+    <Box
+      data-cy="StudioLayersPanel"
+      width={220}
+      flexShrink={0}
+      display="flex"
+      flexDirection="column"
+      gap={1.25}
+      boxShadow={2}
+      zIndex={1}
+      sx={{
+        bgcolor: "grey.50",
+        pt: 1.5,
+        pb: 1.5,
+        pl: 1.5,
+        pr: 0.5,
+      }}
+    >
+      <Typography fontWeight={600} fontSize={16} lineHeight="22px">
+        Layers
+      </Typography>
+      <Box
+        ref={listRef}
+        flex={1}
+        minHeight={0}
+        display="flex"
+        flexDirection="column"
+        gap="1px"
+        sx={{ overflowY: "auto", overflowX: "hidden" }}
+      >
+        {/* Render nothing until the first tree arrives so the panel doesn't
+            swap a loading placeholder for the list (avoids layout shift). */}
+        {hasTree && !flatRows.length ? (
+          <Typography fontSize={13} color="text.secondary">
+            No layers found
+          </Typography>
+        ) : (
+          flatRows.map((row) => (
+            <StudioLayersTreeItem
+              key={row.node.id}
+              row={row}
+              dropIntent={
+                dropIntent?.targetId === row.node.id
+                  ? dropIntent.position
+                  : null
+              }
+              onToggle={onToggle}
+              onSelect={onSelect}
+              onRowDragStart={handleRowDragStart}
+              onRowDragOver={handleRowDragOver}
+              onRowDragLeave={handleRowDragLeave}
+              onRowDrop={handleRowDrop}
+              onRowDragEnd={handleRowDragEnd}
+            />
+          ))
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersPanel.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersPanel.tsx
@@ -95,9 +95,16 @@ export const StudioLayersPanel = ({
     [canDrop]
   );
 
-  const handleRowDragLeave = useCallback((nodeId: string) => {
-    setDropIntent((prev) => (prev?.targetId === nodeId ? null : prev));
-  }, []);
+  const handleRowDragLeave = useCallback(
+    (nodeId: string, evt: DragEvent<HTMLElement>) => {
+      // dragleave also fires when the pointer crosses onto a child element of
+      // the row; ignore those so the drop indicator doesn't flicker — only
+      // clear when actually leaving the row.
+      if (evt.currentTarget.contains(evt.relatedTarget as Node)) return;
+      setDropIntent((prev) => (prev?.targetId === nodeId ? null : prev));
+    },
+    []
+  );
 
   const handleRowDrop = useCallback(
     (nodeId: string, evt: DragEvent<HTMLElement>) => {

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersTreeItem.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersTreeItem.tsx
@@ -118,8 +118,10 @@ export const StudioLayersTreeItem = memo(
         alignItems="center"
         gap={1}
         sx={(theme) => ({
-          p: "4px 8px 4px 4px",
-          pl: `${4 + depth * 12}px`,
+          py: 0.5,
+          pr: 1,
+          // Base inset (0.5) plus 1.5 spacing units (12px) per nesting level.
+          pl: 0.5 + depth * 1.5,
           borderRadius: 0.5,
           cursor: row.selectable || hasChildren ? "pointer" : "default",
           bgcolor: selected

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersTreeItem.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersTreeItem.tsx
@@ -76,7 +76,7 @@ type StudioLayersTreeItemProps = {
   onSelect: (node: LayersTreeNode) => void;
   onRowDragStart: (nodeId: string, evt: DragEvent<HTMLElement>) => void;
   onRowDragOver: (nodeId: string, evt: DragEvent<HTMLElement>) => void;
-  onRowDragLeave: (nodeId: string) => void;
+  onRowDragLeave: (nodeId: string, evt: DragEvent<HTMLElement>) => void;
   onRowDrop: (nodeId: string, evt: DragEvent<HTMLElement>) => void;
   onRowDragEnd: () => void;
 };
@@ -111,7 +111,7 @@ export const StudioLayersTreeItem = memo(
         onClick={() => onSelect(node)}
         onDragStart={(evt) => onRowDragStart(node.id, evt)}
         onDragOver={(evt) => onRowDragOver(node.id, evt)}
-        onDragLeave={() => onRowDragLeave(node.id)}
+        onDragLeave={(evt) => onRowDragLeave(node.id, evt)}
         onDrop={(evt) => onRowDrop(node.id, evt)}
         onDragEnd={onRowDragEnd}
         display="flex"

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersTreeItem.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersTreeItem.tsx
@@ -1,0 +1,189 @@
+import { DragEvent, memo } from "react";
+import { Box, Typography } from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import CodeRounded from "@mui/icons-material/CodeRounded";
+import CropSquareRounded from "@mui/icons-material/CropSquareRounded";
+import TitleRounded from "@mui/icons-material/TitleRounded";
+import SubjectRounded from "@mui/icons-material/SubjectRounded";
+import NewspaperRounded from "@mui/icons-material/NewspaperRounded";
+import NotesRounded from "@mui/icons-material/NotesRounded";
+import ImageRounded from "@mui/icons-material/ImageRounded";
+import LinkRounded from "@mui/icons-material/LinkRounded";
+import DocumentScannerRounded from "@mui/icons-material/DocumentScannerRounded";
+import AccountTreeRounded from "@mui/icons-material/AccountTreeRounded";
+import PaymentsRounded from "@mui/icons-material/PaymentsRounded";
+import CalendarTodayRounded from "@mui/icons-material/CalendarTodayRounded";
+import ScheduleRounded from "@mui/icons-material/ScheduleRounded";
+import PinRounded from "@mui/icons-material/PinRounded";
+import NumbersRounded from "@mui/icons-material/NumbersRounded";
+import ToggleOnRounded from "@mui/icons-material/ToggleOnRounded";
+import ColorLensRounded from "@mui/icons-material/ColorLensRounded";
+import FormatListNumberedRounded from "@mui/icons-material/FormatListNumberedRounded";
+import WidgetsRounded from "@mui/icons-material/WidgetsRounded";
+import AutoAwesomeMotionRounded from "@mui/icons-material/AutoAwesomeMotionRounded";
+import KeyboardArrowDownRounded from "@mui/icons-material/KeyboardArrowDownRounded";
+import KeyboardArrowRightRounded from "@mui/icons-material/KeyboardArrowRightRounded";
+import { LayersFlatRow } from "../../hooks/useStudioLayersTree";
+import { LayersDropPosition, LayersTreeNode } from "../../hooks/studioTypes";
+
+type LayersIcon = typeof CodeRounded;
+
+// Dynamic field rows show an icon for their content type, mirroring the
+// "layer icons" set in the Figma design (and the field-type icons used
+// elsewhere in the app). Keyed by Zesty datatype.
+const fieldDatatypeIcons: Record<string, LayersIcon> = {
+  text: TitleRounded,
+  textarea: SubjectRounded,
+  wysiwyg_basic: NewspaperRounded,
+  wysiwyg_advanced: NewspaperRounded,
+  article_writer: NewspaperRounded,
+  markdown: NotesRounded,
+  images: ImageRounded,
+  one_to_one: AccountTreeRounded,
+  one_to_many: AccountTreeRounded,
+  internal_link: DocumentScannerRounded,
+  link: LinkRounded,
+  number: PinRounded,
+  currency: PaymentsRounded,
+  date: CalendarTodayRounded,
+  datetime: ScheduleRounded,
+  yes_no: ToggleOnRounded,
+  dropdown: KeyboardArrowDownRounded,
+  color: ColorLensRounded,
+  sort: FormatListNumberedRounded,
+  uuid: NumbersRounded,
+  block_selector: WidgetsRounded,
+  repeater: AutoAwesomeMotionRounded,
+};
+
+const getNodeIcon = (node: LayersTreeNode): LayersIcon => {
+  if (node.kind === "codeFile") return CodeRounded;
+  // HTML elements are containers; static text keeps the plain text icon.
+  if (node.kind === "element") return CropSquareRounded;
+  if (node.kind === "field") {
+    // A dynamic <img> src reads as media regardless of the underlying field's
+    // datatype (it's often a plain text field reused as the source).
+    if (node.hostTag === "img" && node.attr === "src") return ImageRounded;
+    return fieldDatatypeIcons[node.fieldType || ""] || TitleRounded;
+  }
+  return TitleRounded;
+};
+
+type StudioLayersTreeItemProps = {
+  row: LayersFlatRow;
+  dropIntent: LayersDropPosition | null;
+  onToggle: (nodeId: string) => void;
+  onSelect: (node: LayersTreeNode) => void;
+  onRowDragStart: (nodeId: string, evt: DragEvent<HTMLElement>) => void;
+  onRowDragOver: (nodeId: string, evt: DragEvent<HTMLElement>) => void;
+  onRowDragLeave: (nodeId: string) => void;
+  onRowDrop: (nodeId: string, evt: DragEvent<HTMLElement>) => void;
+  onRowDragEnd: () => void;
+};
+
+export const StudioLayersTreeItem = memo(
+  ({
+    row,
+    dropIntent,
+    onToggle,
+    onSelect,
+    onRowDragStart,
+    onRowDragOver,
+    onRowDragLeave,
+    onRowDrop,
+    onRowDragEnd,
+  }: StudioLayersTreeItemProps) => {
+    const { node, depth, label, hasChildren, expanded, selected } = row;
+    const TypeIcon = getNodeIcon(node);
+    const dimmed = !row.selectable;
+    // Dynamic content gets the orange treatment (icon + bolt) so it stands out
+    // against the static structure.
+    const isDynamic = node.kind === "field";
+    const Chevron = expanded
+      ? KeyboardArrowDownRounded
+      : KeyboardArrowRightRounded;
+
+    return (
+      <Box
+        data-cy="StudioLayersRow"
+        data-node-id={node.id}
+        draggable={row.draggable || undefined}
+        onClick={() => onSelect(node)}
+        onDragStart={(evt) => onRowDragStart(node.id, evt)}
+        onDragOver={(evt) => onRowDragOver(node.id, evt)}
+        onDragLeave={() => onRowDragLeave(node.id)}
+        onDrop={(evt) => onRowDrop(node.id, evt)}
+        onDragEnd={onRowDragEnd}
+        display="flex"
+        alignItems="center"
+        gap={1}
+        sx={(theme) => ({
+          p: "4px 8px 4px 4px",
+          pl: `${4 + depth * 12}px`,
+          borderRadius: 0.5,
+          cursor: row.selectable || hasChildren ? "pointer" : "default",
+          bgcolor: selected
+            ? alpha(theme.palette.primary.main, 0.08)
+            : "transparent",
+          "&:hover": {
+            bgcolor: selected
+              ? alpha(theme.palette.primary.main, 0.08)
+              : "action.hover",
+          },
+          ...(dropIntent === "before" && {
+            boxShadow: `inset 0 2px 0 ${theme.palette.primary.main}`,
+          }),
+          ...(dropIntent === "after" && {
+            boxShadow: `inset 0 -2px 0 ${theme.palette.primary.main}`,
+          }),
+          ...(dropIntent === "inside" && {
+            outline: `1px dashed ${theme.palette.primary.main}`,
+            outlineOffset: "-1px",
+            bgcolor: alpha(theme.palette.primary.main, 0.08),
+          }),
+        })}
+      >
+        <Box
+          width={16}
+          height={16}
+          flexShrink={0}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          data-cy="StudioLayersRowChevron"
+          onClick={(evt) => {
+            if (!hasChildren) return;
+            evt.stopPropagation();
+            onToggle(node.id);
+          }}
+        >
+          {hasChildren && (
+            <Chevron sx={{ fontSize: 16, color: "action.active" }} />
+          )}
+        </Box>
+        <TypeIcon
+          sx={{
+            fontSize: 16,
+            flexShrink: 0,
+            color: isDynamic
+              ? "primary.main"
+              : dimmed
+              ? "action.disabled"
+              : "action.active",
+          }}
+        />
+        <Typography
+          noWrap
+          flex={1}
+          minWidth={0}
+          fontSize={13}
+          lineHeight="18px"
+          color={dimmed ? "text.secondary" : "text.primary"}
+        >
+          {label}
+        </Typography>
+        {/* Link indicator intentionally hidden until linking UX ships */}
+      </Box>
+    );
+  }
+);

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioSidePanel.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioSidePanel.tsx
@@ -14,6 +14,7 @@ import { VersionSelector } from "../ItemEditHeader/VersionSelector";
 
 type StudioSidePanelProps = {
   headerTitle: string;
+  selectedItemLabel: string;
   pageItemVersion: number | null;
   unresolvedPath: boolean;
   panelMode: "info" | "edit";
@@ -34,6 +35,7 @@ type StudioSidePanelProps = {
 
 export const StudioSidePanel = ({
   headerTitle,
+  selectedItemLabel,
   pageItemVersion,
   unresolvedPath,
   panelMode,
@@ -76,9 +78,13 @@ export const StudioSidePanel = ({
         <Stack>
           <Stack direction="row" alignItems="center" gap={1}>
             <Typography variant="subtitle1" fontWeight="600">
-              {headerTitle}
+              {panelMode === "edit" ? selectedItemLabel : headerTitle}
             </Typography>
-            {pageItemVersion !== null && !unresolvedPath ? (
+            {/* In edit mode the VersionSelector below already shows the
+                selected item's version, so the static label is info-mode only. */}
+            {panelMode !== "edit" &&
+            pageItemVersion !== null &&
+            !unresolvedPath ? (
               <Typography variant="body2" color="text.secondary">
                 v{pageItemVersion}
               </Typography>

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/studioTypes.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/studioTypes.ts
@@ -18,3 +18,32 @@ export type LayoutSelection = {
 };
 
 export type InteractionMode = "content" | "layout";
+
+// "element" = an HTML element (collapsible container). "field" = dynamic
+// content (a studio field marker) rendered as a text row with a bolt.
+// "text" = static text content rendered as a text row.
+export type LayersTreeNodeKind = "codeFile" | "element" | "field" | "text";
+
+export type LayersTreeNode = {
+  id: string;
+  kind: LayersTreeNodeKind;
+  tagName: string | null;
+  codeId: string | null;
+  layoutId: string | null;
+  studioId?: string;
+  fieldZuid?: string;
+  fieldType?: string;
+  itemZuid?: string;
+  modelZuid?: string;
+  // Set when a "field" binds an element attribute (e.g. an <img> src) rather
+  // than inline text. `attr` is the bound attribute, `hostTag` the element it
+  // sits on — used to pick a content-appropriate icon.
+  attr?: string;
+  hostTag?: string;
+  // Rendered content text for "field" / "text" nodes (the bridge resolves
+  // dynamic markers to their actual value).
+  label?: string;
+  children: LayersTreeNode[];
+};
+
+export type LayersDropPosition = "before" | "after" | "inside";

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioBridge.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioBridge.ts
@@ -70,6 +70,7 @@ type Args = {
   handleTemplateSourceMap: (msg: any) => void;
   handleReorderOutput: (msg: any) => void;
   handleLayoutContentUpdate: (msg: any) => void;
+  handleLayersTree: (msg: any) => void;
   applyLayoutSelection: (next: {
     codeId?: string;
     layoutId?: string;
@@ -106,6 +107,7 @@ export const useStudioBridge = ({
   handleTemplateSourceMap,
   handleReorderOutput,
   handleLayoutContentUpdate,
+  handleLayersTree,
   applyLayoutSelection,
   clearLayoutSelection,
   applySelection,
@@ -123,6 +125,7 @@ export const useStudioBridge = ({
       css: bridgeInjectedCss,
     });
     syncBridgeInteractionMode(interactionMode);
+    postCommandToBridge({ action: "requestLayersTree" });
   }, [interactionMode, postCommandToBridge, syncBridgeInteractionMode]);
 
   const handleBridgeError = useCallback(
@@ -305,6 +308,11 @@ export const useStudioBridge = ({
         return;
       }
 
+      if (msg.type === "LAYERS_TREE") {
+        handleLayersTree(msg);
+        return;
+      }
+
       if (msg.type === "STATIC_EDIT_REJECTED") {
         dispatch(
           notify({
@@ -331,6 +339,7 @@ export const useStudioBridge = ({
     handleBridgeDomEvent,
     handleBridgeError,
     handleBridgeReady,
+    handleLayersTree,
     handleLayoutContentUpdate,
     handleReorderOutput,
     handleTemplateSourceMap,

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioLayersTree.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioLayersTree.ts
@@ -1,0 +1,385 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  InteractionMode,
+  LayersDropPosition,
+  LayersTreeNode,
+  LayoutSelection,
+  SelectedElement,
+} from "./studioTypes";
+
+export type LayersFlatRow = {
+  node: LayersTreeNode;
+  depth: number;
+  label: string;
+  hasChildren: boolean;
+  expanded: boolean;
+  selected: boolean;
+  selectable: boolean;
+  draggable: boolean;
+};
+
+// Tags that can never receive children — mirrors the bridge's void-element
+// guard so invalid "inside" drops are rejected before a command is posted.
+const VOID_ELEMENT_TAGS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
+const isLayersTreeNode = (node: any): node is LayersTreeNode =>
+  !!node &&
+  typeof node === "object" &&
+  typeof node.id === "string" &&
+  typeof node.kind === "string" &&
+  Array.isArray(node.children);
+
+type Args = {
+  interactionMode: InteractionMode;
+  postCommandToBridge: (cmd: any) => void;
+  applyBridgeSelection: (next: {
+    studioId?: string;
+    fieldZuid: string;
+    fieldType?: string;
+    itemZuid?: string;
+    modelZuid?: string;
+  }) => void;
+  applyLayoutSelection: (next: {
+    codeId?: string;
+    layoutId?: string;
+    breadcrumb?: { layoutId?: string; label: string }[];
+  }) => void;
+  codeFileNameById: Record<string, string>;
+  fieldsState: Record<string, any>;
+  selectedElement: SelectedElement | null;
+  selectedLayout: LayoutSelection | null;
+  dndDisabled: boolean;
+};
+
+export const useStudioLayersTree = ({
+  interactionMode,
+  postCommandToBridge,
+  applyBridgeSelection,
+  applyLayoutSelection,
+  codeFileNameById,
+  fieldsState,
+  selectedElement,
+  selectedLayout,
+  dndDisabled,
+}: Args) => {
+  const [tree, setTree] = useState<LayersTreeNode[] | null>(null);
+  // Everything is expanded by default; we only track what the user explicitly
+  // collapses, so nodes that appear on later re-emits start open too.
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
+
+  const handleLayersTree = useCallback((msg: any) => {
+    const nextTree: LayersTreeNode[] = Array.isArray(msg?.tree)
+      ? msg.tree.filter(isLayersTreeNode)
+      : [];
+    setTree(nextTree);
+  }, []);
+
+  const resetTree = useCallback(() => {
+    setTree(null);
+    setCollapsedIds(new Set());
+  }, []);
+
+  const { nodeById, parentById } = useMemo(() => {
+    const byId = new Map<string, LayersTreeNode>();
+    const parents = new Map<string, LayersTreeNode | null>();
+    const index = (nodes: LayersTreeNode[], parent: LayersTreeNode | null) => {
+      nodes.forEach((node) => {
+        byId.set(node.id, node);
+        parents.set(node.id, parent);
+        index(node.children, node);
+      });
+    };
+    index(tree || [], null);
+    return { nodeById: byId, parentById: parents };
+  }, [tree]);
+
+  const selectedNodeId = useMemo(() => {
+    if (interactionMode === "layout") {
+      if (!selectedLayout?.layoutId) return null;
+      for (const node of nodeById.values()) {
+        if (
+          node.kind === "element" &&
+          node.layoutId === selectedLayout.layoutId &&
+          node.codeId === selectedLayout.codeId
+        ) {
+          return node.id;
+        }
+      }
+      return null;
+    }
+
+    if (!selectedElement?.fieldZuid) return null;
+    let fallbackId: string | null = null;
+    for (const node of nodeById.values()) {
+      if (node.kind !== "field") continue;
+      if (
+        selectedElement.studioId &&
+        node.studioId === selectedElement.studioId
+      ) {
+        return node.id;
+      }
+      if (
+        !fallbackId &&
+        node.fieldZuid === selectedElement.fieldZuid &&
+        (!selectedElement.itemZuid ||
+          node.itemZuid === selectedElement.itemZuid)
+      ) {
+        fallbackId = node.id;
+      }
+    }
+    return fallbackId;
+  }, [interactionMode, nodeById, selectedElement, selectedLayout]);
+
+  const toggleNode = useCallback((nodeId: string) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(nodeId)) {
+        next.delete(nodeId);
+      } else {
+        next.add(nodeId);
+      }
+      return next;
+    });
+  }, []);
+
+  const getRowLabel = useCallback(
+    (node: LayersTreeNode): string => {
+      if (node.kind === "codeFile") {
+        return node.codeId
+          ? codeFileNameById[node.codeId] || node.codeId
+          : "Page";
+      }
+      if (node.kind === "element") {
+        return node.tagName || "element";
+      }
+      if (node.kind === "field") {
+        // Dynamic content is labeled by its field name, not its value.
+        const field = node.fieldZuid ? fieldsState[node.fieldZuid] : null;
+        return field?.label || field?.name || node.fieldType || "Field";
+      }
+      // Static text shows its actual content.
+      return node.label || "";
+    },
+    [codeFileNameById, fieldsState]
+  );
+
+  const isNodeSelectable = useCallback(
+    (node: LayersTreeNode) => {
+      if (interactionMode === "layout") {
+        // Elements select on the canvas; static text rows are clickable to
+        // enter inline static editing on their enclosing element.
+        if (node.kind === "element") return !!node.layoutId && !!node.codeId;
+        return node.kind === "text";
+      }
+      return node.kind === "field" && !!node.fieldZuid;
+    },
+    [interactionMode]
+  );
+
+  const flatRows = useMemo<LayersFlatRow[]>(() => {
+    const rows: LayersFlatRow[] = [];
+    const visit = (nodes: LayersTreeNode[], depth: number) => {
+      nodes.forEach((node) => {
+        const hasChildren = node.children.length > 0;
+        const expanded = !collapsedIds.has(node.id);
+        rows.push({
+          node,
+          depth,
+          label: getRowLabel(node),
+          hasChildren,
+          expanded,
+          selected: node.id === selectedNodeId,
+          selectable: isNodeSelectable(node),
+          draggable:
+            !dndDisabled &&
+            interactionMode === "layout" &&
+            node.kind === "element" &&
+            !!node.layoutId &&
+            !!node.codeId,
+        });
+        if (hasChildren && expanded) {
+          visit(node.children, depth + 1);
+        }
+      });
+    };
+    visit(tree || [], 0);
+    return rows;
+  }, [
+    dndDisabled,
+    collapsedIds,
+    getRowLabel,
+    interactionMode,
+    isNodeSelectable,
+    selectedNodeId,
+    tree,
+  ]);
+
+  // Select a layout element on the canvas, building the breadcrumb from tree
+  // ancestors so it matches a canvas click (header breadcrumb + bridge state).
+  const selectLayoutElement = useCallback(
+    (node: LayersTreeNode) => {
+      const breadcrumb: { layoutId?: string; label: string }[] = [
+        { layoutId: node.layoutId!, label: node.tagName || "element" },
+      ];
+      let parent = parentById.get(node.id) || null;
+      while (parent) {
+        if (parent.kind === "element" && parent.layoutId) {
+          breadcrumb.unshift({
+            layoutId: parent.layoutId,
+            label: parent.tagName || "element",
+          });
+        }
+        parent = parentById.get(parent.id) || null;
+      }
+
+      applyLayoutSelection({
+        codeId: node.codeId!,
+        layoutId: node.layoutId!,
+        breadcrumb,
+      });
+      postCommandToBridge({
+        action: "setSelectedLayoutId",
+        codeId: node.codeId!,
+        layoutId: node.layoutId!,
+      });
+    },
+    [applyLayoutSelection, parentById, postCommandToBridge]
+  );
+
+  const handleNodeSelect = useCallback(
+    (node: LayersTreeNode) => {
+      // Static content in layout mode → enter inline static editing on the
+      // nearest enclosing element (mirrors double-clicking it on the canvas).
+      if (interactionMode === "layout" && node.kind === "text") {
+        let host = parentById.get(node.id) || null;
+        while (
+          host &&
+          !(host.kind === "element" && host.layoutId && host.codeId)
+        ) {
+          host = parentById.get(host.id) || null;
+        }
+        if (!host) return;
+        selectLayoutElement(host);
+        postCommandToBridge({
+          action: "enterStaticEditingByLayoutId",
+          codeId: host.codeId!,
+          layoutId: host.layoutId!,
+        });
+        return;
+      }
+
+      if (!isNodeSelectable(node)) {
+        if (node.children.length) toggleNode(node.id);
+        return;
+      }
+
+      if (interactionMode === "layout") {
+        selectLayoutElement(node);
+        return;
+      }
+
+      applyBridgeSelection({
+        studioId: node.studioId,
+        fieldZuid: node.fieldZuid!,
+        fieldType: node.fieldType,
+        itemZuid: node.itemZuid,
+        modelZuid: node.modelZuid,
+      });
+    },
+    [
+      applyBridgeSelection,
+      interactionMode,
+      isNodeSelectable,
+      parentById,
+      postCommandToBridge,
+      selectLayoutElement,
+      toggleNode,
+    ]
+  );
+
+  const canDrop = useCallback(
+    (
+      sourceId: string,
+      targetId: string,
+      position: LayersDropPosition
+    ): boolean => {
+      if (dndDisabled || interactionMode !== "layout") return false;
+      const source = nodeById.get(sourceId);
+      const target = nodeById.get(targetId);
+      if (!source || !target || source === target) return false;
+      if (source.kind !== "element" || target.kind !== "element") return false;
+      if (!source.layoutId || !source.codeId || !target.layoutId) return false;
+      // Reordering relative to a target keeps it in its parent; dropping
+      // before/after a region root would move the element outside its code
+      // region, so require a codeId on the target either way.
+      if (!target.codeId) return false;
+
+      // A node can't be dropped into its own subtree.
+      let parent = parentById.get(targetId) || null;
+      while (parent) {
+        if (parent.id === sourceId) return false;
+        parent = parentById.get(parent.id) || null;
+      }
+
+      if (
+        position === "inside" &&
+        target.tagName &&
+        VOID_ELEMENT_TAGS.has(target.tagName)
+      ) {
+        return false;
+      }
+
+      return true;
+    },
+    [dndDisabled, interactionMode, nodeById, parentById]
+  );
+
+  const handleNodeDrop = useCallback(
+    (sourceId: string, targetId: string, position: LayersDropPosition) => {
+      if (!canDrop(sourceId, targetId, position)) return;
+      const source = nodeById.get(sourceId)!;
+      const target = nodeById.get(targetId)!;
+
+      // Select the dragged element first — canvas drags require selection,
+      // and the reorder pipeline re-roots the current selection's breadcrumb.
+      handleNodeSelect(source);
+
+      postCommandToBridge({
+        action: "moveLayoutElement",
+        layoutId: source.layoutId,
+        codeId: source.codeId,
+        targetLayoutId: target.layoutId,
+        targetCodeId: target.codeId,
+        position,
+      });
+    },
+    [canDrop, handleNodeSelect, nodeById, postCommandToBridge]
+  );
+
+  return {
+    hasTree: tree !== null,
+    flatRows,
+    selectedNodeId,
+    handleLayersTree,
+    resetTree,
+    toggleNode,
+    handleNodeSelect,
+    canDrop,
+    handleNodeDrop,
+  };
+};

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioLayersTree.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioLayersTree.ts
@@ -127,9 +127,13 @@ export const useStudioLayersTree = ({
     let fallbackId: string | null = null;
     for (const node of nodeById.values()) {
       if (node.kind !== "field") continue;
+      // Match studioId AND fieldZuid: one element can bind several attributes
+      // (e.g. img src + alt) under a single studioId, so studioId alone is
+      // ambiguous — the fieldZuid disambiguates which binding is selected.
       if (
         selectedElement.studioId &&
-        node.studioId === selectedElement.studioId
+        node.studioId === selectedElement.studioId &&
+        node.fieldZuid === selectedElement.fieldZuid
       ) {
         return node.id;
       }


### PR DESCRIPTION
## Summary

Adds a **Layers Panel** to Studio — a left-hand tree of the page's element hierarchy, built from the WebEngine bridge's `LAYERS_TREE` message.

- **Content mode:** dynamic field rows (icon by datatype) select for editing; static text and structural containers shown for context.
- **Layout mode:** element rows select on the canvas and drag-reorder; static text rows trigger the existing inline static-editing flow on their parent element.
- **Attribute-bound dynamic content** (e.g. an `<img>` `src`) is surfaced as a content row, with an image icon for img-src bindings.
- Two-way selection sync with the canvas; tree expanded by default.
- Also fixes the side-panel header showing the **page item's** title/version instead of the **selected item's** when one is selected.

## Notes for reviewers

- **Stacked on #4149** (`studio/staged-multi-edit-saves`) — base is that branch so the diff is scoped to the Layers Panel work. GitHub will retarget to `dev` once #4149 merges.
- **`Bridge.js` is intentionally excluded.** The WebEngine bridge runs inside the cross-origin preview iframe and is deployed separately to GCS (`instudio-dev`), not bundled by manager-ui. The host communicates with it only via `postMessage` commands (`LAYERS_TREE`, `moveLayoutElement`, `enterStaticEditingByLayoutId`, etc.). Those bridge changes are already deployed.

## Verification

- Verified end-to-end against a live instance: tree renders (code files, containers, static text, dynamic fields, img-src bindings); content-mode field selection opens the editor; layout-mode element selection sets the breadcrumb + canvas outline; static-row click enters inline editing; selecting another element cleanly exits static editing (no double-highlight).
- `tsc --noEmit` and Prettier clean.
- Reviewed via the repo's auto-reviewer focus areas (quality / bugs / security / performance) — no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
