### PR TITLE
Content - Add Schedule Unpublish feature

### DIFF
--- a/cypress/e2e/content/actions.spec.js
+++ b/cypress/e2e/content/actions.spec.js
@@ -245,6 +245,67 @@ describe("Actions in content editor", () => {
     cy.getBySelector("ContentPublishedIndicator").should("exist");
   });
 
+  it("Schedules an item for unpublishing", () => {
+    const { items, publishItem, publishings } = awaitRequests();
+    cy.visit(
+      `/content/${Cypress.env("modelZUID")}/${CONTENT_ITEMS?.[4]?.meta?.ZUID}`
+    );
+    cy.wait([items, publishings], { requestTimeout });
+
+    cy.getBySelector("PublishMenuButton").should("exist").should("be.enabled");
+    cy.getBySelector("PublishMenuButton").click();
+
+    cy.getBySelector("publishingMenu")
+      .should("exist")
+      .within(() => {
+        cy.getBySelector("UnpublishScheduleButton").should("exist");
+        cy.getBySelector("UnpublishScheduleButton").click();
+      });
+
+    cy.getBySelector("ScheduleUnpublishModal")
+      .should("exist")
+      .within(() => {
+        cy.getBySelector("ScheduleUnpublishButton").should("exist");
+        cy.getBySelector("ScheduleUnpublishButton").click();
+      });
+
+    cy.wait(publishItem);
+    cy.wait(publishings);
+
+    cy.getBySelector("ScheduledUnpublishIndicator").should("exist");
+  });
+
+  it("Unschedules an item's unpublish", () => {
+    const { items, publishItem, publishings } = awaitRequests();
+    cy.visit(
+      `/content/${Cypress.env("modelZUID")}/${CONTENT_ITEMS?.[4]?.meta?.ZUID}`
+    );
+    cy.wait([items, publishings], { requestTimeout });
+
+    cy.getBySelector("PublishMenuButton").should("exist").should("be.enabled");
+    cy.getBySelector("PublishMenuButton").click();
+
+    cy.getBySelector("publishingMenu")
+      .should("exist")
+      .within(() => {
+        cy.getBySelector("UnpublishScheduleButton")
+          .should("exist")
+          .should("contain", "Unschedule Unpublish")
+          .click();
+      });
+
+    cy.getBySelector("ScheduleUnpublishModal")
+      .should("exist")
+      .within(() => {
+        cy.getBySelector("UnscheduleUnpublishButton").should("exist");
+        cy.getBySelector("UnscheduleUnpublishButton").click();
+      });
+
+    cy.wait([publishItem, publishings], { requestTimeout });
+
+    cy.getBySelector("ScheduledUnpublishIndicator").should("not.exist");
+  });
+
   it("Unpublishes an item", () => {
     const { items, deletePublishedItem, publishings } = awaitRequests();
     cy.visit(

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/ItemEditHeaderActions.tsx
@@ -156,6 +156,10 @@ export const ItemEditHeaderActions = ({
   const activePublishing = itemPublishings?.find(
     (itemPublishing) => itemPublishing._active
   );
+  const hasScheduledUnpublish = !!(
+    activePublishing?.unpublishAt &&
+    new Date(activePublishing.unpublishAt).getTime() > Date.now()
+  );
   const { data: statusLabels } = useGetWorkflowStatusLabelsQuery();
   const { data: itemWorkflowStatus, isLoading: isLoadingItemWorkflowStatus } =
     useGetItemWorkflowStatusQuery(
@@ -772,6 +776,8 @@ export const ItemEditHeaderActions = ({
         setPublishAfterSave={setPublishAfterSave}
         setScheduleAfterSave={setScheduleAfterSave}
         setUnpublishDialogOpen={setUnpublishDialogOpen}
+        hasScheduledUnpublish={hasScheduledUnpublish}
+        openScheduleUnpublishDialog={() => setScheduledPublishDialogOpen(true)}
         setScheduledPublishDialogOpen={(open) => {
           if (!allowPublish) {
             dispatch(
@@ -806,12 +812,19 @@ export const ItemEditHeaderActions = ({
       {scheduledPublishDialogOpen && (
         <SchedulePublish
           item={item}
+          mode={itemState === ITEM_STATES.published ? "unpublish" : "publish"}
+          hasScheduledUnpublish={hasScheduledUnpublish}
+          scheduledUnpublishAt={activePublishing?.unpublishAt}
           onClose={() => {
             setScheduledPublishDialogOpen(false);
           }}
           onPublishNow={() => {
             handlePublish();
             setScheduledPublishDialogOpen(false);
+          }}
+          onUnpublishNow={() => {
+            setScheduledPublishDialogOpen(false);
+            setUnpublishDialogOpen(true);
           }}
           onUnscheduleSuccess={() => {
             if (publishAfterUnschedule) {
@@ -890,6 +903,8 @@ type PublishingMenuProps = {
   setScheduledPublishDialogOpen: (value: boolean) => void;
   setPublishAfterUnschedule: () => void;
   handlePublish: () => void;
+  hasScheduledUnpublish?: boolean;
+  openScheduleUnpublishDialog: () => void;
   modelZUID: string;
   itemZUID: string;
 };
@@ -905,6 +920,8 @@ const PublishingMenu = ({
   setScheduledPublishDialogOpen,
   setPublishAfterUnschedule,
   handlePublish,
+  hasScheduledUnpublish,
+  openScheduleUnpublishDialog,
   modelZUID,
   itemZUID,
 }: PublishingMenuProps) => {
@@ -978,9 +995,6 @@ const PublishingMenu = ({
               case ITEM_STATES.scheduled:
                 setScheduledPublishDialogOpen(true);
                 break;
-              case ITEM_STATES.published:
-                console.log("schedule unpublish");
-                break;
               case ITEM_STATES.draft:
                 setScheduledPublishDialogOpen(true);
                 break;
@@ -996,9 +1010,23 @@ const PublishingMenu = ({
             ? "Save & Schedule Publish"
             : itemState === ITEM_STATES.scheduled
             ? "Unschedule Publish"
-            : itemState === ITEM_STATES.published
-            ? "Schedule Unpublish"
             : "Schedule Publish"}
+        </MenuItem>
+      )}
+      {itemState === ITEM_STATES.published && (
+        <MenuItem
+          onClick={() => {
+            openScheduleUnpublishDialog();
+            onClose();
+          }}
+          data-cy="UnpublishScheduleButton"
+        >
+          <ListItemIcon>
+            <CalendarTodayRounded fontSize="small" />
+          </ListItemIcon>
+          {hasScheduledUnpublish
+            ? "Unschedule Unpublish"
+            : "Schedule Unpublish"}
         </MenuItem>
       )}
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/PublishStatus.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/ItemEditHeader/PublishStatus.tsx
@@ -30,6 +30,12 @@ export const PublishStatus = ({ currentVersion }: PublishStatusProps) => {
       new Date(item.publishAt).getTime() > Date.now() &&
       !item.unpublishAt
   );
+  const scheduledUnpublishing = itemPublishings?.find(
+    (item) =>
+      item._active &&
+      item.unpublishAt &&
+      new Date(item.unpublishAt).getTime() > Date.now()
+  );
 
   const getUsername = (userZUID: string) => {
     const user = users?.find((user) => user.ZUID === userZUID);
@@ -96,6 +102,40 @@ export const PublishStatus = ({ currentVersion }: PublishStatusProps) => {
                 letterSpacing="0.46px"
               >
                 v{scheduledPublishing.version} Scheduled
+              </Typography>
+            </Stack>
+          </Tooltip>
+        )}
+      {scheduledUnpublishing &&
+        scheduledUnpublishing.version === currentVersion && (
+          <Tooltip
+            enterDelay={1000}
+            enterNextDelay={1000}
+            title={
+              <>
+                v{scheduledUnpublishing.version} scheduled to unpublish on{" "}
+                <br />
+                {formatDate(scheduledUnpublishing.unpublishAt)} <br />
+                by {getUsername(scheduledUnpublishing.publishedByUserZUID)}
+              </>
+            }
+            placement="bottom-start"
+          >
+            <Stack
+              data-cy="ScheduledUnpublishIndicator"
+              direction="row"
+              gap={1}
+              alignItems="center"
+            >
+              <ScheduleRounded fontSize="small" color="warning" />
+              <Typography
+                variant="body2"
+                color="warning.main"
+                fontWeight={500}
+                lineHeight="24px"
+                letterSpacing="0.46px"
+              >
+                v{scheduledUnpublishing.version} Scheduled Unpublish
               </Typography>
             </Stack>
           </Tooltip>

--- a/src/shell/components/SchedulePublish/index.tsx
+++ b/src/shell/components/SchedulePublish/index.tsx
@@ -27,8 +27,12 @@ import { zonedTimeToUtc, formatInTimeZone } from "date-fns-tz";
 
 type SchedulePublishProps = {
   item: ContentItemWithDirtyAndPublishing;
+  mode?: "publish" | "unpublish";
+  hasScheduledUnpublish?: boolean;
+  scheduledUnpublishAt?: string;
   onClose: () => void;
   onPublishNow: () => void;
+  onUnpublishNow?: () => void;
   onScheduleSuccess?: () => void;
   onUnscheduleSuccess?: () => void;
 };
@@ -36,10 +40,15 @@ type SchedulePublishProps = {
 export const SchedulePublish = ({
   onClose,
   item,
+  mode = "publish",
+  hasScheduledUnpublish,
+  scheduledUnpublishAt,
   onPublishNow,
+  onUnpublishNow,
   onScheduleSuccess,
   onUnscheduleSuccess,
 }: SchedulePublishProps) => {
+  const isUnpublishMode = mode === "unpublish";
   const dispatch = useDispatch();
   const { data: users } = useGetUsersQuery();
 
@@ -71,11 +80,11 @@ export const SchedulePublish = ({
     ? isBefore(selectedUtc, new Date())
     : false;
 
-  const handleSchedulePublish = () => {
+  const handleSchedule = () => {
     setIsLoading(true);
 
     // API value must be UTC "YYYY-MM-DD HH:mm:ss"
-    const publishAtUtcStr = formatInTimeZone(
+    const selectedAtUtcStr = formatInTimeZone(
       selectedUtc,
       "UTC",
       "yyyy-MM-dd HH:mm:ss"
@@ -92,10 +101,9 @@ export const SchedulePublish = ({
       publish(
         item?.meta?.contentModelZUID,
         item?.meta?.ZUID,
-        {
-          publishAt: publishAtUtcStr,
-          version: item?.meta?.version,
-        },
+        isUnpublishMode
+          ? { unpublishAt: selectedAtUtcStr, version: item?.meta?.version }
+          : { publishAt: selectedAtUtcStr, version: item?.meta?.version },
         {
           localTime: localPretty,
           localTimezone: publishTimezone,
@@ -109,39 +117,72 @@ export const SchedulePublish = ({
     });
   };
 
-  const handleUnschedulePublish = () => {
+  const handleUnschedule = () => {
     setIsLoading(true);
 
-    dispatch(
-      unpublish(
-        item?.meta?.contentModelZUID,
-        item?.meta?.ZUID,
-        item?.scheduling?.ZUID,
-        { version: item?.scheduling?.version }
-      )
-      // @ts-expect-error untyped action
-    ).finally(() => {
-      setIsLoading(false);
-      onClose();
-      onUnscheduleSuccess?.();
-    });
+    if (isUnpublishMode) {
+      dispatch(
+        publish(item?.meta?.contentModelZUID, item?.meta?.ZUID, {
+          publishAt: "now",
+          unpublishAt: "never",
+          version: item?.meta?.version,
+        })
+        // @ts-expect-error untyped action
+      ).finally(() => {
+        setIsLoading(false);
+        onClose();
+        onUnscheduleSuccess?.();
+      });
+    } else {
+      dispatch(
+        unpublish(
+          item?.meta?.contentModelZUID,
+          item?.meta?.ZUID,
+          item?.scheduling?.ZUID,
+          { version: item?.scheduling?.version }
+        )
+        // @ts-expect-error untyped action
+      ).finally(() => {
+        setIsLoading(false);
+        onClose();
+        onUnscheduleSuccess?.();
+      });
+    }
   };
 
   const guessedTz = tzGuess;
-  const scheduledLocalText = item?.scheduling?.publishAt
-    ? formatInTimeZone(
-        item.scheduling.publishAt,
-        guessedTz,
-        "MMM d, yyyy 'at' h:mm a"
-      )
+  const isAlreadyScheduled = isUnpublishMode
+    ? !!hasScheduledUnpublish
+    : !!item?.scheduling?.isScheduled;
+
+  const scheduledAtSource = isUnpublishMode
+    ? scheduledUnpublishAt
+    : item?.scheduling?.publishAt;
+  const scheduledLocalText = scheduledAtSource
+    ? formatInTimeZone(scheduledAtSource, guessedTz, "MMM d, yyyy 'at' h:mm a")
     : "";
 
   const tzLabel =
     TIMEZONES.find((tz) => tz.id === guessedTz)?.label || guessedTz;
 
+  const scheduledActionVerb = isUnpublishMode ? "unpublish" : "publish";
+
+  let dialogTitlePrefix;
+  if (isUnpublishMode && isAlreadyScheduled) {
+    dialogTitlePrefix = "Unschedule Unpublish:";
+  } else if (isUnpublishMode) {
+    dialogTitlePrefix = "Schedule Unpublish:";
+  } else if (isAlreadyScheduled) {
+    dialogTitlePrefix = "Unschedule Publish:";
+  } else {
+    dialogTitlePrefix = "Schedule Publish:";
+  }
+
   return (
     <Dialog
-      data-cy="SchedulePublishModal"
+      data-cy={
+        isUnpublishMode ? "ScheduleUnpublishModal" : "SchedulePublishModal"
+      }
       open
       onClose={onClose}
       PaperProps={{ sx: { maxWidth: 640, width: 640 } }}
@@ -159,7 +200,7 @@ export const SchedulePublish = ({
               alignItems: "center",
             }}
           >
-            {item?.scheduling?.isScheduled ? (
+            {isAlreadyScheduled ? (
               <CalendarTodayRoundedIcon color="warning" />
             ) : (
               <ScheduleRoundedIcon color="warning" />
@@ -168,9 +209,7 @@ export const SchedulePublish = ({
           <Box>
             <Box mb={1}>
               <Typography variant="h5" display="inline" fontWeight={700}>
-                {item?.scheduling?.isScheduled
-                  ? "Unschedule Publish:"
-                  : "Schedule Publish:"}
+                {dialogTitlePrefix}
                 &nbsp;
               </Typography>
               <Typography variant="h5" display="inline">
@@ -179,8 +218,8 @@ export const SchedulePublish = ({
             </Box>
 
             <Typography variant="body2" color="text.secondary">
-              {item?.scheduling?.isScheduled
-                ? `v${item?.web?.version} is scheduled to publish on ${scheduledLocalText} in ${tzLabel}.`
+              {isAlreadyScheduled
+                ? `v${item?.web?.version} is scheduled to ${scheduledActionVerb} on ${scheduledLocalText} in ${tzLabel}.`
                 : `v${item?.web?.version} saved ${
                     item?.web?.createdAt
                       ? formatDistanceToNow(new Date(item.web.createdAt), {
@@ -195,8 +234,12 @@ export const SchedulePublish = ({
         </Stack>
       </DialogTitle>
 
-      <DialogContent data-cy="PublishScheduleModal">
-        {item?.scheduling?.isScheduled ? (
+      <DialogContent
+        data-cy={
+          isUnpublishMode ? "UnpublishScheduleModal" : "PublishScheduleModal"
+        }
+      >
+        {isAlreadyScheduled ? (
           <Alert severity="info" icon={<InfoRoundedIcon />}>
             This will enable the ability to schedule or publish other versions
             of this content item
@@ -204,7 +247,7 @@ export const SchedulePublish = ({
         ) : (
           <>
             <Typography variant="subtitle2" fontWeight={600} mb={0.5}>
-              Publish on
+              {isUnpublishMode ? "Unpublish on" : "Publish on"}
             </Typography>
             <FieldTypeDateTime
               disablePast
@@ -226,7 +269,7 @@ export const SchedulePublish = ({
                 sx={{ mt: 2.5 }}
               >
                 Since the selected time is a current or past date, this will be
-                immediately published.
+                immediately {isUnpublishMode ? "unpublished" : "published"}.
               </Alert>
             )}
           </>
@@ -235,7 +278,11 @@ export const SchedulePublish = ({
 
       <DialogActions>
         <Button
-          data-cy="CancelSchedulePublishButton"
+          data-cy={
+            isUnpublishMode
+              ? "CancelScheduleUnpublishButton"
+              : "CancelSchedulePublishButton"
+          }
           variant="text"
           color="inherit"
           onClick={onClose}
@@ -244,32 +291,46 @@ export const SchedulePublish = ({
           Cancel
         </Button>
 
-        {item?.scheduling?.isScheduled ? (
+        {isAlreadyScheduled ? (
           <Button
-            data-cy="UnschedulePublishButton"
+            data-cy={
+              isUnpublishMode
+                ? "UnscheduleUnpublishButton"
+                : "UnschedulePublishButton"
+            }
             variant="contained"
             color="warning"
             startIcon={<CalendarTodayRoundedIcon />}
-            onClick={handleUnschedulePublish}
+            onClick={handleUnschedule}
             loading={isLoading}
           >
-            Unschedule Publish
+            {isUnpublishMode
+              ? "Cancel Scheduled Unpublish"
+              : "Unschedule Publish"}
           </Button>
         ) : (
           <Button
-            data-cy="SchedulePublishButton"
+            data-cy={
+              isUnpublishMode
+                ? "ScheduleUnpublishButton"
+                : "SchedulePublishButton"
+            }
             variant="contained"
             startIcon={<ScheduleRoundedIcon />}
             onClick={() => {
               if (isSelectedDatetimePast) {
-                onPublishNow();
+                if (isUnpublishMode) {
+                  onUnpublishNow ? onUnpublishNow() : handleSchedule();
+                } else {
+                  onPublishNow();
+                }
               } else {
-                handleSchedulePublish();
+                handleSchedule();
               }
             }}
             loading={isLoading}
           >
-            Schedule Publish
+            {isUnpublishMode ? "Schedule Unpublish" : "Schedule Publish"}
           </Button>
         )}
       </DialogActions>

--- a/src/shell/store/content.js
+++ b/src/shell/store/content.js
@@ -876,9 +876,17 @@ export function publish(modelZUID, itemZUID, data, meta = {}) {
         }
       })
       .then(() => {
-        const message = data.publishAt
-          ? `Scheduled ${title} to publish on ${meta.localTime} in the ${meta.localTimezone} timezone`
-          : `Published ${title} now`;
+        let message;
+
+        if (data.unpublishAt && data.unpublishAt !== "never") {
+          message = `Scheduled ${title} to unpublish on ${meta.localTime} in the ${meta.localTimezone} timezone`;
+        } else if (data.unpublishAt === "never") {
+          message = `Cancelled scheduled unpublish for ${title}`;
+        } else if (data.publishAt) {
+          message = `Scheduled ${title} to publish on ${meta.localTime} in the ${meta.localTimezone} timezone`;
+        } else {
+          message = `Published ${title} now`;
+        }
 
         return dispatch(
           notify({
@@ -896,9 +904,18 @@ export function publish(modelZUID, itemZUID, data, meta = {}) {
         return dispatch(fetchItemPublishing(modelZUID, itemZUID));
       })
       .catch((err) => {
-        const message = data.publishAt
-          ? `Error scheduling ${title}`
-          : `Error publishing ${title}`;
+        let message;
+
+        if (data.unpublishAt && data.unpublishAt !== "never") {
+          message = `Error scheduling unpublish for ${title}`;
+        } else if (data.unpublishAt === "never") {
+          message = `Error cancelling scheduled unpublish for ${title}`;
+        } else if (data.publishAt) {
+          message = `Error scheduling ${title}`;
+        } else {
+          message = `Error publishing ${title}`;
+        }
+
         dispatch(
           notify({
             message,


### PR DESCRIPTION
## Summary
Adds a "Schedule Unpublish" action for published content items, mirroring the existing Schedule Publish UX. Users can now set a future date/time for a published item to automatically unpublish, unschedule that unpublish, or unpublish immediately from the same dialog.

## Changes
- Extend the `SchedulePublish` dialog with a `mode` prop (`publish` | `unpublish`) so it can drive scheduling either direction via the existing `publish()` thunk (`unpublishAt` instead of `publishAt`) — no new API endpoint.
- Add a "Schedule Unpublish" / "Unschedule Unpublish" menu action on published items, gated on published state, plus an "Unpublish now" path from the dialog.
- Add a "Scheduled Unpublish" status badge/tooltip to `PublishStatus` showing the scheduled date and who scheduled it.
- Add Cypress coverage for scheduling and unscheduling an unpublish.

## Recording:
https://github.com/user-attachments/assets/9592b6b1-6ebb-4902-ac48-99a053dfdea0


## Testing
- Added `cypress/e2e/content/actions.spec.js` cases: "Schedules an item for unpublishing" and "Unschedules an item's unpublish", following the existing schedule/unschedule-publish spec pattern.

## Related
Refs #3151

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
