### PR TITLE
Schema - Integration field selection silently corrupts when Item ID keyPath is non-unique

### DIFF
--- a/cypress/e2e/schema/integration.spec.js
+++ b/cypress/e2e/schema/integration.spec.js
@@ -835,9 +835,7 @@ describe("Integration Field", () => {
       );
 
       cy.getBySelector("integrationKeyPathSelector-itemId").click();
-      cy.get(`.MuiAutocomplete-listbox li:contains("position")`).click(
-        forceClick
-      );
+      cy.getBySelector("integrationKeyPathOption-position").click(forceClick);
 
       cy.getBySelector("integrationItemIdDuplicateWarning").should(
         "contain",
@@ -849,9 +847,7 @@ describe("Integration Field", () => {
 
       // Switching back to a unique keyPath clears the warning and re-enables Done.
       cy.getBySelector("integrationKeyPathSelector-itemId").click();
-      cy.get(`.MuiAutocomplete-listbox li:contains("playerId")`).click(
-        forceClick
-      );
+      cy.getBySelector("integrationKeyPathOption-playerId").click(forceClick);
       cy.getBySelector("integrationItemIdDuplicateWarning").should("not.exist");
 
       cy.intercept("PUT", "**/content/models/*/fields/*").as("updateField");

--- a/cypress/e2e/schema/integration.spec.js
+++ b/cypress/e2e/schema/integration.spec.js
@@ -617,6 +617,61 @@ describe("Integration Field", () => {
       });
     });
   });
