### PR TITLE
[CI] - Fix Claude issue triage never posting its comment

### DIFF
--- a/.github/workflows/claude-issue-critique.yml
+++ b/.github/workflows/claude-issue-critique.yml
@@ -42,9 +42,7 @@ jobs:
             2. Explore only the part of the codebase the issue touches — enough
                to ground your understanding and criteria. Cite only files you
                actually opened; never invent paths or line numbers.
-            3. Post your triage as a single comment (see Posting). If a previous
-               triage comment already exists (marked `<!-- claude-triage -->`),
-               update it in place instead of adding another.
+            3. Post your triage as a single comment (see Posting).
 
             # Triage comment — required sections, in order
             1. **Classification** — ticket type (bug / feature / enhancement /
@@ -77,7 +75,7 @@ jobs:
             Write the full markdown body to the file `triage-comment.md`, then
             post it from that file — never pass the body inline, since issue
             text can contain shell metacharacters:
-            `gh issue comment ${{ github.event.issue.number }} --edit-last --create-if-none --body-file triage-comment.md`
+            `gh issue comment ${{ github.event.issue.number }} --body-file triage-comment.md`
             Begin the body with the hidden marker `<!-- claude-triage -->` so it
             stays identifiable. Only post the comment — never return triage text
             as a chat message.
@@ -87,3 +85,20 @@ jobs:
             --allowedTools "Bash(gh issue comment:*),Bash(gh issue view:*),Write(triage-comment.md),Read,Grep,Glob"
             --model claude-opus-4-8
             --max-turns 30
+
+      # The Claude action reports success even when the model fails to post its
+      # comment, so verify a triage comment actually landed and fail loudly if
+      # not — otherwise a silent non-post shows up as a green run.
+      - name: Verify triage comment was posted
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh issue view "${{ github.event.issue.number }}" \
+               --repo "${{ github.repository }}" \
+               --json comments \
+               --jq '.comments[].body' | grep -q '<!-- claude-triage -->'; then
+            echo "✅ Triage comment found on issue #${{ github.event.issue.number }}."
+          else
+            echo "::error::No triage comment (<!-- claude-triage -->) was posted to issue #${{ github.event.issue.number }}."
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

The **Claude Issue Triage** workflow (`.github/workflows/claude-issue-critique.yml`) has run twice since it was added and posted **zero** comments — yet both runs finished green. Every recently-opened issue (#4183, #4179, #4171, #4174, #4175, #4169) has **0** `<!-- claude-triage -->` comments.

Two root causes:

1. **Fragile posting command.** The prompt gave the model a single posting recipe:
   ```
   gh issue comment N --edit-last --create-if-none --body-file triage-comment.md
   ```
   `--create-if-none` only exists in gh ≥ 2.68, and `--edit-last` errors when there's no prior bot comment. If that one command fails, the model has no fallback and just ends.

2. **Silent failure.** `claude-code-action` returns `is_error: false` even when the model never manages to post (run #28616413352 reported `permission_denials_count: 6` but `subtype: success`). The job passes green with nothing posted.

## Changes

- **Harden the post command** → plain `gh issue comment N --body-file triage-comment.md`, which works on any gh version and still matches the `Bash(gh issue comment:*)` allowlist. Dropped the "update in place" instruction that depended on `--edit-last` (the workflow only triggers on `issues: opened`, so first-post-wins is fine).
- **Add a verification guard step** that greps the issue for the `<!-- claude-triage -->` marker after the action runs and fails the job if it's missing — converting silent non-posts into visible red runs.

## Verification

Re-open a test issue (e.g. re-run against #4183) and confirm a triage comment is posted and the new guard step passes. If the model still can't post for any reason, the job will now go red instead of green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)