### PR TITLE
Cypress: stabilize flaky e2e suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,16 +34,16 @@ jobs:
       - name: Delete Old Screenshots
         run: gsutil rm gs://cypress_screenshots/* || true
 
-  # 5 parallel jobs: runners 0-3 split the non-global specs (SPLIT=4); runner 4
-  # runs the global-state specs (publish/labels/redirects) serially to avoid
-  # cross-runner interference. cypress-split distributes by SPLIT/SPLIT_INDEX.
+  # Single serial runner — whole suite on one runner, no intra-run parallelism.
+  # The shared dev instance 502s under concurrent runner load; serial removes that
+  # variable. (matrix kept at [0] so the coverage/timings/marker steps still work.)
   run_tests:
     needs: setup
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # Don't cancel other runners if one fails
+      fail-fast: false
       matrix:
-        split_index: [0, 1, 2, 3, 4]
+        split_index: [0]
 
     steps:
       - name: Checkout Repo
@@ -66,26 +66,15 @@ jobs:
           project_id: zesty-dev
       - name: Setup Testing Environment
         run: npm run ci:test:setup
+      # Whole suite on one runner (SPLIT=1), serially — no SKIP_SPEC/SPEC needed.
       - name: Run Tests
-        if: matrix.split_index != 4
-        run: npm run ci
-        env:
-          CYPRESS_COVERAGE: "true"
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SPLIT: 4
-          SPLIT_INDEX: ${{ matrix.split_index }}
-          SPLIT_FILE: timings.json
-          SKIP_SPEC: "cypress/e2e/content/actions.spec.js,cypress/e2e/content/list.spec.js,cypress/e2e/content/redirects.spec.js,cypress/e2e/content/workflows.spec.js,cypress/e2e/settings/workflows.spec.js,cypress/e2e/seo/redirects/redirects.spec.js"
-      # Runner 4: global-state specs run serially to avoid cross-runner interference.
-      - name: Run Tests
-        if: matrix.split_index == 4
         run: npm run ci
         env:
           CYPRESS_COVERAGE: "true"
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SPLIT: 1
           SPLIT_INDEX: 0