+
+  describe("Non-unique Item ID (regression #4091)", () => {
+    // Own model, seeded fresh, so reconfiguring itemId to a non-unique
+    // keyPath here can't affect the itemId=playerId fields used elsewhere.
+    let DUPLICATE_MODEL = null;
+
+    before(() => {
+      cy.task("seed:content", "fixtures/integration/maxvalue.json").then(
+        ({ model }) => {
+          DUPLICATE_MODEL = model;
+        }
+      );
+    });
+
+    beforeEach(() => {
+      cy.intercept("POST", "**/get-url*", { body: genericApi });
+    });
+
+    it("Warns, without blocking, when the chosen Item ID is not unique across sampled items", () => {
+      cy.intercept("**/get-url?url=*", {
+        statusCode: 200,
+        body: genericApi,
+      }).as("reconfigureGetUrl");
+
+      cy.visit(`/schema/${DUPLICATE_MODEL.ZUID}/fields`);
+      cy.getBySelector("Field_players").click();
+      cy.wait("@reconfigureGetUrl");
+
+      cy.getBySelector("integrationConfigureButton").click();
+      cy.getBySelector("integrationFormDialog").should("exist");
+      cy.getBySelector("integrationConfigureOptionNextButton").click();
+
+      // playerId (the field's current itemId) is unique — no warning yet.
+      cy.getBySelector("integrationItemIdDuplicateWarning").should("not.exist");
+
+      cy.getBySelector("integrationKeyPathSelector-itemId").click();
+      cy.get(`.MuiAutocomplete-listbox li:contains("position")`).click(
+        forceClick
+      );
+
+      cy.getBySelector("integrationItemIdDuplicateWarning").should(
+        "contain",
+        "is not unique"
+      );
+
+      cy.intercept("PUT", "**/content/models/*/fields/*").as("updateField");
+      cy.getBySelector("integrationConfigureDisplayOptionsDoneButton").click();
+      cy.getBySelector("FieldFormAddFieldBtn").click();
+      cy.wait("@updateField").then(({ request }) => {
+        expect(
+          request.body.settings.integrationFieldConfig.keyPaths.itemId
+        ).to.equal("position");
+      });
+    });
+  });
 });
 
 function connectToEndpoint(endpoint, type, apiData) {

--- a/cypress/e2e/schema/integration.spec.js
+++ b/cypress/e2e/schema/integration.spec.js
@@ -635,7 +635,7 @@ describe("Integration Field", () => {
       cy.intercept("POST", "**/get-url*", { body: genericApi });
     });
 
-    it("Warns, without blocking, when the chosen Item ID is not unique across sampled items", () => {
+    it("Blocks Done and warns when the chosen Item ID is not unique across sampled items", () => {
       cy.intercept("**/get-url?url=*", {
         statusCode: 200,
         body: genericApi,
@@ -649,8 +649,11 @@ describe("Integration Field", () => {
       cy.getBySelector("integrationFormDialog").should("exist");
       cy.getBySelector("integrationConfigureOptionNextButton").click();
 
-      // playerId (the field's current itemId) is unique — no warning yet.
+      // playerId (the field's current itemId) is unique — no warning, Done enabled.
       cy.getBySelector("integrationItemIdDuplicateWarning").should("not.exist");
+      cy.getBySelector("integrationConfigureDisplayOptionsDoneButton").should(
+        "not.be.disabled"
+      );
 
       cy.getBySelector("integrationKeyPathSelector-itemId").click();
       cy.get(`.MuiAutocomplete-listbox li:contains("position")`).click(
@@ -661,6 +664,16 @@ describe("Integration Field", () => {
         "contain",
         "is not unique"
       );
+      cy.getBySelector("integrationConfigureDisplayOptionsDoneButton").should(
+        "be.disabled"
+      );
+
+      // Switching back to a unique keyPath clears the warning and re-enables Done.
+      cy.getBySelector("integrationKeyPathSelector-itemId").click();
+      cy.get(`.MuiAutocomplete-listbox li:contains("playerId")`).click(
+        forceClick
+      );
+      cy.getBySelector("integrationItemIdDuplicateWarning").should("not.exist");
 
       cy.intercept("PUT", "**/content/models/*/fields/*").as("updateField");
       cy.getBySelector("integrationConfigureDisplayOptionsDoneButton").click();
@@ -668,7 +681,7 @@ describe("Integration Field", () => {
       cy.wait("@updateField").then(({ request }) => {
         expect(
           request.body.settings.integrationFieldConfig.keyPaths.itemId
-        ).to.equal("position");
+        ).to.equal("playerId");
       });
     });
   });

--- a/src/apps/schema/src/app/components/contexts/FieldFormProvider.tsx
+++ b/src/apps/schema/src/app/components/contexts/FieldFormProvider.tsx
@@ -191,14 +191,14 @@ export const FieldFormProvider = ({
 
   /** Error setting */
   useEffect(() => {
-    if (!Object.keys(formData).length) {
+    if (!Object.keys(formData)?.length) {
       return;
     }
 
-    const currFieldNames = fields.map((field) => field.name);
+    const currFieldNames = fields?.map((field) => field.name);
     let newErrorsObj: Errors = {};
 
-    Object.keys(formData).map((inputName) => {
+    Object.keys(formData)?.map((inputName) => {
       if (
         inputName === "defaultValue" &&
         isDefaultValueEnabled &&

--- a/src/apps/schema/src/app/components/contexts/FieldFormProvider.tsx
+++ b/src/apps/schema/src/app/components/contexts/FieldFormProvider.tsx
@@ -198,7 +198,7 @@ export const FieldFormProvider = ({
     const currFieldNames = fields?.map((field) => field.name);
     let newErrorsObj: Errors = {};
 
-    Object.keys(formData)?.map((inputName) => {
+    Object.keys(formData).map((inputName) => {
       if (
         inputName === "defaultValue" &&
         isDefaultValueEnabled &&

--- a/src/apps/schema/src/app/components/contexts/FieldFormProvider.tsx
+++ b/src/apps/schema/src/app/components/contexts/FieldFormProvider.tsx
@@ -191,7 +191,7 @@ export const FieldFormProvider = ({
 
   /** Error setting */
   useEffect(() => {
-    if (!Object.keys(formData)?.length) {
+    if (!Object.keys(formData ?? {}).length) {
       return;
     }
 

--- a/src/apps/schema/src/app/utils/index.ts
+++ b/src/apps/schema/src/app/utils/index.ts
@@ -111,8 +111,14 @@ export const getErrorMessage = ({
       return "A field with this API/Parsley Reference already exists";
     }
 
-    if (validate.includes("length") && maxLength && value.length > maxLength) {
-      return `Shorten to less than ${maxLength} characters (${value.length}/${maxLength})`;
+    if (
+      validate.includes("length") &&
+      maxLength &&
+      (value as string)?.length > maxLength
+    ) {
+      return `Shorten to less than ${maxLength} characters (${
+        (value as string).length
+      }/${maxLength})`;
     }
 
     // check for reserved field names

--- a/src/apps/schema/src/app/utils/index.ts
+++ b/src/apps/schema/src/app/utils/index.ts
@@ -117,8 +117,9 @@ export const getErrorMessage = ({
       (value as string)?.length > maxLength
     ) {
       return `Shorten to less than ${maxLength} characters (${
-        (value as string).length
+        (value as string)?.length
       }/${maxLength})`;
+    }
     }
 
     // check for reserved field names

--- a/src/apps/schema/src/app/utils/index.ts
+++ b/src/apps/schema/src/app/utils/index.ts
@@ -120,8 +120,6 @@ export const getErrorMessage = ({
         (value as string)?.length
       }/${maxLength})`;
     }
-    }
-
     // check for reserved field names
     if (RESERVED_FIELD_NAMES.includes(value)) {
       return `"${value}" is a System Reserved Field Name`;

--- a/src/apps/schema/src/app/utils/index.ts
+++ b/src/apps/schema/src/app/utils/index.ts
@@ -120,15 +120,14 @@ export const getErrorMessage = ({
         (value as string)?.length
       }/${maxLength})`;
     }
-    }
-
-    // check for reserved field names
-    if (RESERVED_FIELD_NAMES.includes(value)) {
-      return `"${value}" is a System Reserved Field Name`;
-    }
-
-    return "";
   }
+
+  // check for reserved field names
+  if (RESERVED_FIELD_NAMES.includes(value)) {
+    return `"${value}" is a System Reserved Field Name`;
+  }
+
+  return "";
 };
 
 export const getCategory = (type: string) => {

--- a/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
@@ -136,11 +136,10 @@ const ConfigureDisplayOptions = ({
     if (!itemIdPath || !apiData) return null;
 
     const data = (!rootPath ? apiData : get(apiData, rootPath)) || [];
-    if (!Array.isArray(data) || data?.length < 2) return null;
+    if (!Array.isArray(data) || data.length < 2) return null;
 
     const idValueCounts = new Map<unknown, number>();
     data.forEach((item: object) => {
-      const idValue = get(item, itemIdPath);
       const idValue = get(item, itemIdPath);
       if (idValue !== undefined) {
         idValueCounts.set(idValue, (idValueCounts.get(idValue) ?? 0) + 1);

--- a/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
@@ -149,7 +149,7 @@ const ConfigureDisplayOptions = ({
     );
     if (!hasDuplicates) return null;
 
-    return `"${itemIdPath}" is not unique across the ${data?.length} sampled items — this can cause selections to be recognized incorrectly.`;
+    return `"${itemIdPath}" is not unique across the ${data.length} sampled items — this can cause selections to be recognized incorrectly.`;
   }, [apiData, rootPath, rootPathData.itemId]);
 
   return (

--- a/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
@@ -141,7 +141,10 @@ const ConfigureDisplayOptions = ({
     const idValueCounts = new Map<unknown, number>();
     data.forEach((item: object) => {
       const idValue = get(item, itemIdPath);
-      idValueCounts.set(idValue, (idValueCounts.get(idValue) || 0) + 1);
+      const idValue = get(item, itemIdPath);
+      if (idValue !== undefined) {
+        idValueCounts.set(idValue, (idValueCounts.get(idValue) ?? 0) + 1);
+      }
     });
 
     const hasDuplicates = Array.from(idValueCounts.values()).some(

--- a/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useMemo, useState, useRef } from "react";
 import {
   Button,
   DialogActions,
@@ -174,6 +174,29 @@ const ConfigureDisplayOptions = ({
     setIsCompleted(completed);
   }, [displayConfig, rootPathData, detailsPathData, rootPath]);
 
+  // Heuristic only: flags duplicate Item ID values in the sampled response.
+  // Absence of a warning does not guarantee the keyPath is unique — see #4091.
+  const itemIdDuplicateWarning = useMemo(() => {
+    const itemIdPath = rootPathData.itemId;
+    if (!itemIdPath || !apiData) return null;
+
+    const data = (!rootPath ? apiData : get(apiData, rootPath)) || [];
+    if (!Array.isArray(data) || data.length < 2) return null;
+
+    const idValueCounts = new Map<unknown, number>();
+    data.forEach((item: object) => {
+      const idValue = get(item, itemIdPath);
+      idValueCounts.set(idValue, (idValueCounts.get(idValue) || 0) + 1);
+    });
+
+    const hasDuplicates = Array.from(idValueCounts.values()).some(
+      (count) => count > 1
+    );
+    if (!hasDuplicates) return null;
+
+    return `"${itemIdPath}" is not unique across the ${data.length} sampled items — this can cause selections to be recognized incorrectly.`;
+  }, [apiData, rootPath, rootPathData.itemId]);
+
   return (
     <FormWrapper height="calc(100vh - 40px)" width="1200px">
       <DialogTitle component="div" flexGrow={0}>
@@ -270,6 +293,11 @@ const ConfigureDisplayOptions = ({
                     key={config.name}
                     label={config.label}
                     isRequired={true}
+                    toolTip={config.toolTip}
+                    warning={
+                      config.name === "itemId" ? itemIdDuplicateWarning : null
+                    }
+                    warningTestId="integrationItemIdDuplicateWarning"
                   >
                     {config.type === "option" ? (
                       <Box

--- a/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
@@ -117,7 +117,7 @@ const ConfigureDisplayOptions = ({
   };
 
   const handleRemoveDetail = (index: number) => {
-    if (detailsPathData.length === 1) {
+    if (detailsPathData?.length === 1) {
       setDetailsPathData([""]);
       lastDetailRef.current?.focus();
       return;
@@ -181,7 +181,7 @@ const ConfigureDisplayOptions = ({
     if (!itemIdPath || !apiData) return null;
 
     const data = (!rootPath ? apiData : get(apiData, rootPath)) || [];
-    if (!Array.isArray(data) || data.length < 2) return null;
+    if (!Array.isArray(data) || data?.length < 2) return null;
 
     const idValueCounts = new Map<unknown, number>();
     data.forEach((item: object) => {
@@ -194,7 +194,7 @@ const ConfigureDisplayOptions = ({
     );
     if (!hasDuplicates) return null;
 
-    return `"${itemIdPath}" is not unique across the ${data.length} sampled items — this can cause selections to be recognized incorrectly.`;
+    return `"${itemIdPath}" is not unique across the ${data?.length} sampled items — this can cause selections to be recognized incorrectly.`;
   }, [apiData, rootPath, rootPathData.itemId]);
 
   return (
@@ -258,7 +258,7 @@ const ConfigureDisplayOptions = ({
               </Typography>
             </Box>
 
-            {apiPathOptions.length > 0 && (
+            {apiPathOptions?.length > 0 && (
               <>
                 <FieldWrapper label="Data Path" isRequired>
                   <KeyPathSelector
@@ -287,7 +287,7 @@ const ConfigureDisplayOptions = ({
               gap={1.5}
               data-cy="integrationConfigureOptionKeyPathContainer"
             >
-              {rootPathOptions.length > 0 &&
+              {rootPathOptions?.length > 0 &&
                 displayConfig.map((config: ConfigProps) => (
                   <FieldWrapper
                     key={config.name}

--- a/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
@@ -67,10 +67,6 @@ const ConfigureDisplayOptions = ({
   );
   const [isCompleted, setIsCompleted] = useState<boolean>(false);
 
-  const handleSave = () => {
-    onSave();
-  };
-
   const handleRemoveDetail = (index: number) => {
     if (detailsPathData?.length === 1) {
       setDetailsPathData([""]);
@@ -254,7 +250,11 @@ const ConfigureDisplayOptions = ({
                     warning={
                       config.name === "itemId" ? itemIdDuplicateWarning : null
                     }
-                    warningTestId="integrationItemIdDuplicateWarning"
+                    warningTestId={
+                      config.name === "itemId"
+                        ? "integrationItemIdDuplicateWarning"
+                        : undefined
+                    }
                   >
                     {config.type === "option" ? (
                       <Box
@@ -429,7 +429,7 @@ const ConfigureDisplayOptions = ({
           variant="contained"
           startIcon={<CheckRounded />}
           disabled={!isCompleted || !!itemIdDuplicateWarning}
-          onClick={handleSave}
+          onClick={onSave}
         >
           Done
         </Button>

--- a/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
@@ -141,7 +141,6 @@ const ConfigureDisplayOptions = ({
     const idValueCounts = new Map<unknown, number>();
     data.forEach((item: object) => {
       const idValue = get(item, itemIdPath);
-      const idValue = get(item, itemIdPath);
       if (idValue !== undefined) {
         idValueCounts.set(idValue, (idValueCounts.get(idValue) ?? 0) + 1);
       }

--- a/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConfigureDisplayOptions.tsx
@@ -471,7 +471,7 @@ const ConfigureDisplayOptions = ({
           data-cy="integrationConfigureDisplayOptionsDoneButton"
           variant="contained"
           startIcon={<CheckRounded />}
-          disabled={!isCompleted}
+          disabled={!isCompleted || !!itemIdDuplicateWarning}
           onClick={handleSave}
         >
           Done

--- a/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
@@ -105,7 +105,7 @@ const ConnectToApi = ({
   const [headersLocal, setHeadersLocal] = useState<
     Record<string, { key: string; value: string }>
   >(() => {
-    if (!headers || Object.keys(headers).length === 0) {
+    if (!headers || Object.keys(headers)?.length === 0) {
       const id = uuidv4();
       return { [id]: { key: "", value: "" } };
     }
@@ -118,7 +118,7 @@ const ConnectToApi = ({
 
   const handleNext = () => {
     const headersWithKeys = Object.values(headersLocal).filter((h) => !!h.key);
-    const reqHeaders = !headersWithKeys.length
+    const reqHeaders = !headersWithKeys?.length
       ? null
       : headersWithKeys.reduce<Record<string, string>>(
           (acc, { key, value }) => {
@@ -143,7 +143,7 @@ const ConnectToApi = ({
     setReqAborted(false);
     setApiData(null);
     const headersWithKeys = Object.values(headersLocal).filter((h) => !!h.key);
-    const options = !headersWithKeys.length
+    const options = !headersWithKeys?.length
       ? {}
       : {
           headers: headersWithKeys.reduce<Record<string, string>>(

--- a/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
@@ -126,7 +126,7 @@ const ConnectToApi = ({
 
   const handleNext = () => {
     const headersWithKeys = Object.values(headersLocal).filter((h) => !!h.key);
-    const reqHeaders = !headersWithKeys?.length
+    const reqHeaders = !headersWithKeys.length
       ? null
       : headersWithKeys.reduce<Record<string, string>>(
           (acc, { key, value }) => {
@@ -157,7 +157,7 @@ const ConnectToApi = ({
     setReqAborted(false);
     setApiData(null);
     const headersWithKeys = Object.values(headersLocal).filter((h) => !!h.key);
-    const options = !headersWithKeys?.length
+    const options = !headersWithKeys.length
       ? {}
       : {
           headers: headersWithKeys.reduce<Record<string, string>>(

--- a/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/ConnectToApi.tsx
@@ -113,7 +113,7 @@ const ConnectToApi = ({
   const [headersLocal, setHeadersLocal] = useState<
     Record<string, { key: string; value: string }>
   >(() => {
-    if (!headers || Object.keys(headers)?.length === 0) {
+    if (!headers || Object.keys(headers).length === 0) {
       const id = uuidv4();
       return { [id]: { key: "", value: "" } };
     }

--- a/src/shell/components/FieldTypeIntegration/Configure/KeyPathSelector.tsx
+++ b/src/shell/components/FieldTypeIntegration/Configure/KeyPathSelector.tsx
@@ -82,7 +82,11 @@ const KeyPathSelector = ({
         const { key, ...otherProps } = props;
 
         return (
-          <li key={key} {...otherProps}>
+          <li
+            key={key}
+            {...otherProps}
+            data-cy={`integrationKeyPathOption-${option}`}
+          >
             <Box
               display="flex"
               alignItems="center"

--- a/src/shell/components/FieldTypeIntegration/Shared/DisplayCard.tsx
+++ b/src/shell/components/FieldTypeIntegration/Shared/DisplayCard.tsx
@@ -69,7 +69,8 @@ const DisplayCard = ({
   ) : (
     renderValue(subHeading)
   );
-  const thumbnailValue = thumbnail && validateUrl(thumbnail) ? thumbnail : null;
+  const thumbnailValue =
+    typeof thumbnail === "string" && validateUrl(thumbnail) ? thumbnail : null;
   const detailValue = loading ? <Skeleton width="70px" /> : renderValue(detail);
 
   const noImage = !thumbnailValue || mediaError;

--- a/src/shell/components/FieldTypeIntegration/Shared/FieldWrapper.tsx
+++ b/src/shell/components/FieldTypeIntegration/Shared/FieldWrapper.tsx
@@ -9,6 +9,8 @@ export type FieldWrapperProps = {
   toolTip?: string;
   isRequired?: boolean;
   error?: string;
+  warning?: string;
+  warningTestId?: string;
   children: React.ReactNode;
 };
 
@@ -19,6 +21,8 @@ export const FieldWrapper = ({
   toolTip,
   isRequired,
   error,
+  warning,
+  warningTestId,
   children,
 }: FieldWrapperProps) => {
   return (
@@ -77,6 +81,16 @@ export const FieldWrapper = ({
       {!!error && (
         <Typography variant="body2" color="error.main" mt={0.5}>
           {error}
+        </Typography>
+      )}
+      {!error && !!warning && (
+        <Typography
+          data-cy={warningTestId}
+          variant="body2"
+          color="warning.dark"
+          mt={0.5}
+        >
+          {warning}
         </Typography>
       )}
     </Box>

--- a/src/shell/components/FieldTypeIntegration/Shared/FieldWrapper.tsx
+++ b/src/shell/components/FieldTypeIntegration/Shared/FieldWrapper.tsx
@@ -9,7 +9,7 @@ export type FieldWrapperProps = {
   toolTip?: string;
   isRequired?: boolean;
   error?: string;
-  warning?: string;
+  warning?: string | null;
   warningTestId?: string;
   children: React.ReactNode;
 };

--- a/src/shell/components/FieldTypeIntegration/constants.ts
+++ b/src/shell/components/FieldTypeIntegration/constants.ts
@@ -118,6 +118,8 @@ const ITEM_ID: ConfigProps = {
   type: "text",
   isRequired: true,
   placeholder: "Select",
+  toolTip:
+    "Choose a value the API guarantees is unique for every item (e.g. a database ID) — not just one that looks unique in a small sample. A non-unique Item ID can cause selections to be recognized incorrectly.",
 };
 
 const HEADING: ConfigProps = {

--- a/src/shell/components/FieldTypeIntegration/types.ts
+++ b/src/shell/components/FieldTypeIntegration/types.ts
@@ -73,4 +73,5 @@ export type ConfigProps = {
   isRequired?: boolean;
   description?: string;
   placeholder?: string;
+  toolTip?: string;
 };


### PR DESCRIPTION
### **RCA:**
The integration field's "Select Remote Items" dialog tracks selection identity by the value at
the schema-configured "Item ID" keyPath. When that value isn't unique across the API response
(e.g. `itemId: "position"` when several rows share the same position), distinct rows collapse
into the same selection identity — clicking one row can affect another, and fewer items end up
persisted than the user actually selected. There was no indication anywhere in the schema
configuration flow that the chosen Item ID needed to be unique.

### **FIX:**
This PR closes the awareness gap at the point where it can be prevented — schema configuration —
by surfacing a clear warning when the configured Item ID is not unique, and **blocking** the
"Done" button until it's resolved, so a field can't be saved in a state that produces empty
display cards and corrupted selections downstream. A unique Item ID is what lets the field
reliably track remote data changes per selected item (the resync feature), so this is enforced
rather than left to the user to opt into.

- `Configure/ConfigureDisplayOptions.tsx` — new `itemIdDuplicateWarning`, computed by scanning the
  full sampled API response (not just the first row) for the configured Item ID keyPath. When
  duplicate values are found, a warning renders under the "Item ID" field and the "Done" button
  is disabled until a unique keyPath is chosen. The check is a heuristic over the
  currently-sampled response — a keyPath that happens to look unique in a small sample isn't a
  guarantee, and the copy is worded accordingly.
- `Shared/FieldWrapper.tsx` — new optional `warning`/`warningTestId` props, additive alongside the
  existing `error` prop (doesn't affect any existing consumer).
- `constants.ts` / `types.ts` — the `ITEM_ID` config entry gained a `toolTip` explaining that the
  value should be guaranteed unique by the API itself (e.g. a database ID), not just unique in a
  small sample.

Regression test added: `cypress/e2e/schema/integration.spec.js` — `describe("Non-unique Item ID
(regression #4091)")` → `"Blocks Done and warns when the chosen Item ID is not unique across
sampled items"`.

**Additional hardening found while testing this flow:**
- `schema/src/app/utils/index.ts` — `getErrorMessage` threw `Cannot read properties of null
  (reading 'length')` when an existing field's text setting (e.g. `description`) came back `null`
  from the API, since it read `value.length` unguarded. Now optional-chained.
- `Configure/ConfigureDisplayOptions.tsx`, `contexts/FieldFormProvider.tsx` — defensive optional
  chaining on array `.length`/`.map` accesses in the code paths this feature touches, to avoid
  similar null/undefined crashes.

**Review feedback addressed:**
- `itemIdDuplicateWarning` now skips items where the configured keyPath resolves to `undefined`,
  so a sparse/missing field no longer produces a false-positive duplicate warning.
- `FieldWrapperProps.warning` is typed `string | null` (was `string`) to match the value actually
  passed in from `itemIdDuplicateWarning`.
- `warningTestId` is now scoped to the `itemId` config entry only, instead of being passed to
  every field in the `displayConfig` loop.
- `KeyPathSelector` dropdown options now expose a `data-cy` attribute; the new regression test
  uses it instead of an MUI-internal class selector (`.MuiAutocomplete-listbox li:contains(...)`).
- Removed unnecessary optional chaining (`?.`) on values that can never be nullish — `Object.keys()`
  results, `Array.filter()` results, and a value already narrowed by `Array.isArray()` — including
  reverting it in `Configure/ConnectToApi.tsx`, which turned out not to need it.
- Removed the redundant `handleSave` wrapper in favor of calling `onSave` directly.

### **TESTING PLAN:**
Prerequisites: an API endpoint returning rows with a repeating field value (e.g.
`https://8xbq19z1-dev.preview.stage.zesty.io/api/generic.json`, whose `position` field repeats
across pairs of players).
1. Schema → add/edit an integration field → connect to the endpoint above → Display Type: Text.
2. In "Configure Display Options," set Item ID to a non-unique field (e.g. `position`).
Expected outcome: a warning appears under "Item ID" (`"position" is not unique across the 10
sampled items — this can cause selections to be recognized incorrectly.`); the "Done" button
becomes disabled until a unique Item ID is chosen; hovering the info icon next to "Item ID*"
shows the uniqueness-guidance tooltip. Verified via the new Cypress regression test above, plus
manual browser confirmation during development.

### **RECORDING:**
 
https://github.com/user-attachments/assets/7b8a7583-4c3e-4e4d-983a-0bdaa27b986f



Closes #4091

🤖 Generated with [Claude Code](https://claude.com/claude-code)
