### PR TITLE
Global Search - Use correct block icon

### DIFF
--- a/src/shell/components/GlobalSearch/components/config.ts
+++ b/src/shell/components/GlobalSearch/components/config.ts
@@ -96,7 +96,7 @@ export const SEARCH_ACCELERATORS: Record<ResourceType, SearchAccelerator> = {
     text: "Code",
   },
   block: {
-    icon: CodeRounded,
+    icon: Block as SvgIconComponent,
     text: "Block",
   },
 } as const;


### PR DESCRIPTION
Use correct block icon in search accelerator
Resolves #4171 

<img width="492" height="109" alt="image" src="https://github.com/user-attachments/assets/c9160c64-c3fb-4d0c-a6e0-b19711f53328" />