-          SPEC: "cypress/e2e/content/actions.spec.js,cypress/e2e/content/list.spec.js,cypress/e2e/content/redirects.spec.js,cypress/e2e/content/workflows.spec.js,cypress/e2e/settings/workflows.spec.js,cypress/e2e/seo/redirects/redirects.spec.js"
+          SPLIT_FILE: timings.json
       # Rename so artifacts from each runner have unique filenames and don't overwrite each other.
       - name: Rename Coverage Output
         if: ${{ success() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: [dev, beta, stable, master]
 
+# Serialize all e2e CI across PRs — they share one dev instance and concurrent
+# runs overload it (502s/timeouts). Constant group = one run at a time;
+# cancel-in-progress: false lets the active run finish (newer runs queue).
+concurrency:
+  group: manager-ui-e2e-dev-instance
+  cancel-in-progress: false
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -27,10 +34,9 @@ jobs:
       - name: Delete Old Screenshots
         run: gsutil rm gs://cypress_screenshots/* || true
 
-  # Runs 5 parallel jobs. Runners 0-3 split the non-publish specs evenly (SPLIT=4).
-  # Runner 4 is dedicated to publish-related specs to avoid cross-runner interference.
-  # cypress-split distributes specs based on SPLIT and SPLIT_INDEX.
-  # Repo: https://github.com/bahmutov/cypress-split
+  # 5 parallel jobs: runners 0-3 split the non-global specs (SPLIT=4); runner 4
+  # runs the global-state specs (publish/labels/redirects) serially to avoid
+  # cross-runner interference. cypress-split distributes by SPLIT/SPLIT_INDEX.
   run_tests:
     needs: setup
     runs-on: ubuntu-latest
@@ -69,10 +75,8 @@ jobs:
           SPLIT: 4
           SPLIT_INDEX: ${{ matrix.split_index }}
           SPLIT_FILE: timings.json
-          SKIP_SPEC: "cypress/e2e/content/actions.spec.js,cypress/e2e/content/list.spec.js,cypress/e2e/content/redirects.spec.js,cypress/e2e/content/workflows.spec.js,cypress/e2e/settings/workflows.spec.js"
-      # Runner 4 runs all publish-related specs together so that workflows.spec.js
-      # (which creates a publish-blocking workflow label) and the publish action specs
-      # run sequentially on the same runner, avoiding cross-runner interference.
+          SKIP_SPEC: "cypress/e2e/content/actions.spec.js,cypress/e2e/content/list.spec.js,cypress/e2e/content/redirects.spec.js,cypress/e2e/content/workflows.spec.js,cypress/e2e/settings/workflows.spec.js,cypress/e2e/seo/redirects/redirects.spec.js"
+      # Runner 4: global-state specs run serially to avoid cross-runner interference.
       - name: Run Tests
         if: matrix.split_index == 4
         run: npm run ci
@@ -81,7 +85,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SPLIT: 1
           SPLIT_INDEX: 0
-          SPEC: "cypress/e2e/content/actions.spec.js,cypress/e2e/content/list.spec.js,cypress/e2e/content/redirects.spec.js,cypress/e2e/content/workflows.spec.js,cypress/e2e/settings/workflows.spec.js"
+          SPEC: "cypress/e2e/content/actions.spec.js,cypress/e2e/content/list.spec.js,cypress/e2e/content/redirects.spec.js,cypress/e2e/content/workflows.spec.js,cypress/e2e/settings/workflows.spec.js,cypress/e2e/seo/redirects/redirects.spec.js"
       # Rename so artifacts from each runner have unique filenames and don't overwrite each other.
       - name: Rename Coverage Output
         if: ${{ success() }}
@@ -107,6 +111,21 @@ jobs:
       - name: Upload Screenshots
         if: ${{ failure() }}
         run: ./ci/scripts/upload_debug_screenshots_to_gcp.sh
+      # Backend-attribution markers (from e2e.js), uploaded per runner for backend_health.
+      - name: Rename Backend Markers
+        if: always()
+        run: |
+          if [ -f results/backend-5xx.jsonl ]; then
+            mkdir -p backend-markers
+            cp results/backend-5xx.jsonl backend-markers/backend-5xx-${{ matrix.split_index }}.jsonl
+          fi
+      - name: Upload Backend Markers
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-markers-${{ matrix.split_index }}
+          path: backend-markers/
+          if-no-files-found: ignore
 
   # Aggregates all matrix runner results into a single status check.
   # Branch protection should require this job, not run_tests, because matrix jobs
@@ -121,6 +140,36 @@ jobs:
           if [ "${{ needs.run_tests.result }}" != "success" ]; then
             echo "One or more test runners failed or were cancelled"
             exit 1
+          fi
+
+  # On failure, flag (in this run's summary) whether it was backend-caused
+  # (5xx/timeouts) so you can tell at a glance whether to just re-run.
+  backend_health:
+    needs: run_tests
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.run_tests.result != 'success' }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4.1.0
+        with:
+          node-version: "22.19.0"
+      - name: Download Backend Markers
+        uses: actions/download-artifact@v4
+        with:
+          pattern: backend-markers-*
+          path: backend-markers
+          merge-multiple: true
+      - name: Backend-Health Verdict (run summary)
+        run: |
+          node ci/scripts/backend_health.js backend-markers > backend-health.md || true
+          if [ -s backend-health.md ]; then
+            cat backend-health.md >> "$GITHUB_STEP_SUMMARY"
+            # Also echo to the step log so it's visible without opening the summary tab.
+            echo "::warning::Backend-caused failures detected this run — likely a backend issue, re-run. See run summary."
+          else
+            echo "✅ No backend-attributed failures — this CI failure looks like a real test/app issue, not backend instability." >> "$GITHUB_STEP_SUMMARY"
           fi
 
   # Merges partial timings.json from each runner into a single file and uploads it as an artifact.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,16 +34,19 @@ jobs:
       - name: Delete Old Screenshots
         run: gsutil rm gs://cypress_screenshots/* || true
 
-  # Single serial runner — whole suite on one runner, no intra-run parallelism.
-  # The shared dev instance 502s under concurrent runner load; serial removes that
-  # variable. (matrix kept at [0] so the coverage/timings/marker steps still work.)
+  # Suite split into 5 parts, run SEQUENTIALLY (max-parallel: 1): only one part
+  # hits the dev instance at a time (minimal load), and each part is a separate,
+  # independently re-runnable job. When dev drops mid-run, only the in-flight part
+  # fails — use "Re-run failed jobs" to redo just that part, not the whole suite.
+  # Runners 0-3 split the non-global specs (SPLIT=4); runner 4 = global-state specs.
   run_tests:
     needs: setup
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
-        split_index: [0]
+        split_index: [0, 1, 2, 3, 4]
 
     steps:
       - name: Checkout Repo
@@ -66,15 +69,26 @@ jobs:
           project_id: zesty-dev
       - name: Setup Testing Environment
         run: npm run ci:test:setup
-      # Whole suite on one runner (SPLIT=1), serially — no SKIP_SPEC/SPEC needed.
       - name: Run Tests
+        if: matrix.split_index != 4
+        run: npm run ci
+        env:
+          CYPRESS_COVERAGE: "true"
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SPLIT: 4
+          SPLIT_INDEX: ${{ matrix.split_index }}
+          SPLIT_FILE: timings.json
+          SKIP_SPEC: "cypress/e2e/content/actions.spec.js,cypress/e2e/content/list.spec.js,cypress/e2e/content/redirects.spec.js,cypress/e2e/content/workflows.spec.js,cypress/e2e/settings/workflows.spec.js,cypress/e2e/seo/redirects/redirects.spec.js"
+      # Runner 4: global-state specs (publish/labels/redirects) as one re-runnable unit.
+      - name: Run Tests
+        if: matrix.split_index == 4
         run: npm run ci
         env:
           CYPRESS_COVERAGE: "true"
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SPLIT: 1
           SPLIT_INDEX: 0
-          SPLIT_FILE: timings.json
+          SPEC: "cypress/e2e/content/actions.spec.js,cypress/e2e/content/list.spec.js,cypress/e2e/content/redirects.spec.js,cypress/e2e/content/workflows.spec.js,cypress/e2e/settings/workflows.spec.js,cypress/e2e/seo/redirects/redirects.spec.js"
       # Rename so artifacts from each runner have unique filenames and don't overwrite each other.
       - name: Rename Coverage Output
         if: ${{ success() }}

--- a/ci/scripts/backend_health.js
+++ b/ci/scripts/backend_health.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/*
+ * Reads backend-5xx markers (from cypress/support/e2e.js) and prints a Markdown
+ * banner if any failures were backend-caused; prints nothing otherwise.
+ * Usage: node ci/scripts/backend_health.js <markers-dir>
+ */
+const fs = require("fs");
+const path = require("path");
+
+const root = process.argv[2] || "backend-markers";
+
+function findJsonl(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...findJsonl(full));
+    else if (e.isFile() && e.name.endsWith(".jsonl")) out.push(full);
+  }
+  return out;
+}
+
+const byTest = new Map();
+const specs = new Set();
+
+for (const file of findJsonl(root)) {
+  let text;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    continue;
+  }
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    let e;
+    try {
+      e = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const spec = (e.spec || "").replace(/^.*cypress\/e2e\//, "cypress/e2e/");
+    const key = `${spec} :: ${e.test}`;
+    const rec =
+      byTest.get(key) || { reasons: new Set(), statuses: new Set(), urls: new Set(), err: "" };
+    if (e.reason) rec.reasons.add(e.reason);
+    for (const r of e.responses || []) {
+      if (r.status) rec.statuses.add(r.status);
+      if (r.url) rec.urls.add(String(r.url).replace(/\?.*$/, ""));
+    }
+    if (e.errorSnippet && !rec.err) rec.err = e.errorSnippet;
+    byTest.set(key, rec);
+    specs.add(spec);
+  }
+}
+
+if (byTest.size === 0) {
+  // No backend-attributed failures — say nothing (real failure or green run).
+  process.exit(0);
+}
+
+const lines = [];
+lines.push("<!-- backend-health -->");
+lines.push("## 🚑 Backend-caused failures detected");
+lines.push("");
+lines.push(
+  `**${byTest.size}** test failure(s) across **${specs.size}** spec(s) coincided with backend ` +
+    `errors (**5xx / timeouts**). This run was most likely hit by **dev-instance instability**, ` +
+    `not test or app bugs — **escalate to the backend team and re-run** before triaging these specs.`
+);
+lines.push("");
+lines.push("| Test | Reason | Status / detail |");
+lines.push("| --- | --- | --- |");
+for (const [key, rec] of [...byTest.entries()].slice(0, 50)) {
+  const detail =
+    [...rec.statuses].join(", ") ||
+    (rec.err ? rec.err.replace(/\|/g, "\\|").slice(0, 90) : "");
+  lines.push(
+    `| ${key.replace(/\|/g, "\\|")} | ${[...rec.reasons].join(", ")} | ${detail} |`
+  );
+}
+if (byTest.size > 50) lines.push(`| _…and ${byTest.size - 50} more_ | | |`);
+
+process.stdout.write(lines.join("\n") + "\n");

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -7,7 +7,11 @@ module.exports = defineConfig({
   viewportHeight: 1080,
   video: false,
   numTestsKeptInMemory: 0,
-  defaultCommandTimeout: 15000,
+  // Generous timeouts to tolerate the slow shared dev instance (data/UI can
+  // render several seconds late under load) without flaking.
+  defaultCommandTimeout: 30000,
+  requestTimeout: 30000,
+  responseTimeout: 30000,
   env: {
     API_AUTH: "https://auth.api.dev.zesty.io",
     COOKIE_NAME: "DEV_APP_SID",

--- a/cypress/e2e/content/actions.spec.js
+++ b/cypress/e2e/content/actions.spec.js
@@ -3,7 +3,8 @@ const TEST_DATA = {
   new: `New Item:${timestamp}`,
   ai: `AI Generated:${timestamp}`,
 };
-const requestTimeout = 15000;
+// Generous timeout: the publish/item data requests can be slow under load.
+const requestTimeout = 30000;
 
 describe("Actions in content editor", () => {
   let CONTENT_ITEMS = null;
@@ -40,9 +41,10 @@ describe("Actions in content editor", () => {
 
     cy.getBySelector("field:markdown")
       .find("textarea")
+      // Wait for hydration (seeded value) before clearing, so the save sees it empty.
+      .should("have.value", "markdown")
       .click()
       .clear()
-      .wait(500)
       .should("have.value", "");
 
     cy.getBySelector("SaveItemButton")
@@ -301,7 +303,13 @@ describe("Actions in content editor", () => {
   });
 
   it("Unschedules a Publish for an item", () => {
-    const { deletePublishedItem, publishings } = awaitRequests();
+    const { items, deletePublishedItem, publishings } = awaitRequests();
+    // Re-visit so this test reads the scheduled item fresh, independent of the
+    // previous test's open modal.
+    cy.visit(
+      `/content/${Cypress.env("modelZUID")}/${CONTENT_ITEMS?.[4]?.meta?.ZUID}`
+    );
+    cy.wait([items, publishings], { requestTimeout });
 
     cy.getBySelector("PublishMenuButton").should("exist").should("be.enabled");
     cy.getBySelector("PublishMenuButton").trigger("click");

--- a/cypress/e2e/content/headTags.spec.js
+++ b/cypress/e2e/content/headTags.spec.js
@@ -1,6 +1,23 @@
-// assumes no Head Tags as starting state
+import { API_ENDPOINTS } from "../../support/api";
+
+// This spec is the only head-tag mutator and assumes a clean start; delete all
+// before/after to guarantee that regardless of leftovers from a prior run.
+function cleanAllHeadTags() {
+  cy.apiRequest({
+    url: `${API_ENDPOINTS.devInstance}/web/headtags`,
+  }).then(({ data }) => {
+    (data || []).forEach((tag) => {
+      cy.apiRequest({
+        url: `${API_ENDPOINTS.devInstance}/web/headtags/${tag.ZUID}`,
+        method: "DELETE",
+      });
+    });
+  });
+}
+
 describe("Head Tags", () => {
   before(() => {
+    cleanAllHeadTags();
     cy.task("seed:content", "fixtures/item.json").then(
       ({ model, fields, items }) => {
         Cypress.env("modelZUID", model?.ZUID);
@@ -8,28 +25,20 @@ describe("Head Tags", () => {
       }
     );
   });
+
+  after(() => {
+    cleanAllHeadTags();
+  });
   it("creates and deletes new head tag", () => {
-    cy.intercept("GET", "**/v1/content/models").as("getContentModel");
+    // Wait only on the head tags fetch; the other head-page requests don't
+    // reliably fire, and the Create button assertion below covers readiness.
     cy.intercept("GET", "**/v1/web/headtags").as("getHeadtags");
-    cy.intercept("GET", "**/v1/env/settings").as("getSettings");
-    cy.intercept("GET", "**/v1/web/headers").as("getHeaders");
-    cy.intercept("GET", "**/v1/web/views**").as("getViews");
-    cy.intercept("GET", "**/v1/web/scripts").as("getScripts");
-    cy.intercept("GET", "**/v1/web/stylesheets").as("getStylesheets");
 
     cy.visit(
       `/content/${Cypress.env("modelZUID")}/${Cypress.env("itemZUID")}/head`
     );
 
-    cy.wait([
-      "@getContentModel",
-      "@getHeadtags",
-      "@getSettings",
-      "@getHeaders",
-      "@getViews",
-      "@getScripts",
-      "@getStylesheets",
-    ]);
+    cy.wait("@getHeadtags");
 
     cy.contains("Create Head Tag").should("exist").should("be.enabled").click();
 

--- a/cypress/e2e/content/list.spec.js
+++ b/cypress/e2e/content/list.spec.js
@@ -121,9 +121,6 @@ describe("Content List Actions", () => {
 
   it("Saves bulk edits", () => {
     cy.intercept("PUT", "/v1/content/models/*/items/batch").as("batchSave");
-    // Set up item refetch intercept just before save so it only captures the
-    // post-save fetchItem calls, not earlier background requests.
-    cy.intercept("GET", "/v1/content/models/*/items/*").as("itemRefetch");
 
     cy.getBySelector("listItemTable")
       .find('[data-cy="itemListRow"]')
@@ -141,10 +138,21 @@ describe("Content List Actions", () => {
     cy.getBySelector("MultiPageTableSaveChanges").click();
 
     cy.wait("@batchSave").its("response.statusCode").should("equal", 200);
-    // Wait for the two post-save item refetches so Redux is settled at yes_no=1
-    // before the next test starts. Without this, in-flight GETs can arrive
-    // mid-next-test and cause its eq(0) clicks to be no-ops.
-    cy.wait(["@itemRefetch", "@itemRefetch"]);
+    // Settle on UI state, not an exact count of background refetches: Save button
+    // unmounts when staging clears, then the toggle reflects the refetched value.
+    cy.getBySelector("MultiPageTableSaveChanges").should("not.exist");
+    cy.getBySelector("listItemTable")
+      .find('[data-cy="itemListRow"]')
+      .eq(0)
+      .find('[data-field="yes_no"] button')
+      .eq(1)
+      .should("have.attr", "aria-pressed", "true");
+    cy.getBySelector("listItemTable")
+      .find('[data-cy="itemListRow"]')
+      .eq(1)
+      .find('[data-field="yes_no"] button')
+      .eq(1)
+      .should("have.attr", "aria-pressed", "true");
   });
   it("Saves and publishes bulk edits", () => {
     cy.intercept("PUT", "/v1/content/models/*/items/batch").as("batchSave");

--- a/cypress/e2e/content/redirects.spec.js
+++ b/cypress/e2e/content/redirects.spec.js
@@ -337,7 +337,8 @@ function createTestContents() {
 }
 
 // Poll until every seeded redirect path is queryable (eventual consistency).
-function waitForRedirectsIndexed(attempts = 15) {
+// Request-paced recursion (no hard wait) — each retry fires after the prior GET resolves.
+function waitForRedirectsIndexed(attempts = 30) {
   cy.apiRequest({
     url: `${API_ENDPOINTS.devInstance}/web/redirects`,
   }).then(({ data }) => {
@@ -347,7 +348,6 @@ function waitForRedirectsIndexed(attempts = 15) {
       )
     );
     if (!allPresent && attempts > 0) {
-      cy.wait(400);
       waitForRedirectsIndexed(attempts - 1);
     }
   });

--- a/cypress/e2e/content/redirects.spec.js
+++ b/cypress/e2e/content/redirects.spec.js
@@ -111,6 +111,10 @@ const REDIRECT_PATHS = [
   ...REDIRECTS.map((item) => item.path),
   ADD_REDIRECTS?.path,
   EDIT_REDIRECTS?.path,
+  // Content-item redirects ("Redirect Content Item") are created on the content
+  // item's own path. Include those so cleanup removes a lingering one from a
+  // prior run — otherwise the re-create POSTs a duplicate and 400s.
+  ...CONTENT_ITEMS.map((item) => item?.web?.pathPart),
 ];
 
 describe("Content item redirects", () => {

--- a/cypress/e2e/content/redirects.spec.js
+++ b/cypress/e2e/content/redirects.spec.js
@@ -118,6 +118,9 @@ describe("Content item redirects", () => {
     deleteTestContents();
     deleteTestRedirects();
     createTestContents();
+    // Wait until the seeded redirects are queryable before any test loads the page
+    // (eventual consistency — otherwise the grid renders with too few rows).
+    waitForRedirectsIndexed();
   });
   after(() => {
     deleteTestContents();
@@ -333,6 +336,23 @@ function createTestContents() {
   });
 }
 
+// Poll until every seeded redirect path is queryable (eventual consistency).
+function waitForRedirectsIndexed(attempts = 15) {
+  cy.apiRequest({
+    url: `${API_ENDPOINTS.devInstance}/web/redirects`,
+  }).then(({ data }) => {
+    const allPresent = REDIRECTS.every((redirect) =>
+      data?.some(
+        (item) => item?.path?.replace(/^\/|\/$/g, "") === redirect.path
+      )
+    );
+    if (!allPresent && attempts > 0) {
+      cy.wait(400);
+      waitForRedirectsIndexed(attempts - 1);
+    }
+  });
+}
+
 function createTestRedirects(ZUID) {
   REDIRECTS.forEach((redirect) => {
     const data = {
@@ -391,6 +411,6 @@ function awaitRedirectsData(path) {
 
   cy.visit(path);
   cy.wait(["@getModels", "@getPublishings", "@getRedirects"], {
-    requestTimeout: 10000,
+    requestTimeout: 30000,
   });
 }

--- a/cypress/e2e/content/workflows.spec.js
+++ b/cypress/e2e/content/workflows.spec.js
@@ -25,7 +25,7 @@ const LABEL_DATA = {
   },
 };
 const cleanUp = () => {
-  cy.task("cleanup:labels", [TITLES.publishLabel, TITLES.testLabel]);
+  cy.task("cleanup:labels");
 };
 
 describe("Content Item Workflows", () => {
@@ -55,6 +55,9 @@ describe("Content Item Workflows", () => {
   });
 
   it("Can add a workflow label", () => {
+    // Intercept must be registered before the click that fires the PUT.
+    cy.intercept("PUT", "**/labels/*").as("updateLabel");
+
     ContentItemPage.elements.versionSelector().should("exist").click();
     ContentItemPage.elements.addWorkflowStatusLabel().should("exist").click();
     ContentItemPage.elements
@@ -65,8 +68,10 @@ describe("Content Item Workflows", () => {
 
     cy.get("body").type("{esc}");
 
-    cy.intercept("PUT", "**/labels/*").as("updateLabel");
-    cy.wait("@updateLabel");
+    // Wait for the save to persist before reloading.
+    cy.wait("@updateLabel")
+      .its("response.statusCode")
+      .should("be.oneOf", [200, 201]);
 
     cy.reload();
 
@@ -126,28 +131,30 @@ describe("Content Item Workflows", () => {
   });
 
   it("Can publish a content item if label with allowPublish is applied", () => {
+    // Intercept must be registered before the click that fires the PUT.
+    cy.intercept("PUT", "**/labels/*").as("updateLabel");
+
     cy.reload();
     ContentItemPage.elements.versionSelector().should("exist").click();
     ContentItemPage.elements.addWorkflowStatusLabel().should("exist").click();
     ContentItemPage.elements
       .workflowStatusLabelOption()
-      .contains(`Publish Approval - ${NOW}`)
+      .contains(TITLES.publishLabel)
       .should("exist")
       .click({ force: true });
 
     cy.get("body").type("{esc}");
 
-    cy.intercept("PUT", "**/labels/*").as("updateLabel");
-    cy.wait("@updateLabel");
+    cy.wait("@updateLabel")
+      .its("response.statusCode")
+      .should("be.oneOf", [200, 201]);
 
     cy.reload();
 
     ContentItemPage.elements.publishItemButton().should("exist").click();
     ContentItemPage.elements.confirmPublishItemButton().should("exist").click();
 
-    cy.intercept("GET", "**/publishings").as("publish");
-    cy.wait("@publish");
-
+    // Assert on resulting UI state rather than racing a post-action intercept.
     ContentItemPage.elements.contentPublishedIndicator().should("exist");
   });
 });

--- a/cypress/e2e/search/search-bar.spec.js
+++ b/cypress/e2e/search/search-bar.spec.js
@@ -56,13 +56,14 @@ describe("Global Search: Search Bar", () => {
       .should("exist")
       .should("contain", SEARCH_TERM);
 
-    // Remove keyword from saved keywords, trigger mouseover is needed because remove button only shows up on list item hover
-    cy.getBySelector("global-search-recent-keyword")
-      .should("exist")
-      .trigger("mouseover");
-    cy.getBySelector("RemoveRecentSearchKeyword")
-      .should("exist")
-      .click({ force: true });
+    // The remove button only shows on hover, and the MUI Autocomplete option list
+    // can re-render asynchronously — re-query fresh and force so a transient
+    // re-render can't detach the element mid-action.
+    cy.getBySelector("global-search-recent-keyword").should("exist");
+    cy.getBySelector("global-search-recent-keyword").trigger("mouseover", {
+      force: true,
+    });
+    cy.getBySelector("RemoveRecentSearchKeyword").click({ force: true });
 
     // Verify if keyword was removed
     cy.getBySelector("global-search-recent-keyword").should("not.exist");
@@ -88,8 +89,11 @@ describe("Global Search: Search Bar", () => {
       .should("exist")
       .click();
 
-    // Click on the recently saved keyword
-    cy.getBySelector("global-search-recent-keyword").should("exist").click();
+    // Click the recently saved keyword. The MUI Autocomplete option list can
+    // re-render asynchronously, detaching the element mid-click — re-query fresh
+    // and force so the click lands.
+    cy.getBySelector("global-search-recent-keyword").should("exist");
+    cy.getBySelector("global-search-recent-keyword").click({ force: true });
 
     // Verify that user is navigated to search page with correct search param
     cy.location("pathname").should("equal", "/search");

--- a/cypress/e2e/settings/actions.spec.js
+++ b/cypress/e2e/settings/actions.spec.js
@@ -19,7 +19,10 @@ describe("Settings Actions", () => {
 
   it.only("Typography", () => {
     cy.get("[data-cy=SettingsNav]").contains("Typography").click();
-    cy.get("[data-cy=SubApp] .MuiSelect-select").first().click();
+    // Use the font-weight select (always has the static 100-900 options). The
+    // font-family selects are empty when the instance has no installed fonts, so
+    // they have no "aria-selected=false" option to pick.
+    cy.get("#mui-component-select-headings-font-weight").click();
     cy.get(".MuiList-root li[aria-selected=false]").last().click();
     cy.get("#SaveSettings").click();
     cy.get('[data-cy="ConfirmSaveSettings"]').should("exist");

--- a/cypress/e2e/settings/workflows.spec.js
+++ b/cypress/e2e/settings/workflows.spec.js
@@ -462,7 +462,9 @@ Cypress.Commands.add("cleanTestData", function () {
     TEST_DATA?.temp3?.name,
   ];
 
-  cy.apiRequest({ url: `${INSTANCE_API}/env/labels?showDeleted=true` }).then(
+  // Active labels only — showDeleted=true returns the bloated soft-deleted history
+  // and can time out; we only delete active labels here anyway.
+  cy.apiRequest({ url: `${INSTANCE_API}/env/labels` }).then(
     (response) => {
       response?.data
         ?.filter(

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -11,6 +11,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
+const fs = require("fs");
 const path = require("path");
 const dotenv = require("dotenv");
 const os = require("os");
@@ -25,6 +26,20 @@ module.exports = (on, config) => {
   on("task", {
     log(message) {
       console.log(message);
+      return null;
+    },
+    // Appends a backend-attributed failure marker (one JSON per line) for the
+    // backend_health CI job to read.
+    "record:backend5xx"(entry) {
+      try {
+        fs.mkdirSync("results", { recursive: true });
+        fs.appendFileSync(
+          path.join("results", "backend-5xx.jsonl"),
+          JSON.stringify(entry) + "\n"
+        );
+      } catch (e) {
+        console.error("record:backend5xx failed:", e?.message);
+      }
       return null;
     },
     ...content(config),

--- a/cypress/plugins/seeds/content.ts
+++ b/cypress/plugins/seeds/content.ts
@@ -107,6 +107,8 @@ module.exports = function content(config) {
     };
   }
 
+  // Delete all non-default labels. Safe behind the CI concurrency gate, and
+  // drains accumulated label bloat that slows the labels endpoint.
   async function deleteAllLabels(): Promise<string[]> {
     const sdk = await getSDK(config);
     const allLabels = await sdk.instance.fetchLabels();
@@ -119,7 +121,7 @@ module.exports = function content(config) {
         (label) => !["Needs Review", "Draft", "Approved"]?.includes(label?.name)
       )
       .map((label) => {
-        sdk.instance.deleteLabel(label?.ZUID).then((res) => {
+        return sdk.instance.deleteLabel(label?.ZUID).then((res) => {
           return res.data;
         });
       });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -51,10 +51,11 @@ before(() => {
 // Backend 5xx responses seen during the current test (recorded, not stubbed/retried).
 let backend5xx = [];
 
-// High-confidence backend-failure signals only. Intentionally excludes "No request
-// ever occurred" (ambiguous — could be a real bug), so we never mask real failures.
+// High-confidence, HTTP-level backend signals only. Excludes "No request ever
+// occurred" and network-layer errors (econnrefused/etimedout/etc.) — those can be
+// a misconfigured or broken test, and false backend attribution would mask real bugs.
 const BACKEND_ERR_RE =
-  /\b50[0-9]\b|bad gateway|service unavailable|gateway time-?out|no response ever occurred|response to the route|cy\.request\(\) timed out|seed:content.*timed out|failed to create model|econnrefused|esockettimedout|etimedout|socket hang up|ehostunreach/i;
+  /\b50[0-9]\b|bad gateway|service unavailable|gateway time-?out|no response ever occurred|response to the route|cy\.request\(\) timed out|seed:content.*timed out|failed to create model/i;
 
 // Before each test in spec
 beforeEach(() => {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -48,8 +48,34 @@ before(() => {
   cy.blockAnnouncements();
 });
 
+// Backend 5xx responses seen during the current test (recorded, not stubbed/retried).
+let backend5xx = [];
+
+// High-confidence backend-failure signals only. Intentionally excludes "No request
+// ever occurred" (ambiguous — could be a real bug), so we never mask real failures.
+const BACKEND_ERR_RE =
+  /\b50[0-9]\b|bad gateway|service unavailable|gateway time-?out|no response ever occurred|response to the route|cy\.request\(\) timed out|seed:content.*timed out|failed to create model|econnrefused|esockettimedout|etimedout|socket hang up|ehostunreach/i;
+
 // Before each test in spec
 beforeEach(() => {
+  backend5xx = [];
+
+  // Observe-only (middleware:true → can't affect spec aliases): record any 5xx.
+  cy.intercept(
+    { url: "**/*.api.dev.zesty.io/**", middleware: true },
+    (req) => {
+      req.on("response", (res) => {
+        if (res.statusCode >= 500) {
+          backend5xx.push({
+            method: req.method,
+            url: req.url,
+            status: res.statusCode,
+          });
+        }
+      });
+    }
+  );
+
   /**
    * NOTE: Zesty is a multitennant app with a lock feature
    * that presents a modal when USER X is viewing the same
@@ -64,4 +90,28 @@ beforeEach(() => {
 
   // Blocks the api call to render the announcement popup
   cy.blockAnnouncements();
+});
+
+// On failure, mark it backend-caused if a 5xx was seen or the error matches a
+// backend signal. Read by the backend_health CI job for the run-summary verdict.
+afterEach(function () {
+  if (this.currentTest?.state !== "failed") return;
+  const errText = this.currentTest.err?.message || "";
+  const matchedErr = BACKEND_ERR_RE.test(errText);
+  if (backend5xx.length || matchedErr) {
+    const reason = backend5xx.length ? "5xx" : "timeout/no-response";
+    const info = {
+      spec: Cypress.spec?.relative,
+      test: this.currentTest.fullTitle(),
+      count: backend5xx.length || 1,
+      reason,
+      responses: backend5xx.slice(0, 10),
+      errorSnippet: errText.slice(0, 200),
+    };
+    Cypress.log({
+      name: "backend5xx",
+      message: `⚠️ likely backend-caused failure (${reason})`,
+    });
+    cy.task("record:backend5xx", info, { log: false });
+  }
 });


### PR DESCRIPTION
## Summary

Stabilizes the intermittently-failing Cypress e2e suite. The flakiness had two sources: real test-logic races, and the **shared dev instance** being overloaded by concurrent CI runs. This fixes the former and isolates/handles the latter.

## Test-logic fixes
- **workflows**: register the label `PUT` intercepts **before** the click that fires them (they were registered after → `cy.wait` always timed out); assert publish via resulting UI state instead of a post-action intercept.
- **list › Saves bulk edits**: settle on observable UI state (Save button unmounts, toggle reflects refetched value) instead of waiting on an exact count of background refetches.
- **actions**: assert field hydration before clearing a required field; `Unschedules a Publish` now re-visits the item so it no longer depends on the previous test's open modal.
- **redirects**: poll until seeded redirects are queryable before loading the page (eventual consistency).
- **headTags**: hermetic head-tag cleanup; wait only on the head-tags fetch (the other head-page requests don't reliably fire).
- **settings/workflows**: query active labels only (the `showDeleted=true` history had bloated enough to time out the `before` hook).

## Isolation & environment
- **CI concurrency gate**: serialize all e2e CI across PRs, they share one dev instance and concurrent runs overload it (502s/timeouts). One run touches the instance at a time.


## Backend-failure attribution
When a test fails on a backend `5xx` or timeout, it's marked backend-caused; the `backend_health` CI job surfaces a verdict **on the run's summary** (+ a `::warning::` annotation). S

