### PR TITLE
Schema - Fix app crash when adding a field

### DIFF
--- a/src/apps/schema/src/app/components/contexts/FieldFormProvider.tsx
+++ b/src/apps/schema/src/app/components/contexts/FieldFormProvider.tsx
@@ -195,7 +195,7 @@ export const FieldFormProvider = ({
       return;
     }
 
-    const currFieldNames = fields.map((field) => field.name);
+    const currFieldNames = fields?.map((field) => field.name);
     let newErrorsObj: Errors = {};
 
     Object.keys(formData).map((inputName) => {
@@ -367,7 +367,7 @@ export const FieldFormProvider = ({
     });
 
     setErrors(newErrorsObj);
-  }, [formData, isDefaultValueEnabled]);
+  }, [formData, isDefaultValueEnabled, fields]);
 
   const handleFieldDataChange = useCallback(
     ({ inputName, value }: { inputName: string; value: FormValue }) => {

--- a/src/shell/services/instance.ts
+++ b/src/shell/services/instance.ts
@@ -371,7 +371,7 @@ export const instanceApi = createApi({
         };
       },
       transformResponse: (res: { data: ContentModelField[] }) =>
-        res.data.sort((a, b) => a.sort - b.sort),
+        res.data?.sort((a, b) => a.sort - b.sort),
       providesTags: (result, error, { modelZUID }) => [
         { type: "ContentModelFields", id: modelZUID },
       ],

--- a/src/shell/services/instance.ts
+++ b/src/shell/services/instance.ts
@@ -371,7 +371,7 @@ export const instanceApi = createApi({
         };
       },
       transformResponse: (res: { data: ContentModelField[] }) =>
-        res.data?.sort((a, b) => a.sort - b.sort),
+        res.data?.sort((a, b) => a.sort - b.sort) ?? [],
       providesTags: (result, error, { modelZUID }) => [
         { type: "ContentModelFields", id: modelZUID },
       ],


### PR DESCRIPTION
## Summary
- Add optional chaining on `fields?.map()` in `FieldFormProvider.tsx` to prevent crash when `fields` is undefined during field addition
- Add `fields` to the `useEffect` dependency array so validation re-runs when fields load
- Add optional chaining on `res.data?.sort()` in `instance.ts` to guard against undefined response data

## Test plan
- [x] Open the Schema app on an instance
- [x] Add a new field to a content model — app should not crash
- [x] Verify field validation still works correctly (duplicate name detection, etc.)
- [x] Verify fields list sorts correctly after fetching

Fixes #4169

🤖 Generated with [Claude Code](https://claude.com/claude-code)