### PR TITLE
Studio - Add element Attributes panel (img/video/text, tag swap, video attrs)

### DIFF
--- a/cypress/e2e/studio/attributes-panel.spec.js
+++ b/cypress/e2e/studio/attributes-panel.spec.js
@@ -38,6 +38,8 @@ describe("Studio Attributes Panel", () => {
     cy.getBySelector(`${prefix}SaveChangesButton`).click();
     cy.getBySelector("StudioSaveChangesModal").should("exist");
     cy.getBySelector("StudioSaveAllButton").click();
+    // Let the modal fade out before any subsequent query.
+    cy.getBySelector("StudioSaveChangesModal").should("not.exist");
   };
 
   // Open a MUI TextField `select` (the data-cy sits on its hidden native input,

--- a/cypress/e2e/studio/attributes-panel.spec.js
+++ b/cypress/e2e/studio/attributes-panel.spec.js
@@ -1,0 +1,271 @@
+import { API_ENDPOINTS } from "../../support/api";
+
+// The Attributes panel is driven entirely by the in-iframe bridge via a
+// `LAYERS_TREE` postMessage. As every studio spec does, we impersonate the
+// bridge from the parent window (the real cross-origin preview is never
+// touched) and assert on the host React UI plus the same-origin web/views PUT.
+describe("Studio Attributes Panel", () => {
+  let studioPath = "/";
+  let modelZUID = "";
+
+  const postBridgeMessage = (message) => {
+    cy.getBySelector("StudioHeader").should("exist");
+    cy.window().then(
+      (win) =>
+        new Cypress.Promise((resolve) => {
+          win.requestAnimationFrame(() => {
+            win.requestAnimationFrame(() => {
+              win.postMessage({ source: "studio-bridge", message }, "*");
+              resolve();
+            });
+          });
+        })
+    );
+  };
+
+  const feedTree = (node) =>
+    postBridgeMessage({ type: "LAYERS_TREE", tree: [node] });
+
+  const setStudioMode = (mode) => {
+    cy.getBySelector("StudioHeader").should("exist");
+    cy.getBySelector("StudioModeToggle")
+      .find('input[type="checkbox"]')
+      [mode === "layout" ? "check" : "uncheck"]();
+  };
+
+  const saveAllViaModal = (mode = "layout") => {
+    const prefix = mode === "layout" ? "StudioLayout" : "StudioContent";
+    cy.getBySelector(`${prefix}SaveChangesButton`).click();
+    cy.getBySelector("StudioSaveChangesModal").should("exist");
+    cy.getBySelector("StudioSaveAllButton").click();
+  };
+
+  // Open a MUI TextField `select` (the data-cy sits on its hidden native input,
+  // whose InputBase parent is the clickable control) and pick an option by its
+  // stable semantic value.
+  const selectMuiOption = (dataCy, optionValue) => {
+    cy.getBySelector(dataCy).parent().click();
+    cy.get(`[role="option"][data-value="${optionValue}"]`).click();
+  };
+
+  const attrSlot = (attr, label, value = "") => ({
+    kind: "attribute",
+    key: attr,
+    attr,
+    label,
+    isDynamic: false,
+    value,
+    layoutEditable: true,
+    control: "text",
+  });
+
+  const boolSlot = (attr, label, trueLabel, falseLabel) => ({
+    kind: "attribute",
+    key: attr,
+    attr,
+    label,
+    isDynamic: false,
+    value: "false",
+    layoutEditable: true,
+    control: "select",
+    booleanAttr: true,
+    options: [
+      { value: "true", label: trueLabel },
+      { value: "false", label: falseLabel },
+    ],
+  });
+
+  const elementNode = (codeId, tagName, slots) => ({
+    id: `${codeId}:1`,
+    kind: "element",
+    tagName,
+    codeId,
+    layoutId: "1",
+    layoutPatch: {
+      codeId,
+      layoutId: "1",
+      isSelf: true,
+      tagName,
+      elementIndex: 0,
+    },
+    slots,
+    children: [],
+  });
+
+  const imgNode = (codeId) =>
+    elementNode(codeId, "img", [
+      attrSlot("src", "Source", "a.jpg"),
+      attrSlot("alt", "Alt text", "hero"),
+    ]);
+
+  const videoNode = (codeId) =>
+    elementNode(codeId, "video", [
+      attrSlot("src", "Source", "a.mp4"),
+      boolSlot("controls", "Video Control Visibility", "Show", "Hide"),
+      boolSlot("autoplay", "Autoplay", "Yes", "No"),
+      boolSlot("muted", "Mute Video", "Yes", "No"),
+      boolSlot("loop", "Loop Video", "Yes", "No"),
+      attrSlot("poster", "Video Poster"),
+    ]);
+
+  const headingNode = (codeId) =>
+    elementNode(codeId, "h1", [
+      {
+        kind: "text",
+        key: "text",
+        label: "Text",
+        isDynamic: false,
+        value: "Hello",
+        layoutEditable: true,
+        control: "text",
+      },
+    ]);
+
+  // Click a specific tree row by node id (robust against any tree the real
+  // preview iframe might also emit) and confirm the panel opened.
+  const openPanelFor = (node) => {
+    cy.get(`[data-cy="StudioLayersRow"][data-node-id="${node.id}"]`).click();
+    cy.getBySelector("StudioAttributesPanel").should("exist");
+  };
+
+  // Seed the template source for a code region so layout-mode edits have a
+  // source to patch, then feed + open the matching element node.
+  const seedLayoutElement = (codeId, source, node) => {
+    postBridgeMessage({
+      type: "TEMPLATE_SOURCE_MAP",
+      templateSourceByCodeId: { [codeId]: source },
+    });
+    feedTree(node);
+    openPanelFor(node);
+  };
+
+  before(() => {
+    cy.task("seed:content", "fixtures/studio.json").then(({ model, items }) => {
+      modelZUID = model.ZUID;
+      studioPath = `/${items[0].web.pathPart}`;
+    });
+  });
+
+  after(() => {
+    if (modelZUID) cy.deleteModel(modelZUID);
+  });
+
+  beforeEach(() => {
+    cy.waitOn("/v1/content/models**", () => {
+      cy.visit(`/studio?path=${studioPath}`);
+    });
+  });
+
+  it("opens the attributes panel with read-only src + alt for an img in content mode", () => {
+    const node = imgNode("code-1");
+    feedTree(node);
+    openPanelFor(node);
+
+    // Content mode is read-only for static attributes.
+    cy.getBySelector("StudioAttrInput-src").should("exist").and("be.disabled");
+    cy.getBySelector("StudioAttrInput-alt").should("exist").and("be.disabled");
+
+    cy.getBySelector("StudioAttributesPanelClose").click();
+    cy.getBySelector("StudioAttributesPanel").should("not.exist");
+  });
+
+  it("surfaces the full video attribute set", () => {
+    const node = videoNode("code-1");
+    feedTree(node);
+    openPanelFor(node);
+
+    // Media Type selector (img/video family) + the six video attributes.
+    cy.getBySelector("StudioTagSelect").should("exist");
+    ["src", "controls", "autoplay", "muted", "loop", "poster"].forEach(
+      (key) => {
+        cy.getBySelector(`StudioAttrInput-${key}`).should("exist");
+      }
+    );
+  });
+
+  it("changes a heading's tag (h1 → h2) and saves it to the view code", () => {
+    setStudioMode("layout");
+    cy.apiRequest({
+      url: `${API_ENDPOINTS.devInstance}/web/views?status=dev`,
+    }).then(({ data }) => {
+      const webView = data?.[0];
+      expect(webView?.ZUID).to.exist;
+      cy.intercept("PUT", `/v1/web/views/${webView.ZUID}`).as("updateWebView");
+
+      seedLayoutElement(
+        webView.ZUID,
+        `<h1 data-layout-id="1">Hello</h1>`,
+        headingNode(webView.ZUID)
+      );
+
+      selectMuiOption("StudioTagSelect", "h2");
+
+      cy.getBySelector("StudioLayoutSaveBar").should("exist");
+      saveAllViaModal("layout");
+
+      cy.wait("@updateWebView").then(({ request }) => {
+        expect(request.body.code).to.contain("<h2");
+        expect(request.body.code).to.contain("Hello");
+        expect(request.body.code).not.to.contain("<h1");
+      });
+    });
+  });
+
+  it("swaps an img to a video (Media Type) and saves the new tag", () => {
+    setStudioMode("layout");
+    cy.apiRequest({
+      url: `${API_ENDPOINTS.devInstance}/web/views?status=dev`,
+    }).then(({ data }) => {
+      const webView = data?.[0];
+      expect(webView?.ZUID).to.exist;
+      cy.intercept("PUT", `/v1/web/views/${webView.ZUID}`).as("updateWebView");
+
+      seedLayoutElement(
+        webView.ZUID,
+        `<img data-layout-id="1" src="a.jpg" alt="hero">`,
+        imgNode(webView.ZUID)
+      );
+
+      selectMuiOption("StudioTagSelect", "video");
+      // The panel reflects the swap immediately.
+      cy.getBySelector("StudioAttributesPanel").should("contain", "Video");
+
+      cy.getBySelector("StudioLayoutSaveBar").should("exist");
+      saveAllViaModal("layout");
+
+      cy.wait("@updateWebView").then(({ request }) => {
+        expect(request.body.code).to.contain("<video");
+        expect(request.body.code).to.contain("a.jpg");
+        expect(request.body.code).not.to.contain("<img");
+      });
+    });
+  });
+
+  it("toggles a boolean video attribute (controls) and saves its presence", () => {
+    setStudioMode("layout");
+    cy.apiRequest({
+      url: `${API_ENDPOINTS.devInstance}/web/views?status=dev`,
+    }).then(({ data }) => {
+      const webView = data?.[0];
+      expect(webView?.ZUID).to.exist;
+      cy.intercept("PUT", `/v1/web/views/${webView.ZUID}`).as("updateWebView");
+
+      seedLayoutElement(
+        webView.ZUID,
+        `<video data-layout-id="1" src="a.mp4"></video>`,
+        videoNode(webView.ZUID)
+      );
+
+      // "Show" adds the bare `controls` attribute.
+      selectMuiOption("StudioAttrInput-controls", "true");
+
+      cy.getBySelector("StudioLayoutSaveBar").should("exist");
+      saveAllViaModal("layout");
+
+      cy.wait("@updateWebView").then(({ request }) => {
+        expect(request.body.code).to.contain("controls");
+        expect(request.body.code).to.contain("<video");
+      });
+    });
+  });
+});

--- a/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
@@ -1223,6 +1223,14 @@ export const StudioWrapper = () => {
   const slotPatchTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>(
     {}
   );
+  // Clear any pending debounced slot patches when the studio unmounts so a
+  // timer never fires into a stale closure.
+  useEffect(
+    () => () => {
+      Object.values(slotPatchTimers.current).forEach(clearTimeout);
+    },
+    []
+  );
   const handleSlotChange = useCallback(
     (slot: ElementSlot, value: string) => {
       const patch = selectedAttributeElement?.layoutPatch;

--- a/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
@@ -43,6 +43,7 @@ import {
 import { StudioHeader } from "./components/StudioWrapper/StudioHeader";
 import { StudioPreview } from "./components/StudioWrapper/StudioPreview";
 import { StudioSidePanel } from "./components/StudioWrapper/StudioSidePanel";
+import { StudioAttributesPanel } from "./components/StudioWrapper/StudioAttributesPanel";
 import { StudioLayersPanel } from "./components/StudioWrapper/StudioLayersPanel";
 import {
   StudioSaveChange,
@@ -54,7 +55,11 @@ import {
   useStudioContentSave,
 } from "./hooks/useStudioContentSave";
 import { useStudioBridge } from "./hooks/useStudioBridge";
-import { InteractionMode, LayoutBreadcrumbItem } from "./hooks/studioTypes";
+import {
+  ElementSlot,
+  InteractionMode,
+  LayoutBreadcrumbItem,
+} from "./hooks/studioTypes";
 import { useStudioSelection } from "./hooks/useStudioSelection";
 import { useStudioLayersTree } from "./hooks/useStudioLayersTree";
 import { getRefRegistry } from "../../../../../../engine/refRegistry";
@@ -106,6 +111,12 @@ export const StudioWrapper = () => {
     isLeafImg: boolean;
     imgIndex: number;
     currentSrc: string;
+    // Set when the picker was opened from the Attributes panel, so the panel's
+    // displayed value updates after a pick. `attr` is the target attribute
+    // (src or poster) and `tagName` addresses nested elements.
+    fromAttributesPanel?: boolean;
+    attr?: string;
+    tagName?: string;
   } | null>(null);
   const history = useHistory();
   const location = useLocation();
@@ -164,6 +175,12 @@ export const StudioWrapper = () => {
       isLeafImg?: boolean;
       imgIndex?: number;
       newSrc?: string;
+      attr?: string;
+      isSelf?: boolean;
+      tagName?: string;
+      elementIndex?: number;
+      newTag?: string;
+      booleanAttr?: boolean;
     }) => {
       const iframeWindow = iframeRef.current?.contentWindow;
       if (!iframeWindow) return;
@@ -185,6 +202,7 @@ export const StudioWrapper = () => {
   const {
     selectedElement,
     selectedLayout,
+    selectedAttributeElement,
     panelMode,
     filteredFieldName,
     setSelectedLayout,
@@ -194,6 +212,10 @@ export const StudioWrapper = () => {
     handleLayoutBreadcrumbSelect,
     clearHighlightOnly,
     applySelection,
+    applyAttributeSelection,
+    returnToAttributes,
+    updateSelectedSlotValue,
+    refreshSelectedElementSlots,
   } = useStudioSelection({
     postCommandToBridge,
     codeFileNameById,
@@ -692,6 +714,9 @@ export const StudioWrapper = () => {
     handleReorderOutput,
     handleLayoutContentUpdate,
     handleLayoutImageSrcUpdate,
+    handleLayoutElementAttrUpdate,
+    handleLayoutTextUpdate,
+    handleLayoutTagUpdate,
   } = useLayoutReorderState({
     webViews,
     codeFileNameById,
@@ -1129,10 +1154,13 @@ export const StudioWrapper = () => {
     postCommandToBridge,
     applyBridgeSelection,
     applyLayoutSelection,
+    applyAttributeSelection,
+    refreshSelectedElementSlots,
     codeFileNameById,
     fieldsState,
     selectedElement,
     selectedLayout,
+    selectedAttributeElement,
     dndDisabled: isSavingLayout || isRefreshing,
   });
 
@@ -1171,6 +1199,119 @@ export const StudioWrapper = () => {
     setIsRefreshing(false);
     handlePreviewLoad();
   }, [handlePreviewLoad]);
+
+  // Content mode: a dynamic slot (a bound attribute or bound text) was clicked
+  // — open the existing single-field content editor for its field.
+  const handleEditDynamicSlot = useCallback(
+    (slot: ElementSlot) => {
+      if (!slot.fieldZuid) return;
+      applyBridgeSelection({
+        studioId: slot.studioId,
+        fieldZuid: slot.fieldZuid,
+        fieldType: slot.fieldType,
+        itemZuid: slot.itemZuid,
+        modelZuid: slot.modelZuid,
+      });
+    },
+    [applyBridgeSelection]
+  );
+
+  // Layout mode: a slot was edited free-text. Live-update the preview on every
+  // keystroke (cheap postMessage) but debounce the template-source patch
+  // (DOMParse + restage) so we don't reparse on each character. Attributes
+  // write via setAttribute; text writes the element's inner text.
+  const slotPatchTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>(
+    {}
+  );
+  const handleSlotChange = useCallback(
+    (slot: ElementSlot, value: string) => {
+      const patch = selectedAttributeElement?.layoutPatch;
+      if (!patch || !patch.codeId) return;
+
+      if (slot.kind === "text") {
+        postCommandToBridge({
+          action: "updateElementText",
+          layoutId: patch.layoutId,
+          value,
+        });
+        clearTimeout(slotPatchTimers.current[slot.key]);
+        slotPatchTimers.current[slot.key] = setTimeout(() => {
+          handleLayoutTextUpdate(patch.codeId!, patch.layoutId, value);
+        }, 300);
+        return;
+      }
+
+      const attr = slot.attr || slot.key;
+      postCommandToBridge({
+        action: "updateElementAttr",
+        layoutId: patch.layoutId,
+        isSelf: patch.isSelf,
+        tagName: patch.tagName,
+        elementIndex: patch.elementIndex,
+        attr,
+        value,
+        booleanAttr: slot.booleanAttr,
+      });
+      clearTimeout(slotPatchTimers.current[slot.key]);
+      slotPatchTimers.current[slot.key] = setTimeout(() => {
+        handleLayoutElementAttrUpdate(
+          patch.codeId!,
+          patch.layoutId,
+          patch.isSelf,
+          patch.tagName,
+          patch.elementIndex,
+          attr,
+          value,
+          slot.booleanAttr
+        );
+      }, 300);
+    },
+    [
+      handleLayoutElementAttrUpdate,
+      handleLayoutTextUpdate,
+      postCommandToBridge,
+      selectedAttributeElement,
+    ]
+  );
+
+  // Layout mode: change the element's tag (e.g. h1 → h2, img → video). Only
+  // valid when the element carries its own data-layout-id (isSelf), since the
+  // swap is addressed by layout id. Applied immediately — it's a discrete
+  // select change, not per-keystroke.
+  const handleTagChange = useCallback(
+    (newTag: string) => {
+      const patch = selectedAttributeElement?.layoutPatch;
+      if (!patch || !patch.codeId || !patch.isSelf) return;
+      postCommandToBridge({
+        action: "updateElementTag",
+        layoutId: patch.layoutId,
+        newTag,
+      });
+      handleLayoutTagUpdate(patch.codeId, patch.layoutId, newTag);
+    },
+    [handleLayoutTagUpdate, postCommandToBridge, selectedAttributeElement]
+  );
+
+  // Layout mode: open the media picker for a media-URL slot (src or poster).
+  // Reuses the img media-picker dialog; the tag-agnostic patch maps onto its
+  // isLeafImg / imgIndex addressing, and `attr` records which attribute to set.
+  const handleBrowseAttributeMedia = useCallback(
+    (slot: ElementSlot) => {
+      const patch = selectedAttributeElement?.layoutPatch;
+      if (!patch || !patch.codeId) return;
+      setImageEditState({
+        codeId: patch.codeId,
+        layoutId: patch.layoutId,
+        isLeafImg: patch.isSelf,
+        imgIndex: patch.elementIndex,
+        currentSrc: slot.value,
+        fromAttributesPanel: true,
+        attr: slot.attr || "src",
+        tagName: patch.tagName,
+      });
+    },
+    [selectedAttributeElement]
+  );
 
   const renderInfoPanel = () => {
     if (!isResolved) {
@@ -1224,7 +1365,17 @@ export const StudioWrapper = () => {
         isLoadingItem={isSelectedItemLoading}
         visibleFieldName={filteredFieldName || undefined}
       />
-      {filteredFieldName ? (
+      {selectedAttributeElement ? (
+        <Button
+          data-cy="StudioBackToAttributes"
+          variant="outlined"
+          size="large"
+          fullWidth
+          onClick={returnToAttributes}
+        >
+          Back to Image Attributes
+        </Button>
+      ) : filteredFieldName ? (
         <Button
           variant="outlined"
           size="large"
@@ -1291,13 +1442,31 @@ export const StudioWrapper = () => {
               isBusy={isRefreshing || studioSaving || isSavingLayout}
               onLoad={handlePreviewFrameLoad}
             />
-            {interactionMode === "content" ? (
+            {panelMode === "attributes" && selectedAttributeElement ? (
+              <StudioAttributesPanel
+                mode={interactionMode}
+                elementKey={selectedAttributeElement.nodeId}
+                tagName={selectedAttributeElement.tagName}
+                slots={selectedAttributeElement.slots}
+                canChangeTag={
+                  interactionMode === "layout" &&
+                  !!selectedAttributeElement.layoutPatch?.isSelf
+                }
+                onChangeTag={handleTagChange}
+                onClose={requestClearSelection}
+                onEditDynamicSlot={handleEditDynamicSlot}
+                onChangeSlot={handleSlotChange}
+                onBrowseMedia={handleBrowseAttributeMedia}
+                drawerWidth={drawerWidth}
+                logoSrc={contentOneLogo}
+              />
+            ) : interactionMode === "content" ? (
               <StudioSidePanel
                 headerTitle={headerTitle}
                 selectedItemLabel={selectedItemLabel}
                 pageItemVersion={pageItemVersion}
                 unresolvedPath={unresolvedPath}
-                panelMode={panelMode}
+                panelMode={panelMode === "edit" ? "edit" : "info"}
                 clearSelection={requestClearSelection}
                 activeVersion={activeVersion}
                 selectedModelZUID={selectedModelZUID}
@@ -1433,20 +1602,46 @@ export const StudioWrapper = () => {
               addImagesCallback={(images: any[]) => {
                 if (!images.length) return;
                 const newSrc = images[0].url;
-                handleLayoutImageSrcUpdate(
-                  imageEditState.codeId,
-                  imageEditState.layoutId,
-                  imageEditState.isLeafImg,
-                  imageEditState.imgIndex,
-                  newSrc
-                );
-                postCommandToBridge({
-                  action: "updateImageSrc",
-                  layoutId: imageEditState.layoutId,
-                  isLeafImg: imageEditState.isLeafImg,
-                  imgIndex: imageEditState.imgIndex,
-                  newSrc,
-                });
+                if (imageEditState.fromAttributesPanel) {
+                  // Attributes-panel Browse: write the chosen URL to the
+                  // recorded attribute (src or poster) via the generic path.
+                  const attr = imageEditState.attr || "src";
+                  handleLayoutElementAttrUpdate(
+                    imageEditState.codeId,
+                    imageEditState.layoutId,
+                    imageEditState.isLeafImg,
+                    imageEditState.tagName || "img",
+                    imageEditState.imgIndex,
+                    attr,
+                    newSrc
+                  );
+                  postCommandToBridge({
+                    action: "updateElementAttr",
+                    layoutId: imageEditState.layoutId,
+                    isSelf: imageEditState.isLeafImg,
+                    tagName: imageEditState.tagName || "img",
+                    elementIndex: imageEditState.imgIndex,
+                    attr,
+                    value: newSrc,
+                  });
+                  updateSelectedSlotValue(attr, newSrc);
+                } else {
+                  // Canvas image-replace flow: img-specific src update.
+                  handleLayoutImageSrcUpdate(
+                    imageEditState.codeId,
+                    imageEditState.layoutId,
+                    imageEditState.isLeafImg,
+                    imageEditState.imgIndex,
+                    newSrc
+                  );
+                  postCommandToBridge({
+                    action: "updateImageSrc",
+                    layoutId: imageEditState.layoutId,
+                    isLeafImg: imageEditState.isLeafImg,
+                    imgIndex: imageEditState.imgIndex,
+                    newSrc,
+                  });
+                }
                 setImageEditState(null);
               }}
             />

--- a/src/apps/content-editor/src/app/views/ItemEdit/bridge.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/bridge.js
@@ -2084,7 +2084,7 @@
 
     if (payload.action === "updateImageSrc") {
       var imgLeaf = document.querySelector(
-        '[data-layout-id="' + payload.layoutId + '"]'
+        '[data-layout-id="' + CSS.escape(payload.layoutId) + '"]'
       );
       if (!imgLeaf) return;
       var imgTarget = payload.isLeafImg
@@ -2098,7 +2098,7 @@
 
     if (payload.action === "updateElementAttr" && payload.attr) {
       var attrLeaf = document.querySelector(
-        '[data-layout-id="' + payload.layoutId + '"]'
+        '[data-layout-id="' + CSS.escape(payload.layoutId) + '"]'
       );
       if (!attrLeaf) return;
       var attrTarget = payload.isSelf
@@ -2121,7 +2121,7 @@
     // own data-layout-id, so replacing textContent is safe.
     if (payload.action === "updateElementText") {
       var textLeaf = document.querySelector(
-        '[data-layout-id="' + payload.layoutId + '"]'
+        '[data-layout-id="' + CSS.escape(payload.layoutId) + '"]'
       );
       if (textLeaf) textLeaf.textContent = payload.value || "";
       return;
@@ -2131,8 +2131,11 @@
     // carrying over every attribute (data-layout-id, data-studio-id, class,
     // the studio-selected outline, …) and its children.
     if (payload.action === "updateElementTag" && payload.newTag) {
+      // Only swap to a tag the panel actually exposes — never createElement an
+      // arbitrary (or scripting) tag from an untrusted message.
+      if (!SUPPORTED_ELEMENTS[payload.newTag]) return;
       var tagLeaf = document.querySelector(
-        '[data-layout-id="' + payload.layoutId + '"]'
+        '[data-layout-id="' + CSS.escape(payload.layoutId) + '"]'
       );
       if (!tagLeaf || !tagLeaf.parentNode) return;
       var swapped = document.createElement(payload.newTag);

--- a/src/apps/content-editor/src/app/views/ItemEdit/bridge.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/bridge.js
@@ -1,0 +1,2838 @@
+(function () {
+  if (window.ZestyStudioBridge?.__initialized) return;
+
+  var parentOrigin = "*";
+  var markerIdPattern = /data-studio-id\s*=\s*"([^"]+)"/i;
+  var markerBoundaryPattern = /data-studio-boundary\s*=\s*"(start|end)"/i;
+  var codeIdPattern = /data-code-id\s*=\s*"([^"]+)"/i;
+  var codeBoundaryPattern = /data-code-boundary\s*=\s*"(start|end)"/i;
+  var editableFieldTypes = {
+    text: true,
+    textarea: true,
+    markdown: true,
+    wysiwyg_basic: true,
+    wysiwyg_advanced: true,
+  };
+
+  var interactionMode = "content";
+  var currentHoverStudioId = null;
+  var currentHoverLayoutId = null;
+  var lastLayoutSelectionPath = null;
+  var lastLayoutSelectionDepth = -1;
+  var reorderState = {
+    enabled: false,
+    selector: "[data-layout-id]",
+    dragEl: null,
+    dragPath: null,
+    dragPreviewEl: null,
+    dropTargetEl: null,
+    dropPosition: null,
+    dropAxis: null,
+    didDrop: false,
+    sourceCodeId: null,
+    observer: null,
+  };
+
+  var staticEditState = {
+    layoutEl: null,
+    layoutId: null,
+    codeId: null,
+  };
+  var staticEditEligibilityCache = new Map();
+
+  var studioContextById = {};
+  // All attribute bindings (entities with an `attr`) per studio id. One element
+  // can bind several attributes (e.g. an <img> src and alt) under a single
+  // data-studio-id, so this keeps the full list rather than just the first.
+  var studioAttrBindingsById = {};
+
+  var bridgeScriptUrl =
+    (document.currentScript && document.currentScript.src) || null;
+
+  // Interaction mode state
+  function syncInteractionModeClass() {
+    var root = document.documentElement || document.body;
+    if (!root) return;
+    root.classList.toggle("studio-layout-mode", interactionMode === "layout");
+  }
+
+  // Messaging + error reporting
+  function post(message) {
+    if (!window.parent || window.parent === window) return;
+    window.parent.postMessage(
+      { source: "studio-bridge", message: message },
+      parentOrigin
+    );
+  }
+
+  function reportBridgeError(kind, info) {
+    try {
+      post({
+        type: "BRIDGE_ERROR",
+        kind: kind,
+        error: {
+          message: info.message || "",
+          filename: info.filename || null,
+          lineno: info.lineno || null,
+          colno: info.colno || null,
+          stack: info.stack || null,
+        },
+      });
+    } catch (e) {}
+  }
+
+  // Runtime data loading
+  function loadStudioContextById() {
+    var contextScript = document.getElementById("studio-entities");
+
+    if (!contextScript) {
+      return {};
+    }
+
+    var raw = contextScript.textContent || "";
+    if (!raw.trim()) {
+      return {};
+    }
+
+    try {
+      var parsed = JSON.parse(raw);
+      var entities = parsed?.entities;
+      if (!entities || typeof entities !== "object") {
+        return {};
+      }
+
+      var nextContextById = {};
+      var nextAttrBindings = {};
+
+      Object.keys(entities).forEach(function (studioId) {
+        var entityList = Array.isArray(entities[studioId])
+          ? entities[studioId]
+          : [];
+        var objectEntities = entityList.filter(function (entity) {
+          return entity && typeof entity === "object" && !Array.isArray(entity);
+        });
+        var firstEntity = objectEntities[0];
+
+        if (!firstEntity) {
+          return;
+        }
+
+        nextContextById[studioId] = {
+          fieldZuid: firstEntity.fieldZUID || firstEntity.fieldZuid || "",
+          itemZuid: firstEntity.itemZUID || firstEntity.itemZuid || "",
+          modelZuid: firstEntity.modelZUID || firstEntity.modelZuid || "",
+          fieldType:
+            firstEntity.dataType ||
+            firstEntity.fieldType ||
+            firstEntity.datatype ||
+            "",
+          // Present when the field binds an element attribute (e.g. an <img>
+          // src) instead of inline text content.
+          attr: firstEntity.attr || "",
+        };
+
+        // An element can bind multiple attributes under one studio id; capture
+        // every attribute binding, not just the first.
+        var bindings = objectEntities
+          .filter(function (entity) {
+            return entity.attr;
+          })
+          .map(function (entity) {
+            return {
+              attr: entity.attr,
+              fieldZuid: entity.fieldZUID || entity.fieldZuid || "",
+              itemZuid: entity.itemZUID || entity.itemZuid || "",
+              modelZuid: entity.modelZUID || entity.modelZuid || "",
+              fieldType:
+                entity.dataType || entity.fieldType || entity.datatype || "",
+            };
+          });
+        if (bindings.length) {
+          nextAttrBindings[studioId] = bindings;
+        }
+      });
+
+      studioAttrBindingsById = nextAttrBindings;
+      return nextContextById;
+    } catch (error) {
+      reportBridgeError("context_parse", {
+        message: error?.message || "Unable to parse #studio-entities JSON",
+      });
+      return {};
+    }
+  }
+
+  studioContextById = loadStudioContextById();
+
+  window.addEventListener(
+    "error",
+    function (event) {
+      var ErrorEventCtor = window.ErrorEvent;
+      if (
+        typeof ErrorEventCtor === "function" &&
+        !(event instanceof ErrorEventCtor)
+      ) {
+        return;
+      }
+
+      if (!event.filename) return;
+      if (bridgeScriptUrl && event.filename !== bridgeScriptUrl) return;
+
+      reportBridgeError("error", {
+        message: event.message,
+        filename: event.filename,
+        lineno: event.lineno,
+        colno: event.colno,
+        stack: event.error && event.error.stack,
+      });
+    },
+    true
+  );
+
+  // Marker parsing + dataset helpers
+  function toElement(node) {
+    if (!node) return null;
+    if (node.nodeType === Node.ELEMENT_NODE) return node;
+    return node.parentElement || null;
+  }
+
+  function parseCommentMarker(commentNode, idPattern, boundaryPattern, idKey) {
+    if (!commentNode || commentNode.nodeType !== Node.COMMENT_NODE) {
+      return null;
+    }
+
+    var content = commentNode.nodeValue || "";
+    var idMatch = content.match(idPattern);
+    var boundaryMatch = content.match(boundaryPattern);
+    var markerId = idMatch?.[1];
+    var boundary = boundaryMatch?.[1];
+
+    if (!markerId || !boundary) return null;
+
+    var marker = {
+      boundary: boundary,
+    };
+    marker[idKey] = markerId;
+    return marker;
+  }
+
+  function parseMarker(commentNode) {
+    return parseCommentMarker(
+      commentNode,
+      markerIdPattern,
+      markerBoundaryPattern,
+      "studioId"
+    );
+  }
+
+  function parseCodeMarker(commentNode) {
+    return parseCommentMarker(
+      commentNode,
+      codeIdPattern,
+      codeBoundaryPattern,
+      "codeId"
+    );
+  }
+
+  function buildDataset(studioId) {
+    var context = studioContextById[studioId] || {};
+
+    return {
+      studioId: studioId || "",
+      fieldZuid: context.fieldZuid || "",
+      itemZuid: context.itemZuid || "",
+      modelZuid: context.modelZuid || "",
+      fieldType: context.fieldType || "",
+      attr: context.attr || "",
+    };
+  }
+
+  function buildLayoutDataset(layoutTarget) {
+    if (!layoutTarget) return null;
+
+    var codeRegion = resolveCodeRegionForNode(layoutTarget);
+
+    return {
+      layoutId: layoutTarget.getAttribute("data-layout-id") || "",
+      codeId: codeRegion?.codeId || "",
+    };
+  }
+
+  function getLayoutBreadcrumb(layoutTarget) {
+    if (!layoutTarget) return [];
+
+    var path = getLayoutSelectionPath(layoutTarget);
+
+    return path.map(function (node) {
+      return {
+        layoutId: node.getAttribute("data-layout-id") || "",
+        label: node.tagName.toLowerCase(),
+      };
+    });
+  }
+
+  // Code region + template helpers
+  function getTemplateSourceByCodeId() {
+    var templateSourceByCodeId = {};
+
+    document
+      .querySelectorAll("template[data-code-id]")
+      .forEach(function (node) {
+        var codeId = node.getAttribute("data-code-id");
+        if (!codeId) return;
+        templateSourceByCodeId[codeId] = node.innerHTML || "";
+      });
+
+    return templateSourceByCodeId;
+  }
+
+  function getOrderedBlocks(selector) {
+    return Array.prototype.slice.call(document.querySelectorAll(selector));
+  }
+
+  function getNodesBetween(startNode, endNode) {
+    if (!startNode || !endNode || startNode.parentNode !== endNode.parentNode) {
+      return [];
+    }
+
+    var nodes = [];
+    var current = startNode.nextSibling;
+    while (current && current !== endNode) {
+      nodes.push(current);
+      current = current.nextSibling;
+    }
+
+    return nodes;
+  }
+
+  function getOrderedBlocksWithinNodes(selector, nodes, codeId) {
+    var matches = [];
+
+    nodes.forEach(function (node) {
+      if (node.nodeType !== Node.ELEMENT_NODE) return;
+      if (
+        node.matches &&
+        node.matches(selector) &&
+        (!codeId || resolveCodeRegionForNode(node)?.codeId === codeId)
+      ) {
+        matches.push(node);
+      }
+      matches.push.apply(
+        matches,
+        Array.prototype.slice
+          .call(node.querySelectorAll(selector))
+          .filter(function (el) {
+            return !codeId || resolveCodeRegionForNode(el)?.codeId === codeId;
+          })
+      );
+    });
+
+    return matches;
+  }
+
+  function getParentLayoutId(node, selector, codeId) {
+    var current = node?.parentElement || null;
+
+    while (current) {
+      if (current.matches && current.matches(selector)) {
+        var currentCodeId = resolveCodeRegionForNode(current)?.codeId || "";
+        if (!codeId || currentCodeId === codeId) {
+          return current.getAttribute("data-layout-id") || null;
+        }
+      }
+
+      current = current.parentElement;
+    }
+
+    return null;
+  }
+
+  function getLayoutStructure(selector, nodes, codeId) {
+    return getOrderedBlocksWithinNodes(selector, nodes, codeId)
+      .map(function (el) {
+        var layoutId = el.getAttribute("data-layout-id");
+        if (!layoutId) return null;
+
+        return {
+          layoutId: layoutId,
+          parentLayoutId: getParentLayoutId(el, selector, codeId),
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function resolveCodeRegionForCodeId(codeId) {
+    if (!codeId) return null;
+    var root = document.body || document.documentElement;
+    if (!root) return null;
+
+    var walker = document.createTreeWalker(root, NodeFilter.SHOW_COMMENT);
+    var startComment = null;
+    var node = walker.nextNode();
+
+    while (node) {
+      var marker = parseCodeMarker(node);
+      if (marker && marker.codeId === codeId) {
+        if (marker.boundary === "start" && !startComment) {
+          startComment = node;
+        } else if (marker.boundary === "end" && startComment) {
+          return {
+            codeId: codeId,
+            startComment: startComment,
+            endComment: node,
+          };
+        }
+      }
+      node = walker.nextNode();
+    }
+
+    return null;
+  }
+
+  function resolveCodeRegionForNode(node) {
+    var currentNode = node;
+    var currentParent = currentNode?.parentNode || null;
+
+    while (currentNode && currentParent) {
+      var siblings = Array.prototype.slice.call(currentParent.childNodes);
+      var nodeIndex = siblings.indexOf(currentNode);
+
+      if (nodeIndex !== -1) {
+        for (var i = nodeIndex - 1; i >= 0; i -= 1) {
+          var startMarker = parseCodeMarker(siblings[i]);
+          if (startMarker?.boundary === "start") {
+            var startComment = siblings[i];
+            var codeId = startMarker.codeId;
+
+            for (var j = nodeIndex + 1; j < siblings.length; j += 1) {
+              var endMarker = parseCodeMarker(siblings[j]);
+              if (
+                endMarker?.boundary === "end" &&
+                endMarker.codeId === codeId
+              ) {
+                return {
+                  codeId: codeId,
+                  startComment: startComment,
+                  endComment: siblings[j],
+                };
+              }
+            }
+
+            // Keep scanning backward until we find the nearest enclosing region.
+            // A closer start marker may belong to a nested region that already ended
+            // before this node, which does not enclose the current target.
+            continue;
+          }
+        }
+      }
+
+      currentNode = currentParent;
+      currentParent = currentParent.parentNode;
+    }
+
+    return null;
+  }
+
+  // Static editing of layout blocks
+  //
+  // "Eligibility" here means: the block's template source, with every nested
+  // [data-layout-id] subtree replaced by a positional sentinel, matches the
+  // live DOM subtree with the same substitution. If that holds, the text
+  // around the nested blocks is free of Parsley / studio-field resolution
+  // and is safe to overwrite. Nested [data-layout-id] descendants are kept
+  // read-only while editing and restored from the template on save so their
+  // Parsley / field bindings are never clobbered.
+  function stripDescendantLayouts(source) {
+    if (typeof source !== "string") return "";
+    var container = document.createElement("div");
+    container.innerHTML = source;
+    var descendants = container.querySelectorAll("[data-layout-id]");
+    Array.prototype.forEach.call(descendants, function (node) {
+      var layoutId = node.getAttribute("data-layout-id") || "";
+      var sentinel = document.createComment("studio-layout-hole:" + layoutId);
+      if (node.parentNode) {
+        node.parentNode.replaceChild(sentinel, node);
+      }
+    });
+    return container.innerHTML.replace(/\s+/g, " ").trim();
+  }
+
+  function getTemplateLeafElement(codeId, layoutId) {
+    if (!codeId || !layoutId) return null;
+
+    var templateSource = getTemplateSourceByCodeId()[codeId];
+    if (typeof templateSource !== "string" || !templateSource) return null;
+
+    var parser = new DOMParser();
+    var doc = parser.parseFromString(
+      '<div id="studio-template-root">' + templateSource + "</div>",
+      "text/html"
+    );
+    var root = doc.getElementById("studio-template-root");
+    if (!root) return null;
+
+    return root.querySelector('[data-layout-id="' + layoutId + '"]') || null;
+  }
+
+  function isLeafStaticallyEditable(leafEl) {
+    if (!leafEl || leafEl.nodeType !== Node.ELEMENT_NODE) return false;
+
+    var layoutId = leafEl.getAttribute("data-layout-id");
+    if (!layoutId) return false;
+
+    var codeId = resolveCodeRegionForNode(leafEl)?.codeId || "";
+    if (!codeId) return false;
+
+    var cacheKey = codeId + "::" + layoutId;
+    if (staticEditEligibilityCache.has(cacheKey)) {
+      return staticEditEligibilityCache.get(cacheKey);
+    }
+
+    var templateLeaf = getTemplateLeafElement(codeId, layoutId);
+    if (!templateLeaf) {
+      staticEditEligibilityCache.set(cacheKey, false);
+      return false;
+    }
+
+    var normalizedTemplate = stripDescendantLayouts(templateLeaf.innerHTML);
+    var normalizedLive = stripDescendantLayouts(leafEl.innerHTML);
+    var verdict = !!normalizedTemplate && normalizedTemplate === normalizedLive;
+
+    staticEditEligibilityCache.set(cacheKey, verdict);
+    return verdict;
+  }
+
+  function resolveClickedImg(leafEl, target) {
+    if (!leafEl || !target) return null;
+    if (leafEl.tagName === "IMG") return leafEl;
+    var el =
+      typeof target.closest === "function" ? target.closest("img") : null;
+    if (el && leafEl.contains(el)) return el;
+    return null;
+  }
+
+  function getImgIndex(leafEl, imgEl) {
+    var imgs = Array.prototype.slice.call(leafEl.querySelectorAll("img"));
+    return imgs.indexOf(imgEl);
+  }
+
+  function enterStaticEditing(leafEl) {
+    if (!leafEl || staticEditState.layoutEl === leafEl) return;
+
+    var layoutId = leafEl.getAttribute("data-layout-id") || "";
+    var codeId = resolveCodeRegionForNode(leafEl)?.codeId || "";
+    if (!layoutId || !codeId) return;
+
+    leafEl.setAttribute("contenteditable", "true");
+    leafEl.setAttribute("spellcheck", "false");
+    leafEl.classList.add("studio-static-editing");
+    leafEl.removeAttribute("draggable");
+    syncDraggableLayoutElements(null);
+
+    // Lock nested layout descendants so only the text around them is editable.
+    // Their original template subtrees are re-inserted on save, so whatever
+    // the browser shows inside them here is throwaway.
+    var nested = leafEl.querySelectorAll("[data-layout-id]");
+    Array.prototype.forEach.call(nested, function (node) {
+      node.setAttribute("contenteditable", "false");
+      node.setAttribute("data-studio-static-frozen", "true");
+    });
+
+    staticEditState.layoutEl = leafEl;
+    staticEditState.layoutId = layoutId;
+    staticEditState.codeId = codeId;
+
+    if (typeof leafEl.focus === "function") {
+      try {
+        leafEl.focus({ preventScroll: true });
+      } catch (e) {
+        leafEl.focus();
+      }
+    }
+  }
+
+  function exitStaticEditing() {
+    var leafEl = staticEditState.layoutEl;
+    staticEditState.layoutEl = null;
+    staticEditState.layoutId = null;
+    staticEditState.codeId = null;
+    staticEditEligibilityCache.clear();
+
+    if (!leafEl) return;
+
+    leafEl.removeAttribute("contenteditable");
+    leafEl.removeAttribute("spellcheck");
+    leafEl.classList.remove("studio-static-editing");
+    var frozen = leafEl.querySelectorAll("[data-studio-static-frozen]");
+    Array.prototype.forEach.call(frozen, function (node) {
+      node.removeAttribute("contenteditable");
+      node.removeAttribute("data-studio-static-frozen");
+    });
+    syncDraggableLayoutElements(getSelectedLayoutElement());
+    // The layers observer is suppressed during static editing — re-emit now.
+    scheduleLayersTreePost();
+  }
+
+  // Layout reorder state + targeting
+  function buildRegionPayload(selector, codeRegion) {
+    if (!codeRegion) return null;
+    var regionNodes = getNodesBetween(
+      codeRegion.startComment,
+      codeRegion.endComment
+    );
+    var ordered = getOrderedBlocksWithinNodes(
+      selector,
+      regionNodes,
+      codeRegion.codeId
+    );
+    var layoutStructure = getLayoutStructure(
+      selector,
+      regionNodes,
+      codeRegion.codeId
+    );
+    return {
+      codeId: codeRegion.codeId,
+      selector: selector,
+      orderedLayoutIds: ordered
+        .map(function (el) {
+          return el.getAttribute("data-layout-id");
+        })
+        .filter(Boolean),
+      layoutStructure: layoutStructure,
+      outputHtml: ordered
+        .map(function (el) {
+          return el.outerHTML;
+        })
+        .join("\n"),
+    };
+  }
+
+  function postReorderOutput(selector, anchorNode) {
+    var activeNode = anchorNode || reorderState.dragEl;
+    var destCodeRegion = resolveCodeRegionForNode(activeNode);
+    var destCodeId = destCodeRegion?.codeId || null;
+    var sourceCodeId = reorderState.sourceCodeId;
+    var sourceCodeRegion =
+      sourceCodeId && sourceCodeId !== destCodeId
+        ? resolveCodeRegionForCodeId(sourceCodeId)
+        : null;
+
+    var regions = [];
+    if (destCodeRegion) {
+      var destPayload = buildRegionPayload(selector, destCodeRegion);
+      if (destPayload) regions.push(destPayload);
+    }
+    if (sourceCodeRegion) {
+      var sourcePayload = buildRegionPayload(selector, sourceCodeRegion);
+      if (sourcePayload) regions.push(sourcePayload);
+    }
+
+    if (!regions.length) {
+      // Page without code regions — fall back to a single anonymous payload so
+      // pre-existing single-template flows keep working.
+      var ordered = getOrderedBlocks(selector);
+      regions = [
+        {
+          codeId: null,
+          selector: selector,
+          orderedLayoutIds: ordered
+            .map(function (el) {
+              return el.getAttribute("data-layout-id");
+            })
+            .filter(Boolean),
+          layoutStructure: ordered
+            .map(function (el) {
+              var layoutId = el.getAttribute("data-layout-id");
+              if (!layoutId) return null;
+              return {
+                layoutId: layoutId,
+                parentLayoutId: getParentLayoutId(el, selector, null),
+              };
+            })
+            .filter(Boolean),
+          outputHtml: ordered
+            .map(function (el) {
+              return el.outerHTML;
+            })
+            .join("\n"),
+        },
+      ];
+    }
+
+    post({
+      type: "REORDER_OUTPUT",
+      regions: regions,
+      primaryCodeId: destCodeId,
+      selectedLayoutId: activeNode?.getAttribute("data-layout-id") || null,
+      selectedLayoutBreadcrumb: getLayoutBreadcrumb(activeNode),
+      selector: selector,
+    });
+  }
+
+  function getReorderTarget(target) {
+    if (!target) return null;
+
+    var current =
+      target.nodeType === Node.ELEMENT_NODE ? target : target.parentElement;
+
+    while (current && current !== document.documentElement) {
+      if (
+        current.matches &&
+        current.matches(reorderState.selector) &&
+        current !== reorderState.dragEl
+      ) {
+        return current;
+      }
+
+      current = current.parentElement;
+    }
+
+    return null;
+  }
+
+  function cleanupDragPreview() {
+    if (!reorderState.dragPreviewEl) return;
+    reorderState.dragPreviewEl.remove();
+    reorderState.dragPreviewEl = null;
+  }
+
+  function clearDragIntent() {
+    if (reorderState.dropTargetEl && reorderState.dropPosition) {
+      reorderState.dropTargetEl.classList.remove(
+        "studio-drop-" + reorderState.dropPosition
+      );
+      if (reorderState.dropAxis) {
+        reorderState.dropTargetEl.classList.remove(
+          "studio-drop-" +
+            reorderState.dropPosition +
+            "-" +
+            reorderState.dropAxis
+        );
+      }
+    }
+    reorderState.dropTargetEl = null;
+    reorderState.dropPosition = null;
+    reorderState.dropAxis = null;
+  }
+
+  function createDragPreview(el) {
+    if (!el) return null;
+
+    cleanupDragPreview();
+
+    var preview = el.cloneNode(true);
+    preview.removeAttribute("draggable");
+    preview.classList.remove("studio-dragging");
+    preview.style.position = "fixed";
+    preview.style.top = "-9999px";
+    preview.style.left = "-9999px";
+    preview.style.pointerEvents = "none";
+    preview.style.margin = "0";
+    preview.style.boxSizing = "border-box";
+    preview.style.width = el.getBoundingClientRect().width + "px";
+    preview.style.maxWidth = "none";
+    preview.style.zIndex = "2147483647";
+    document.body.appendChild(preview);
+
+    reorderState.dragPreviewEl = preview;
+    return preview;
+  }
+
+  function setDragIntent(target, position, axis) {
+    if (
+      reorderState.dropTargetEl === target &&
+      reorderState.dropPosition === position &&
+      reorderState.dropAxis === axis
+    ) {
+      return;
+    }
+
+    clearDragIntent();
+
+    if (!target || !position) return;
+
+    target.classList.add("studio-drop-" + position);
+    if (axis) {
+      target.classList.add("studio-drop-" + position + "-" + axis);
+    }
+    reorderState.dropTargetEl = target;
+    reorderState.dropPosition = position;
+    reorderState.dropAxis = axis || null;
+  }
+
+  function finalizeDraggedLayoutPlacement(shouldPostOutput) {
+    if (!reorderState.dragEl) return;
+
+    var dragEl = reorderState.dragEl;
+    var target = reorderState.dropTargetEl;
+    var position = reorderState.dropPosition;
+
+    if (target && position) {
+      if (position === "before" && target.parentNode) {
+        target.parentNode.insertBefore(dragEl, target);
+      } else if (position === "after" && target.parentNode) {
+        target.parentNode.insertBefore(dragEl, target.nextSibling);
+      } else if (
+        position === "inside" &&
+        target !== dragEl &&
+        !dragEl.contains(target)
+      ) {
+        target.appendChild(dragEl);
+      }
+    }
+
+    clearDragIntent();
+
+    if (shouldPostOutput) {
+      postReorderOutput(reorderState.selector, dragEl);
+    }
+
+    dragEl.classList.remove("studio-dragging");
+    var selectionData = getLayoutSelectionData(dragEl);
+    if (selectionData?.path?.length) {
+      lastLayoutSelectionPath = selectionData.pathKey;
+      lastLayoutSelectionDepth = selectionData.path.length - 1;
+    }
+    reorderState.dragEl = null;
+    reorderState.dragPath = null;
+    cleanupDragPreview();
+    reorderState.sourceCodeId = null;
+    reorderState.didDrop = false;
+    syncDraggableLayoutElements(dragEl);
+    // The layers observer is suppressed while a drag is active — re-emit now
+    // that the DOM has settled.
+    scheduleLayersTreePost();
+  }
+
+  function getLayoutElements(layoutId, codeId) {
+    if (!layoutId) return [];
+
+    var elements = Array.prototype.slice.call(
+      document.querySelectorAll('[data-layout-id="' + layoutId + '"]')
+    );
+
+    if (!codeId) {
+      return elements;
+    }
+
+    return elements.filter(function (node) {
+      return resolveCodeRegionForNode(node)?.codeId === codeId;
+    });
+  }
+
+  function getLayoutElement(layoutId, codeId) {
+    return getLayoutElements(layoutId, codeId)[0] || null;
+  }
+
+  function getSelectedLayoutElement() {
+    return (
+      document.querySelector(
+        reorderState.selector + '.studio-selected[draggable="true"]'
+      ) || document.querySelector(reorderState.selector + ".studio-selected")
+    );
+  }
+
+  function syncDraggableLayoutElements(activeLayoutElement) {
+    getOrderedBlocks(reorderState.selector).forEach(function (node) {
+      if (activeLayoutElement && node === activeLayoutElement) {
+        node.setAttribute("draggable", "true");
+        return;
+      }
+
+      node.removeAttribute("draggable");
+    });
+  }
+
+  function getDraggableLayoutTarget(target) {
+    if (!target) return null;
+
+    var selectedTarget =
+      target.closest &&
+      target.closest(reorderState.selector + ".studio-selected");
+    if (selectedTarget) {
+      return selectedTarget;
+    }
+
+    var selectedLayoutElement = getSelectedLayoutElement();
+    if (selectedLayoutElement && selectedLayoutElement.contains(target)) {
+      return selectedLayoutElement;
+    }
+
+    if (target.closest) {
+      return target.closest(reorderState.selector);
+    }
+
+    return null;
+  }
+
+  function getBranchPlacementTarget(target) {
+    var deepestTarget = toElement(target)?.closest?.(reorderState.selector);
+    var selectionData = getLayoutSelectionData(deepestTarget);
+    var path = selectionData?.path || [];
+
+    if (!path.length) {
+      return deepestTarget || null;
+    }
+
+    if (!reorderState.dragPath?.length) {
+      return path[0] || deepestTarget || null;
+    }
+
+    var commonPrefixLength = 0;
+    while (
+      commonPrefixLength < reorderState.dragPath.length &&
+      commonPrefixLength < path.length &&
+      reorderState.dragPath[commonPrefixLength] ===
+        (path[commonPrefixLength]?.getAttribute("data-layout-id") || "")
+    ) {
+      commonPrefixLength += 1;
+    }
+
+    return (
+      path[commonPrefixLength] || path[path.length - 1] || deepestTarget || null
+    );
+  }
+
+  function getDragAxis(target) {
+    var parent = target?.parentElement;
+    if (!parent) return "vertical";
+
+    var computed = window.getComputedStyle(parent);
+    var display = computed.display;
+
+    if (display === "flex" || display === "inline-flex") {
+      var flexDirection = computed.flexDirection || "row";
+      return flexDirection.indexOf("row") === 0 ? "horizontal" : "vertical";
+    }
+
+    if (display === "grid" || display === "inline-grid") {
+      var targetRect = target.getBoundingClientRect();
+      if (targetRect.width > 0 && targetRect.height > 0) {
+        var targetCenterX = targetRect.left + targetRect.width / 2;
+        var targetCenterY = targetRect.top + targetRect.height / 2;
+
+        var findNeighbor = function (start, useNext) {
+          var node = start;
+          while (node) {
+            var sibling = useNext
+              ? node.nextElementSibling
+              : node.previousElementSibling;
+            if (!sibling) return null;
+            if (sibling.matches && sibling.matches(reorderState.selector)) {
+              var rect = sibling.getBoundingClientRect();
+              if (rect.width > 0 && rect.height > 0) {
+                return rect;
+              }
+            }
+            node = sibling;
+          }
+          return null;
+        };
+
+        var neighbors = [];
+        var prevRect = findNeighbor(target, false);
+        if (prevRect) neighbors.push(prevRect);
+        var nextRect = findNeighbor(target, true);
+        if (nextRect) neighbors.push(nextRect);
+
+        if (neighbors.length > 0) {
+          var bestDx = 0;
+          var bestDy = 0;
+          var bestMag = Infinity;
+          for (var i = 0; i < neighbors.length; i += 1) {
+            var r = neighbors[i];
+            var dx = Math.abs(r.left + r.width / 2 - targetCenterX);
+            var dy = Math.abs(r.top + r.height / 2 - targetCenterY);
+            var mag = dx * dx + dy * dy;
+            if (mag < bestMag) {
+              bestMag = mag;
+              bestDx = dx;
+              bestDy = dy;
+            }
+          }
+          return bestDx >= bestDy ? "horizontal" : "vertical";
+        }
+      }
+
+      var autoFlow = computed.gridAutoFlow || "row";
+      return autoFlow.indexOf("column") !== -1 ? "vertical" : "horizontal";
+    }
+
+    return "vertical";
+  }
+
+  // Layout selection helpers
+  function getLayoutSelectionPath(layoutTarget, codeId) {
+    if (!layoutTarget) return [];
+
+    var path = [];
+    var current = layoutTarget;
+
+    while (current && current !== document.documentElement) {
+      if (current.matches && current.matches(reorderState.selector)) {
+        var currentCodeId = resolveCodeRegionForNode(current)?.codeId || "";
+        if (!codeId || currentCodeId === codeId) {
+          path.unshift(current);
+        }
+      }
+      if (codeId) {
+        var parentCodeId =
+          resolveCodeRegionForNode(current.parentElement)?.codeId || "";
+        if (current.parentElement && parentCodeId && parentCodeId !== codeId) {
+          break;
+        }
+      }
+      current = current.parentElement;
+    }
+
+    return path;
+  }
+
+  function getInnermostLayoutCodeId(layoutTarget) {
+    return resolveCodeRegionForNode(layoutTarget)?.codeId || "";
+  }
+
+  function getLayoutSelectionData(layoutTarget) {
+    var codeId = getInnermostLayoutCodeId(layoutTarget);
+    var path = getLayoutSelectionPath(layoutTarget, codeId);
+    if (!path.length) return null;
+
+    return {
+      codeId: codeId,
+      path: path,
+      pathKey: getLayoutSelectionPathKey(path),
+    };
+  }
+
+  function getLayoutSelectionPathKey(path) {
+    return path
+      .map(function (node) {
+        return node.getAttribute("data-layout-id") || "";
+      })
+      .join(">");
+  }
+
+  function selectTopLayoutTarget(layoutTarget) {
+    var selectionData = getLayoutSelectionData(layoutTarget);
+    if (!selectionData) return null;
+
+    lastLayoutSelectionPath = selectionData.pathKey;
+    lastLayoutSelectionDepth = 0;
+
+    return selectionData.path[0] || null;
+  }
+
+  // Selects a same-level sibling without snapping back to the parent. Returns
+  // null (so the caller falls back to selectTopLayoutTarget) unless the clicked
+  // element shares every ancestor of the current selection.
+  function selectSiblingLayoutTarget(layoutTarget) {
+    if (lastLayoutSelectionDepth < 0 || !lastLayoutSelectionPath) return null;
+
+    var selectionData = getLayoutSelectionData(layoutTarget);
+    if (!selectionData) return null;
+    var path = selectionData.path;
+
+    var oldIds = lastLayoutSelectionPath.split(">");
+    var depth = lastLayoutSelectionDepth;
+
+    var commonPrefixLength = 0;
+    while (
+      commonPrefixLength < oldIds.length &&
+      commonPrefixLength < path.length &&
+      oldIds[commonPrefixLength] ===
+        (path[commonPrefixLength]?.getAttribute("data-layout-id") || "")
+    ) {
+      commonPrefixLength += 1;
+    }
+
+    // Only treat the click as a same-level move when it shares every ancestor
+    // of the current selection (i.e. a sibling, or a descendant of it).
+    if (commonPrefixLength < depth || !path[depth]) return null;
+
+    lastLayoutSelectionPath = selectionData.pathKey;
+    lastLayoutSelectionDepth = depth;
+
+    return path[depth];
+  }
+
+  function selectNextLayoutTarget(layoutTarget) {
+    var selectionData = getLayoutSelectionData(layoutTarget);
+    if (!selectionData) return null;
+    var path = selectionData.path;
+    var pathKey = selectionData.pathKey;
+
+    if (pathKey !== lastLayoutSelectionPath) {
+      lastLayoutSelectionPath = pathKey;
+      lastLayoutSelectionDepth = 0;
+      return path[0] || null;
+    }
+
+    lastLayoutSelectionDepth = Math.min(
+      Math.max(lastLayoutSelectionDepth, 0) + 1,
+      path.length - 1
+    );
+
+    return path[lastLayoutSelectionDepth] || null;
+  }
+
+  // Bridge -> host DOM events
+  function emitLayoutDomEvent(
+    eventType,
+    layoutId,
+    evt,
+    element,
+    codeId,
+    breadcrumb
+  ) {
+    post({
+      type: "DOM_EVENT",
+      eventType: eventType,
+      element: element || {
+        dataset: {
+          layoutId: layoutId,
+          codeId: codeId || "",
+        },
+      },
+      breadcrumb: breadcrumb || [],
+      clientX: evt?.clientX,
+      clientY: evt?.clientY,
+    });
+  }
+
+  // Layout drag + reorder listeners
+  function setupReorderListeners() {
+    if (setupReorderListeners.__bound) return;
+    setupReorderListeners.__bound = true;
+
+    document.addEventListener(
+      "dragstart",
+      function (evt) {
+        if (!reorderState.enabled) return;
+        var el = getDraggableLayoutTarget(evt.target);
+        if (!el) return;
+        if (!el.classList.contains("studio-selected")) {
+          evt.preventDefault();
+          return;
+        }
+
+        reorderState.dragEl = el;
+        reorderState.sourceCodeId =
+          resolveCodeRegionForNode(el)?.codeId || null;
+        reorderState.dragPath =
+          getLayoutSelectionData(el)?.path.map(function (node) {
+            return node.getAttribute("data-layout-id") || "";
+          }) || null;
+        reorderState.didDrop = false;
+        syncDraggableLayoutElements(el);
+        clearDragIntent();
+        el.classList.add("studio-dragging");
+
+        if (evt.dataTransfer) {
+          var preview = createDragPreview(el);
+          evt.dataTransfer.effectAllowed = "move";
+          evt.dataTransfer.setData(
+            "text/plain",
+            el.getAttribute("data-layout-id") || ""
+          );
+          if (preview) {
+            evt.dataTransfer.setDragImage(preview, 0, 0);
+          }
+        }
+      },
+      true
+    );
+
+    document.addEventListener(
+      "pointerdown",
+      function (evt) {
+        if (!reorderState.enabled) return;
+        var el = getDraggableLayoutTarget(evt.target);
+        if (!el) return;
+        if (!el.classList.contains("studio-selected")) return;
+        syncDraggableLayoutElements(el);
+      },
+      true
+    );
+
+    document.addEventListener(
+      "dragover",
+      function (evt) {
+        if (!reorderState.enabled || !reorderState.dragEl) return;
+        var deepestTarget = toElement(evt.target)?.closest?.(
+          reorderState.selector
+        );
+        var branchTarget = getBranchPlacementTarget(evt.target);
+        var branchReorderTarget = getReorderTarget(branchTarget);
+        var nestedReorderTarget = getReorderTarget(deepestTarget);
+        var target = branchReorderTarget || nestedReorderTarget;
+        if (!target) return;
+
+        evt.preventDefault();
+
+        var rect = target.getBoundingClientRect();
+        var axis = getDragAxis(target);
+        var edgeRatio = 0.35;
+        if (!target.parentNode) return;
+
+        if (axis === "horizontal") {
+          var leftBand = rect.left + rect.width * edgeRatio;
+          var rightBand = rect.right - rect.width * edgeRatio;
+
+          if (evt.clientX < leftBand) {
+            setDragIntent(
+              branchReorderTarget || target,
+              "before",
+              "horizontal"
+            );
+          } else if (evt.clientX > rightBand) {
+            setDragIntent(branchReorderTarget || target, "after", "horizontal");
+          } else if (
+            nestedReorderTarget &&
+            nestedReorderTarget !== reorderState.dragEl &&
+            !reorderState.dragEl.contains(nestedReorderTarget)
+          ) {
+            setDragIntent(nestedReorderTarget, "inside", "horizontal");
+          } else {
+            clearDragIntent();
+          }
+          return;
+        }
+
+        var topBand = rect.top + rect.height * edgeRatio;
+        var bottomBand = rect.bottom - rect.height * edgeRatio;
+
+        if (evt.clientY < topBand) {
+          setDragIntent(branchReorderTarget || target, "before", "vertical");
+        } else if (evt.clientY > bottomBand) {
+          setDragIntent(branchReorderTarget || target, "after", "vertical");
+        } else if (
+          nestedReorderTarget &&
+          nestedReorderTarget !== reorderState.dragEl &&
+          !reorderState.dragEl.contains(nestedReorderTarget)
+        ) {
+          setDragIntent(nestedReorderTarget, "inside", "vertical");
+        } else {
+          clearDragIntent();
+        }
+      },
+      true
+    );
+
+    document.addEventListener(
+      "drop",
+      function (evt) {
+        if (!reorderState.enabled || !reorderState.dragEl) return;
+        evt.preventDefault();
+        reorderState.didDrop = true;
+        finalizeDraggedLayoutPlacement(true);
+      },
+      true
+    );
+
+    document.addEventListener(
+      "dragend",
+      function () {
+        if (!reorderState.dragEl) return;
+        finalizeDraggedLayoutPlacement(!reorderState.didDrop);
+      },
+      true
+    );
+  }
+
+  function handleEscapeKey(evt) {
+    if (evt.key !== "Escape") return;
+
+    if (interactionMode !== "layout") {
+      emitDomEvent("escape", "", evt);
+      return;
+    }
+
+    clearDragIntent();
+
+    if (staticEditState.layoutEl) {
+      exitStaticEditing();
+      return;
+    }
+
+    if (!getSelectedLayoutElement()) return;
+
+    emitLayoutDomEvent("escape", "", evt, {
+      dataset: {},
+    });
+  }
+
+  function ensureReorderAttributes() {
+    syncDraggableLayoutElements(getSelectedLayoutElement());
+  }
+
+  function setupReorderObserver() {
+    if (reorderState.observer) return;
+    if (typeof MutationObserver !== "function") return;
+
+    reorderState.observer = new MutationObserver(function () {
+      if (!reorderState.enabled) return;
+      ensureReorderAttributes();
+    });
+
+    reorderState.observer.observe(document.documentElement || document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  // Studio field range helpers
+  function getAllMarkerPairs() {
+    var root = document.body || document.documentElement;
+    if (!root) return [];
+
+    var pendingByStudioId = {};
+    var pairs = [];
+    var walker = document.createTreeWalker(root, NodeFilter.SHOW_COMMENT);
+    var commentNode = walker.nextNode();
+
+    while (commentNode) {
+      var marker = parseMarker(commentNode);
+      if (marker) {
+        if (marker.boundary === "start") {
+          if (!pendingByStudioId[marker.studioId]) {
+            pendingByStudioId[marker.studioId] = [];
+          }
+          pendingByStudioId[marker.studioId].push(commentNode);
+        } else if (marker.boundary === "end") {
+          var pending = pendingByStudioId[marker.studioId];
+          if (pending?.length) {
+            var startComment = pending.shift();
+            pairs.push({
+              studioId: marker.studioId,
+              startComment: startComment,
+              endComment: commentNode,
+            });
+          }
+        }
+      }
+
+      commentNode = walker.nextNode();
+    }
+
+    return pairs;
+  }
+
+  function getPairsWithinNode(node, allPairs) {
+    if (!node) return [];
+    var pairs = allPairs || getAllMarkerPairs();
+    return pairs.filter(function (pair) {
+      return node.contains(pair.startComment);
+    });
+  }
+
+  function getRangeNodes(pair) {
+    if (!pair?.startComment || !pair?.endComment) return [];
+    if (pair.startComment.parentNode !== pair.endComment.parentNode) return [];
+
+    var nodes = [];
+    var current = pair.startComment.nextSibling;
+
+    while (current && current !== pair.endComment) {
+      nodes.push(current);
+      current = current.nextSibling;
+    }
+
+    return nodes;
+  }
+
+  function getWrapperForPair(pair) {
+    var nextNode = pair.startComment?.nextSibling;
+    if (
+      nextNode &&
+      nextNode.nodeType === Node.ELEMENT_NODE &&
+      nextNode.getAttribute("data-studio-highlight-wrapper") === "true" &&
+      nextNode.getAttribute("data-studio-id") === pair.studioId
+    ) {
+      return nextNode;
+    }
+    return null;
+  }
+
+  function createWrapperForPair(pair) {
+    var fieldType = studioContextById[pair.studioId]?.fieldType;
+    var tagName = ["markdown", "wysiwyg_basic", "wysiwyg_advanced"].includes(
+      fieldType
+    )
+      ? "div"
+      : "span";
+    var wrapper = document.createElement(tagName);
+    wrapper.setAttribute("data-studio-highlight-wrapper", "true");
+    wrapper.setAttribute("data-studio-id", pair.studioId);
+    return wrapper;
+  }
+
+  function wrapPairIfNeeded(pair) {
+    var existing = getWrapperForPair(pair);
+    if (existing) return existing;
+
+    var nodes = getRangeNodes(pair);
+    if (!nodes.length) return null;
+
+    var wrapper = createWrapperForPair(pair);
+    pair.startComment.parentNode.insertBefore(wrapper, nodes[0]);
+    nodes.forEach(function (node) {
+      wrapper.appendChild(node);
+    });
+
+    return wrapper;
+  }
+
+  function unwrapIfUnused(wrapper) {
+    if (!wrapper) return;
+    if (
+      wrapper.classList.contains("studio-hover") ||
+      wrapper.classList.contains("studio-selected")
+    ) {
+      return;
+    }
+
+    while (wrapper.firstChild) {
+      wrapper.parentNode.insertBefore(wrapper.firstChild, wrapper);
+    }
+    wrapper.remove();
+  }
+
+  function getPairsByStudioId(studioId) {
+    if (!studioId) return [];
+    return getAllMarkerPairs().filter(function (pair) {
+      return pair.studioId === studioId;
+    });
+  }
+
+  function getPairsByField(fieldZuid, itemZuid) {
+    if (!fieldZuid) return [];
+    return getAllMarkerPairs().filter(function (pair) {
+      var context = studioContextById[pair.studioId] || {};
+      if (context.fieldZuid !== fieldZuid) return false;
+      if (itemZuid && context.itemZuid && context.itemZuid !== itemZuid) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  function getPairRects(pair) {
+    var nodes = getRangeNodes(pair);
+    if (!nodes.length) return [];
+
+    var range = document.createRange();
+    range.setStartBefore(nodes[0]);
+    range.setEndAfter(nodes[nodes.length - 1]);
+
+    return Array.from(range.getClientRects());
+  }
+
+  function pickPairByPoint(pairs, clientX, clientY) {
+    if (!pairs.length) return null;
+    if (typeof clientX !== "number" || typeof clientY !== "number") {
+      return pairs[0];
+    }
+
+    for (var i = 0; i < pairs.length; i += 1) {
+      var rects = getPairRects(pairs[i]);
+      for (var j = 0; j < rects.length; j += 1) {
+        var rect = rects[j];
+        if (
+          clientX >= rect.left &&
+          clientX <= rect.right &&
+          clientY >= rect.top &&
+          clientY <= rect.bottom
+        ) {
+          return pairs[i];
+        }
+      }
+    }
+
+    return pairs[0];
+  }
+
+  function resolveInteraction(target, clientX, clientY) {
+    var allPairs = getAllMarkerPairs();
+    var current = target;
+    while (current && current !== document.documentElement) {
+      var pairs = getPairsWithinNode(current, allPairs);
+
+      if (pairs.length === 1) {
+        return pairs[0];
+      }
+
+      if (pairs.length > 1) {
+        return pickPairByPoint(pairs, clientX, clientY);
+      }
+
+      current = current.parentNode;
+    }
+
+    return null;
+  }
+
+  function replacePairContent(pair, mode, nextValue) {
+    var wrapper = getWrapperForPair(pair);
+    if (wrapper) {
+      if (mode === "html") {
+        if (wrapper.innerHTML !== nextValue) {
+          wrapper.innerHTML = nextValue;
+        }
+      } else if ((wrapper.textContent || "") !== nextValue) {
+        wrapper.textContent = nextValue;
+      }
+      return;
+    }
+
+    var nodes = getRangeNodes(pair);
+    nodes.forEach(function (node) {
+      node.remove();
+    });
+
+    if (mode === "html") {
+      var template = document.createElement("template");
+      template.innerHTML = nextValue;
+      pair.startComment.parentNode.insertBefore(
+        template.content,
+        pair.endComment
+      );
+      return;
+    }
+
+    pair.startComment.parentNode.insertBefore(
+      document.createTextNode(nextValue),
+      pair.endComment
+    );
+  }
+
+  // Bridge -> host field events
+  function emitDomEvent(eventType, studioId, evt, value) {
+    post({
+      type: "DOM_EVENT",
+      eventType: eventType,
+      element: {
+        dataset: buildDataset(studioId),
+      },
+      clientX: evt?.clientX,
+      clientY: evt?.clientY,
+      value: value,
+    });
+  }
+
+  // Location + link interception
+  function notifyPathChange(reason, locationOverride) {
+    var loc = locationOverride || {
+      path: window.location.pathname,
+      search: window.location.search,
+      hash: window.location.hash,
+      href: window.location.href,
+    };
+    post({
+      type: "PATH_CHANGE",
+      reason: reason || null,
+      location: loc,
+    });
+  }
+
+  function notifyPathChangeForUrl(reason, href) {
+    if (!href) return;
+
+    try {
+      var url = new URL(href, window.location.href);
+      if (url.origin !== window.location.origin) return;
+
+      notifyPathChange(reason, {
+        path: url.pathname,
+        search: url.search,
+        hash: url.hash,
+        href: url.href,
+      });
+    } catch (e) {
+      // ignore invalid URLs
+    }
+  }
+
+  function setupPathListeners() {
+    var currentHref = window.location.href;
+    ["pushState", "replaceState"].forEach(function (method) {
+      if (!history[method]) return;
+      var original = history[method];
+      history[method] = function (state, title, url) {
+        if (typeof url === "string") {
+          try {
+            var targetUrl = new URL(url, window.location.href);
+            notifyPathChange(method, {
+              path: targetUrl.pathname,
+              search: targetUrl.search,
+              hash: targetUrl.hash,
+              href: targetUrl.href,
+            });
+          } catch (e) {
+            notifyPathChange(method);
+          }
+        } else {
+          notifyPathChange(method);
+        }
+        return null;
+      };
+      history[method].__original = original;
+    });
+
+    window.addEventListener("popstate", function () {
+      var attemptedHref = window.location.href;
+      if (attemptedHref !== currentHref) {
+        var originalPushState = history.pushState.__original;
+        if (typeof originalPushState === "function") {
+          originalPushState.call(history, null, document.title, currentHref);
+        }
+      }
+      notifyPathChange("popstate", {
+        path: window.location.pathname,
+        search: window.location.search,
+        hash: window.location.hash,
+        href: attemptedHref,
+      });
+    });
+
+    window.addEventListener("hashchange", function () {
+      var attemptedHref = window.location.href;
+      if (attemptedHref !== currentHref) {
+        var originalReplaceState = history.replaceState.__original;
+        if (typeof originalReplaceState === "function") {
+          originalReplaceState.call(history, null, document.title, currentHref);
+        }
+      }
+      notifyPathChange("hashchange", {
+        path: window.location.pathname,
+        search: window.location.search,
+        hash: window.location.hash,
+        href: attemptedHref,
+      });
+    });
+
+    notifyPathChange("init");
+  }
+
+  function handleLinkClick(evt) {
+    var target = toElement(evt.target);
+    if (!target) return;
+
+    var el = target.closest && target.closest("a");
+    if (!el) return;
+
+    var href = el.getAttribute("href");
+    if (!href) return;
+
+    evt.preventDefault();
+    evt.stopPropagation();
+    if (typeof evt.stopImmediatePropagation === "function") {
+      evt.stopImmediatePropagation();
+    }
+
+    if (href[0] === "#") return;
+
+    notifyPathChangeForUrl("anchor", href);
+  }
+
+  function handleLinkPointerDown(evt) {
+    var target = toElement(evt.target);
+    if (!target) return;
+
+    var el = target.closest && target.closest("a");
+    if (!el) return;
+
+    evt.preventDefault();
+    evt.stopPropagation();
+    if (typeof evt.stopImmediatePropagation === "function") {
+      evt.stopImmediatePropagation();
+    }
+  }
+
+  function handleLinkKeyDown(evt) {
+    if (evt.key !== "Enter") return;
+
+    var target = toElement(evt.target);
+    if (!target) return;
+
+    var el = target.closest && target.closest("a");
+    if (!el) return;
+
+    var href = el.getAttribute("href");
+    if (!href) return;
+
+    evt.preventDefault();
+    evt.stopPropagation();
+    if (typeof evt.stopImmediatePropagation === "function") {
+      evt.stopImmediatePropagation();
+    }
+
+    if (href[0] === "#") return;
+
+    notifyPathChangeForUrl("anchor", href);
+  }
+
+  function handleFormSubmit(evt) {
+    if (!evt.target || !window.HTMLFormElement) return;
+    if (!(evt.target instanceof window.HTMLFormElement)) return;
+
+    evt.preventDefault();
+    evt.stopPropagation();
+
+    var action = evt.target.getAttribute("action");
+    notifyPathChangeForUrl("form", action || window.location.href);
+  }
+
+  // DOM interaction handlers
+  function handleStudioClick(evt) {
+    if (interactionMode === "layout") {
+      evt.preventDefault();
+      evt.stopPropagation();
+      if (typeof evt.stopImmediatePropagation === "function") {
+        evt.stopImmediatePropagation();
+      }
+      return;
+    }
+
+    var pair = resolveInteraction(evt.target, evt.clientX, evt.clientY);
+    if (!pair?.studioId) {
+      emitDomEvent("escape", "", evt);
+      return;
+    }
+    emitDomEvent("click", pair.studioId, evt);
+  }
+
+  function handleStudioMouseMove(evt) {
+    if (interactionMode === "layout") {
+      var layoutTarget = toElement(evt.target)?.closest?.(
+        reorderState.selector
+      );
+      var nextLayoutId = layoutTarget?.getAttribute("data-layout-id") || null;
+
+      if (currentHoverLayoutId === nextLayoutId) {
+        return;
+      }
+
+      if (currentHoverLayoutId) {
+        emitLayoutDomEvent("mouseout", currentHoverLayoutId, evt);
+      }
+
+      currentHoverLayoutId = nextLayoutId;
+
+      if (nextLayoutId) {
+        var nextLayoutDataset = buildLayoutDataset(layoutTarget);
+        var nextPayload = nextLayoutDataset
+          ? {
+              dataset: nextLayoutDataset,
+            }
+          : null;
+        if (!nextPayload) return;
+        emitLayoutDomEvent(
+          "mouseover",
+          nextLayoutId,
+          evt,
+          nextPayload,
+          nextLayoutDataset.codeId
+        );
+      }
+
+      return;
+    }
+
+    var pair = resolveInteraction(evt.target, evt.clientX, evt.clientY);
+    var nextStudioId = pair?.studioId || null;
+
+    if (currentHoverStudioId === nextStudioId) {
+      return;
+    }
+
+    if (currentHoverStudioId) {
+      emitDomEvent("mouseout", currentHoverStudioId, evt);
+    }
+
+    currentHoverStudioId = nextStudioId;
+
+    if (nextStudioId) {
+      emitDomEvent("mouseover", nextStudioId, evt);
+    }
+  }
+
+  function handleStudioMouseLeave(evt) {
+    if (interactionMode === "layout") {
+      if (!currentHoverLayoutId) return;
+      emitLayoutDomEvent("mouseout", currentHoverLayoutId, evt);
+      currentHoverLayoutId = null;
+      return;
+    }
+
+    if (!currentHoverStudioId) return;
+    emitDomEvent("mouseout", currentHoverStudioId, evt);
+    currentHoverStudioId = null;
+  }
+
+  function handleStudioMouseDown(evt) {
+    if (interactionMode !== "layout") return;
+
+    if (staticEditState.layoutEl) {
+      if (staticEditState.layoutEl.contains(evt.target)) {
+        return;
+      }
+      exitStaticEditing();
+    }
+
+    var deepestLayoutTarget = toElement(evt.target)?.closest?.(
+      reorderState.selector
+    );
+    var selectionData = getLayoutSelectionData(deepestLayoutTarget);
+    if (!selectionData) {
+      emitLayoutDomEvent("escape", "", evt, {
+        dataset: {},
+      });
+      return;
+    }
+
+    var shouldResetSelection =
+      selectionData.pathKey !== lastLayoutSelectionPath ||
+      lastLayoutSelectionDepth < 0;
+    if (!shouldResetSelection) {
+      return;
+    }
+
+    var layoutTarget =
+      selectSiblingLayoutTarget(deepestLayoutTarget) ||
+      selectTopLayoutTarget(deepestLayoutTarget);
+    var layoutDataset = buildLayoutDataset(layoutTarget);
+    if (!layoutDataset) return;
+
+    emitLayoutDomEvent(
+      "mousedown",
+      layoutDataset.layoutId,
+      evt,
+      {
+        dataset: layoutDataset,
+      },
+      layoutDataset.codeId,
+      getLayoutBreadcrumb(layoutTarget)
+    );
+  }
+
+  function handleStudioDoubleClick(evt) {
+    if (interactionMode !== "layout") return;
+    if (
+      staticEditState.layoutEl &&
+      staticEditState.layoutEl.contains(evt.target)
+    ) {
+      return;
+    }
+
+    var deepestLayoutTarget = toElement(evt.target)?.closest?.(
+      reorderState.selector
+    );
+    if (!deepestLayoutTarget) return;
+
+    var selectionData = getLayoutSelectionData(deepestLayoutTarget);
+    var isAtLeaf =
+      !!selectionData &&
+      selectionData.pathKey === lastLayoutSelectionPath &&
+      lastLayoutSelectionDepth === selectionData.path.length - 1;
+
+    if (isAtLeaf) {
+      var clickedImg = resolveClickedImg(deepestLayoutTarget, evt.target);
+      if (clickedImg) {
+        evt.preventDefault();
+        var isLeafImg = clickedImg === deepestLayoutTarget;
+        post({
+          type: "STATIC_EDIT_IMAGE",
+          codeId: selectionData.codeId,
+          layoutId: deepestLayoutTarget.getAttribute("data-layout-id") || "",
+          isLeafImg: isLeafImg,
+          imgIndex: isLeafImg
+            ? 0
+            : getImgIndex(deepestLayoutTarget, clickedImg),
+          currentSrc: clickedImg.getAttribute("src") || "",
+        });
+        return;
+      }
+
+      if (isLeafStaticallyEditable(deepestLayoutTarget)) {
+        evt.preventDefault();
+        enterStaticEditing(deepestLayoutTarget);
+      } else {
+        post({
+          type: "STATIC_EDIT_REJECTED",
+          layoutId: deepestLayoutTarget.getAttribute("data-layout-id") || "",
+        });
+      }
+      return;
+    }
+
+    var layoutTarget = selectNextLayoutTarget(deepestLayoutTarget);
+    var layoutDataset = buildLayoutDataset(layoutTarget);
+    if (!layoutDataset) return;
+
+    emitLayoutDomEvent(
+      "dblclick",
+      layoutDataset.layoutId,
+      evt,
+      {
+        dataset: layoutDataset,
+      },
+      layoutDataset.codeId,
+      getLayoutBreadcrumb(layoutTarget)
+    );
+  }
+
+  function handleLayoutStaticInput(evt) {
+    if (!staticEditState.layoutEl) return;
+    if (!staticEditState.layoutEl.contains(evt.target)) return;
+
+    post({
+      type: "LAYOUT_CONTENT_UPDATE",
+      codeId: staticEditState.codeId,
+      layoutId: staticEditState.layoutId,
+      innerHtml: staticEditState.layoutEl.innerHTML,
+    });
+  }
+
+  function handleLayoutStaticKeydown(evt) {
+    if (!staticEditState.layoutEl) return;
+    if (!staticEditState.layoutEl.contains(evt.target)) return;
+    if (evt.key === "Enter") {
+      evt.preventDefault();
+    }
+  }
+
+  function handleEditableInput(evt) {
+    if (staticEditState.layoutEl) {
+      handleLayoutStaticInput(evt);
+      return;
+    }
+
+    var wrapper = toElement(evt.target)?.closest?.(
+      "[data-studio-highlight-wrapper]"
+    );
+    if (!wrapper) return;
+
+    var studioId = wrapper.getAttribute("data-studio-id");
+    if (!studioId) return;
+
+    var fieldType = studioContextById[studioId]?.fieldType;
+    emitDomEvent(
+      "input",
+      studioId,
+      evt,
+      ["markdown", "wysiwyg_basic", "wysiwyg_advanced"].includes(fieldType)
+        ? wrapper.innerHTML
+        : wrapper.textContent || ""
+    );
+  }
+
+  // Host -> bridge commands
+  function handleIncomingMessage(evt) {
+    if (parentOrigin !== "*" && evt.origin !== parentOrigin) return;
+    var data = evt.data;
+    if (!data || data.source !== "zesty-studio-host") return;
+    var payload = data.message?.payload;
+    if (!payload || !payload.action) return;
+
+    if (payload.action === "injectCss" && payload.css) {
+      var style = document.createElement("style");
+      style.appendChild(document.createTextNode(payload.css));
+      document.head.appendChild(style);
+      return;
+    }
+
+    if (payload.action === "setTextByField") {
+      getPairsByField(payload.fieldZuid, payload.itemZuid).forEach(function (
+        pair
+      ) {
+        replacePairContent(pair, "text", payload.value || "");
+      });
+      return;
+    }
+
+    if (payload.action === "setHtmlByField") {
+      getPairsByField(payload.fieldZuid, payload.itemZuid).forEach(function (
+        pair
+      ) {
+        replacePairContent(pair, "html", payload.html || "");
+      });
+      return;
+    }
+
+    if (payload.action === "enableReorderByUid") {
+      reorderState.enabled = true;
+      reorderState.selector = payload.selector || "[data-layout-id]";
+      ensureReorderAttributes();
+      setupReorderListeners();
+      setupReorderObserver();
+      postReorderOutput(reorderState.selector, null);
+      return;
+    }
+
+    if (payload.action === "disableReorderByUid") {
+      exitStaticEditing();
+      reorderState.enabled = false;
+      if (reorderState.dragEl) {
+        finalizeDraggedLayoutPlacement(false);
+      }
+      reorderState.dragEl = null;
+      reorderState.dragPath = null;
+      cleanupDragPreview();
+      clearDragIntent();
+      reorderState.sourceCodeId = null;
+      reorderState.didDrop = false;
+      syncDraggableLayoutElements(null);
+      return;
+    }
+
+    if (payload.action === "setInteractionMode") {
+      exitStaticEditing();
+      interactionMode = payload.mode === "layout" ? "layout" : "content";
+      syncInteractionModeClass();
+      currentHoverStudioId = null;
+      currentHoverLayoutId = null;
+      lastLayoutSelectionPath = null;
+      lastLayoutSelectionDepth = -1;
+      return;
+    }
+
+    if (payload.action === "addClassByLayoutId") {
+      if (!payload.layoutId || !payload.className) return;
+      getLayoutElements(payload.layoutId, payload.codeId).forEach(function (
+        node
+      ) {
+        node.classList.add(payload.className);
+      });
+      if (payload.className === "studio-selected") {
+        syncDraggableLayoutElements(
+          getLayoutElement(payload.layoutId, payload.codeId)
+        );
+      }
+      return;
+    }
+
+    if (payload.action === "removeClassByLayoutId") {
+      if (!payload.layoutId || !payload.className) return;
+      getLayoutElements(payload.layoutId, payload.codeId).forEach(function (
+        node
+      ) {
+        node.classList.remove(payload.className);
+      });
+      if (payload.className === "studio-selected") {
+        syncDraggableLayoutElements(getSelectedLayoutElement());
+      }
+      return;
+    }
+
+    if (payload.action === "setSelectedLayoutId") {
+      var selectedLayoutTarget = getLayoutElement(
+        payload.layoutId,
+        payload.codeId
+      );
+      // Selecting a different element ends any in-progress static edit, so the
+      // previously-edited element doesn't keep its static-editing outline.
+      if (
+        selectedLayoutTarget &&
+        staticEditState.layoutEl &&
+        staticEditState.layoutEl !== selectedLayoutTarget
+      ) {
+        exitStaticEditing();
+      }
+      var selectionData = getLayoutSelectionData(selectedLayoutTarget);
+      if (!selectionData) return;
+      lastLayoutSelectionPath = selectionData.pathKey;
+      lastLayoutSelectionDepth = Math.max(
+        0,
+        selectionData.path.findIndex(function (node) {
+          return (
+            (node.getAttribute && node.getAttribute("data-layout-id")) ===
+            payload.layoutId
+          );
+        })
+      );
+      return;
+    }
+
+    if (payload.action === "clearSelectedLayout") {
+      exitStaticEditing();
+      lastLayoutSelectionPath = null;
+      lastLayoutSelectionDepth = -1;
+      clearDragIntent();
+      syncDraggableLayoutElements(null);
+      return;
+    }
+
+    // Enter static editing on a specific element — used by the layers panel so
+    // clicking a static content row triggers the same inline editing as
+    // double-clicking the element on the canvas.
+    if (payload.action === "enterStaticEditingByLayoutId") {
+      if (interactionMode !== "layout") return;
+      var staticEl = getLayoutElement(payload.layoutId, payload.codeId);
+      if (!staticEl) return;
+      if (staticEditState.layoutEl === staticEl) return;
+      if (staticEditState.layoutEl) exitStaticEditing();
+      if (isLeafStaticallyEditable(staticEl)) {
+        enterStaticEditing(staticEl);
+      } else {
+        post({
+          type: "STATIC_EDIT_REJECTED",
+          layoutId: payload.layoutId || "",
+        });
+      }
+      return;
+    }
+
+    if (payload.action === "updateImageSrc") {
+      var imgLeaf = document.querySelector(
+        '[data-layout-id="' + payload.layoutId + '"]'
+      );
+      if (!imgLeaf) return;
+      var imgTarget = payload.isLeafImg
+        ? imgLeaf
+        : Array.prototype.slice.call(imgLeaf.querySelectorAll("img"))[
+            payload.imgIndex
+          ];
+      if (imgTarget) imgTarget.setAttribute("src", payload.newSrc);
+      return;
+    }
+
+    if (payload.action === "updateElementAttr" && payload.attr) {
+      var attrLeaf = document.querySelector(
+        '[data-layout-id="' + payload.layoutId + '"]'
+      );
+      if (!attrLeaf) return;
+      var attrTarget = payload.isSelf
+        ? attrLeaf
+        : Array.prototype.slice.call(
+            attrLeaf.querySelectorAll(payload.tagName)
+          )[payload.elementIndex];
+      if (!attrTarget) return;
+      if (payload.booleanAttr) {
+        // Presence toggle: "true" adds the bare attribute, "false" removes it.
+        if (payload.value === "true") attrTarget.setAttribute(payload.attr, "");
+        else attrTarget.removeAttribute(payload.attr);
+      } else {
+        attrTarget.setAttribute(payload.attr, payload.value || "");
+      }
+      return;
+    }
+
+    // Text-slot live preview. Only fired for a pure-text leaf addressed by its
+    // own data-layout-id, so replacing textContent is safe.
+    if (payload.action === "updateElementText") {
+      var textLeaf = document.querySelector(
+        '[data-layout-id="' + payload.layoutId + '"]'
+      );
+      if (textLeaf) textLeaf.textContent = payload.value || "";
+      return;
+    }
+
+    // Tag-change live preview: replace the element with one of the new tag,
+    // carrying over every attribute (data-layout-id, data-studio-id, class,
+    // the studio-selected outline, …) and its children.
+    if (payload.action === "updateElementTag" && payload.newTag) {
+      var tagLeaf = document.querySelector(
+        '[data-layout-id="' + payload.layoutId + '"]'
+      );
+      if (!tagLeaf || !tagLeaf.parentNode) return;
+      var swapped = document.createElement(payload.newTag);
+      Array.prototype.forEach.call(tagLeaf.attributes, function (attribute) {
+        swapped.setAttribute(attribute.name, attribute.value);
+      });
+      swapped.innerHTML = tagLeaf.innerHTML;
+      tagLeaf.parentNode.replaceChild(swapped, tagLeaf);
+      return;
+    }
+
+    if (payload.action === "requestLayersTree") {
+      postLayersTree(true);
+      return;
+    }
+
+    if (payload.action === "moveLayoutElement") {
+      if (interactionMode !== "layout") return;
+      var movePosition = payload.position;
+      if (
+        movePosition !== "before" &&
+        movePosition !== "after" &&
+        movePosition !== "inside"
+      ) {
+        return;
+      }
+
+      var moveEl = getLayoutElement(payload.layoutId, payload.codeId);
+      var moveTargetEl = getLayoutElement(
+        payload.targetLayoutId,
+        payload.targetCodeId
+      );
+      if (!moveEl || !moveTargetEl || moveEl === moveTargetEl) return;
+      if (moveEl.contains(moveTargetEl)) return;
+      if (movePosition === "inside" && voidElementTags[moveTargetEl.tagName]) {
+        return;
+      }
+      if (movePosition !== "inside" && !moveTargetEl.parentNode) return;
+
+      exitStaticEditing();
+      reorderState.sourceCodeId =
+        resolveCodeRegionForNode(moveEl)?.codeId || null;
+
+      if (movePosition === "before") {
+        moveTargetEl.parentNode.insertBefore(moveEl, moveTargetEl);
+      } else if (movePosition === "after") {
+        moveTargetEl.parentNode.insertBefore(moveEl, moveTargetEl.nextSibling);
+      } else {
+        moveTargetEl.appendChild(moveEl);
+      }
+
+      postReorderOutput(reorderState.selector, moveEl);
+
+      var moveSelectionData = getLayoutSelectionData(moveEl);
+      if (moveSelectionData?.path?.length) {
+        lastLayoutSelectionPath = moveSelectionData.pathKey;
+        lastLayoutSelectionDepth = moveSelectionData.path.length - 1;
+      }
+      reorderState.sourceCodeId = null;
+      syncDraggableLayoutElements(moveEl);
+      scheduleLayersTreePost();
+      return;
+    }
+
+    var targetPairs = payload.studioId
+      ? getPairsByStudioId(payload.studioId)
+      : [];
+    if (!targetPairs.length) return;
+
+    if (payload.action === "addClass") {
+      targetPairs.forEach(function (pair) {
+        var wrapper = wrapPairIfNeeded(pair);
+        if (wrapper && payload.className) {
+          wrapper.classList.add(payload.className);
+        }
+      });
+      return;
+    }
+
+    if (payload.action === "removeClass") {
+      targetPairs.forEach(function (pair) {
+        var wrapper = getWrapperForPair(pair);
+        if (!wrapper || !payload.className) return;
+        wrapper.classList.remove(payload.className);
+        unwrapIfUnused(wrapper);
+      });
+      return;
+    }
+
+    if (payload.action === "enableEditing") {
+      targetPairs.forEach(function (pair) {
+        var wrapper = wrapPairIfNeeded(pair);
+        var fieldType = studioContextById[pair.studioId]?.fieldType;
+        if (!wrapper || !editableFieldTypes[fieldType]) return;
+        wrapper.setAttribute("contenteditable", "true");
+        wrapper.setAttribute("spellcheck", "false");
+      });
+      return;
+    }
+
+    if (payload.action === "disableEditing") {
+      targetPairs.forEach(function (pair) {
+        var wrapper = getWrapperForPair(pair);
+        if (!wrapper) return;
+        wrapper.removeAttribute("contenteditable");
+        wrapper.removeAttribute("spellcheck");
+      });
+    }
+  }
+
+  function postTemplateSourceMap() {
+    post({
+      type: "TEMPLATE_SOURCE_MAP",
+      templateSourceByCodeId: getTemplateSourceByCodeId(),
+    });
+  }
+
+  // Layers tree
+  var voidElementTags = {
+    AREA: true,
+    BASE: true,
+    BR: true,
+    COL: true,
+    EMBED: true,
+    HR: true,
+    IMG: true,
+    INPUT: true,
+    LINK: true,
+    META: true,
+    PARAM: true,
+    SOURCE: true,
+    TRACK: true,
+    WBR: true,
+  };
+
+  // Element tags whose editable slots are surfaced in the host's Attributes
+  // panel, keyed by lowercase tag name. `attrs` lists exposed attributes;
+  // `text` exposes the element's inner text content as a slot. Add more tags
+  // here as the panel grows to support them.
+  var SUPPORTED_ELEMENTS = {
+    img: { attrs: ["src", "alt"], text: false },
+    video: {
+      attrs: ["src", "controls", "autoplay", "muted", "loop", "poster"],
+      text: false,
+    },
+    h1: { attrs: [], text: true },
+    h2: { attrs: [], text: true },
+    h3: { attrs: [], text: true },
+    h4: { attrs: [], text: true },
+    h5: { attrs: [], text: true },
+    h6: { attrs: [], text: true },
+    p: { attrs: [], text: true },
+    span: { attrs: [], text: true },
+  };
+
+  // Per-attribute metadata: display label and, for boolean HTML attributes
+  // (presence = on), the select options. Boolean slots are edited as a Yes/No
+  // (or Show/Hide) dropdown and written by toggling the attribute's presence.
+  var ATTR_META = {
+    src: { label: "Source" },
+    alt: { label: "Alt text" },
+    poster: { label: "Video Poster" },
+    controls: {
+      label: "Video Control Visibility",
+      boolean: true,
+      trueLabel: "Show",
+      falseLabel: "Hide",
+    },
+    autoplay: {
+      label: "Autoplay",
+      boolean: true,
+      trueLabel: "Yes",
+      falseLabel: "No",
+    },
+    muted: {
+      label: "Mute Video",
+      boolean: true,
+      trueLabel: "Yes",
+      falseLabel: "No",
+    },
+    loop: {
+      label: "Loop Video",
+      boolean: true,
+      trueLabel: "Yes",
+      falseLabel: "No",
+    },
+  };
+  var TEXT_SLOT_LABEL = "Text";
+
+  var layersTreeTimer = null;
+  var lastLayersTreeJson = null;
+  var LAYERS_LABEL_MAX = 120;
+
+  function normalizeLayersText(text) {
+    var t = (text || "").replace(/\s+/g, " ").trim();
+    if (t.length > LAYERS_LABEL_MAX) {
+      t = t.slice(0, LAYERS_LABEL_MAX) + "…";
+    }
+    return t;
+  }
+
+  function buildLayersTree() {
+    var root = document.body || document.documentElement;
+    if (!root) return [];
+
+    var fieldOccurrenceByStudioId = {};
+    var textNodeCount = 0;
+    var attrElementCount = 0;
+    var virtualRoot = { children: [] };
+
+    // Build an attribute slot (e.g. <img> src/alt). Dynamic when the attribute
+    // is bound to a content field via data-studio-id / studioAttrBindingsById,
+    // otherwise static (the value read straight off the rendered element).
+    // `layoutEditable` is true when the element is addressable for a source
+    // patch (any addressable element — attributes are always safe to overwrite
+    // as "changing the code").
+    function buildAttributeSlot(el, attr, layoutPatch) {
+      var meta = ATTR_META[attr] || { label: attr };
+
+      // Boolean attributes (controls, autoplay, muted, loop) are presence
+      // toggles rendered as a dropdown; they're never field-bound.
+      if (meta.boolean) {
+        return {
+          kind: "attribute",
+          key: attr,
+          attr: attr,
+          label: meta.label,
+          isDynamic: false,
+          value: el.hasAttribute(attr) ? "true" : "false",
+          layoutEditable: !!layoutPatch,
+          control: "select",
+          booleanAttr: true,
+          options: [
+            { value: "true", label: meta.trueLabel },
+            { value: "false", label: meta.falseLabel },
+          ],
+        };
+      }
+
+      var studioId = el.getAttribute("data-studio-id");
+      var bindings = (studioId && studioAttrBindingsById[studioId]) || [];
+      var binding = null;
+      for (var i = 0; i < bindings.length; i += 1) {
+        if (bindings[i].attr === attr && bindings[i].fieldZuid) {
+          binding = bindings[i];
+          break;
+        }
+      }
+      var slot = {
+        kind: "attribute",
+        key: attr,
+        attr: attr,
+        label: meta.label,
+        isDynamic: !!binding,
+        value: el.getAttribute(attr) || "",
+        layoutEditable: !!layoutPatch,
+        control: "text",
+      };
+      if (binding) {
+        slot.studioId = studioId;
+        slot.fieldZuid = binding.fieldZuid;
+        slot.fieldType = binding.fieldType;
+        slot.itemZuid = binding.itemZuid;
+        slot.modelZuid = binding.modelZuid;
+      }
+      return slot;
+    }
+
+    // Find a dynamic inline-text binding on an element: dynamic text is wrapped
+    // in a studio field marker comment pair among the element's child nodes.
+    // Returns the field dataset (fieldZuid, etc.) or null for static text.
+    function findInlineFieldBinding(el) {
+      var child = el.firstChild;
+      while (child) {
+        if (child.nodeType === Node.COMMENT_NODE) {
+          var marker = parseMarker(child);
+          if (marker && marker.boundary === "start") {
+            var dataset = buildDataset(marker.studioId);
+            if (dataset.fieldZuid) return dataset;
+          }
+        }
+        child = child.nextSibling;
+      }
+      return null;
+    }
+
+    // Build the text-content slot for a supported text element (e.g. <h1>).
+    // Dynamic when its text is a bound field (click-through to the content
+    // editor). `layoutEditable` only when it's a static, pure-text leaf that is
+    // statically editable — overwriting a mixed/dynamic block as free text
+    // would clobber nested layouts or field bindings.
+    function buildTextSlot(el) {
+      var dynamic = findInlineFieldBinding(el);
+      var isPureTextLeaf = el.children.length === 0;
+      var slot = {
+        kind: "text",
+        key: "text",
+        label: TEXT_SLOT_LABEL,
+        control: "text",
+        isDynamic: !!dynamic,
+        // The full editable text — NOT normalizeLayersText, which truncates and
+        // collapses whitespace (that's only for the layers-row label).
+        value: (el.textContent || "").trim(),
+        layoutEditable:
+          !dynamic && isPureTextLeaf && isLeafStaticallyEditable(el),
+      };
+      if (dynamic) {
+        slot.studioId = dynamic.studioId;
+        slot.fieldZuid = dynamic.fieldZuid;
+        slot.fieldType = dynamic.fieldType;
+        slot.itemZuid = dynamic.itemZuid;
+        slot.modelZuid = dynamic.modelZuid;
+      }
+      return slot;
+    }
+
+    // Assemble every editable slot (attributes + text) for a supported element.
+    function buildElementSlots(el, config, layoutPatch) {
+      var slots = [];
+      (config.attrs || []).forEach(function (attr) {
+        slots.push(buildAttributeSlot(el, attr, layoutPatch));
+      });
+      if (config.text) {
+        slots.push(buildTextSlot(el));
+      }
+      return slots;
+    }
+
+    // Compute the coordinates the host needs to patch this element's attributes
+    // back into the cached template source in layout mode. Tag-agnostic: an
+    // element with its own [data-layout-id] is addressed directly (`isSelf`),
+    // otherwise it's the Nth same-tag descendant of the nearest layout region.
+    // Returns null when the element can't be tied to a code region.
+    function buildElementLayoutPatch(el, codeId) {
+      var tagName = el.tagName.toLowerCase();
+      if (el.getAttribute("data-layout-id")) {
+        return {
+          codeId: codeId || null,
+          layoutId: el.getAttribute("data-layout-id"),
+          isSelf: true,
+          tagName: tagName,
+          elementIndex: 0,
+        };
+      }
+      var host = el.closest && el.closest("[data-layout-id]");
+      if (!host || !codeId) return null;
+      var matches = Array.prototype.slice.call(host.querySelectorAll(tagName));
+      var elementIndex = matches.indexOf(el);
+      if (elementIndex < 0) return null;
+      return {
+        codeId: codeId,
+        layoutId: host.getAttribute("data-layout-id"),
+        isSelf: false,
+        tagName: tagName,
+        elementIndex: elementIndex,
+      };
+    }
+
+    // Some dynamic content binds an element attribute (e.g. an <img> src)
+    // rather than inline text, so it is marked with a `data-studio-id`
+    // attribute on the element instead of comment-pair markers. An element can
+    // bind several attributes, each shown as its own content row under the
+    // element's node.
+    function appendAttributeBinding(el, sink, codeId) {
+      var studioId = el.getAttribute("data-studio-id");
+      if (!studioId) return;
+      var bindings = studioAttrBindingsById[studioId];
+      if (!bindings || !bindings.length) return;
+      var hostTag = el.tagName.toLowerCase();
+      bindings.forEach(function (binding) {
+        if (!binding.fieldZuid) return;
+        var occurrenceKey = studioId + ":" + binding.attr;
+        var occurrence = (fieldOccurrenceByStudioId[occurrenceKey] || 0) + 1;
+        fieldOccurrenceByStudioId[occurrenceKey] = occurrence;
+        sink.children.push({
+          id:
+            (codeId || "page") +
+            ":attr:" +
+            studioId +
+            ":" +
+            binding.attr +
+            ":" +
+            occurrence,
+          kind: "field",
+          tagName: null,
+          codeId: codeId,
+          layoutId: null,
+          studioId: studioId,
+          fieldZuid: binding.fieldZuid,
+          fieldType: binding.fieldType,
+          itemZuid: binding.itemZuid,
+          modelZuid: binding.modelZuid,
+          attr: binding.attr,
+          hostTag: hostTag,
+          label: "",
+          children: [],
+        });
+      });
+    }
+
+    // Walk the child nodes of `domNode`, pushing tree nodes into the active
+    // sink's `children`. Every [data-layout-id] element becomes a collapsible
+    // container; the content inside an element becomes child "text" nodes —
+    // static text and dynamic field output alike — so the panel mirrors the
+    // design's "containers with content rows" shape. `textBuf` (a shared
+    // {value} box) accumulates static text across non-layout wrapper recursion
+    // so a run that spans inline tags collapses into one content row.
+    function walk(domNode, sink, enclosingCodeId, textBuf) {
+      // Code-region markers are same-parent comment siblings, so each element
+      // level keeps its own region stack; the active region decides where
+      // subsequent nodes attach.
+      var stack = [{ node: sink, codeId: enclosingCodeId }];
+      var suppress = null;
+
+      function current() {
+        return stack[stack.length - 1];
+      }
+
+      function flushStaticText() {
+        var text = normalizeLayersText(textBuf.value);
+        textBuf.value = "";
+        if (!text) return;
+        textNodeCount += 1;
+        current().node.children.push({
+          id: (current().codeId || "page") + ":text:" + textNodeCount,
+          kind: "text",
+          tagName: null,
+          codeId: current().codeId,
+          layoutId: null,
+          label: text,
+          children: [],
+        });
+      }
+
+      var child = domNode.firstChild;
+      while (child) {
+        if (child.nodeType === Node.COMMENT_NODE) {
+          var codeMarker = parseCodeMarker(child);
+          if (codeMarker && !suppress) {
+            flushStaticText();
+            if (codeMarker.boundary === "start") {
+              var codeNode = {
+                id: codeMarker.codeId,
+                kind: "codeFile",
+                tagName: null,
+                codeId: codeMarker.codeId,
+                layoutId: null,
+                children: [],
+              };
+              current().node.children.push(codeNode);
+              stack.push({ node: codeNode, codeId: codeMarker.codeId });
+            } else {
+              for (var i = stack.length - 1; i > 0; i -= 1) {
+                var popped = stack.pop();
+                if (
+                  popped.node.kind === "codeFile" &&
+                  popped.node.codeId === codeMarker.codeId
+                ) {
+                  break;
+                }
+              }
+            }
+            child = child.nextSibling;
+            continue;
+          }
+
+          var fieldMarker = parseMarker(child);
+          if (fieldMarker) {
+            if (fieldMarker.boundary === "start" && !suppress) {
+              flushStaticText();
+              var dataset = buildDataset(fieldMarker.studioId);
+              if (!dataset.fieldZuid) {
+                // Marker pair with no backing entity (e.g. an empty `[[]]`
+                // entry in #studio-entities): unidentifiable, so swallow its
+                // content without surfacing a row.
+                suppress = {
+                  node: null,
+                  studioId: fieldMarker.studioId,
+                  parts: [],
+                };
+              } else {
+                var occurrence =
+                  (fieldOccurrenceByStudioId[fieldMarker.studioId] || 0) + 1;
+                fieldOccurrenceByStudioId[fieldMarker.studioId] = occurrence;
+                var fieldNode = {
+                  id:
+                    (current().codeId || "page") +
+                    ":field:" +
+                    fieldMarker.studioId +
+                    ":" +
+                    occurrence,
+                  kind: "field",
+                  tagName: null,
+                  codeId: current().codeId,
+                  layoutId: null,
+                  studioId: fieldMarker.studioId,
+                  fieldZuid: dataset.fieldZuid,
+                  fieldType: dataset.fieldType,
+                  itemZuid: dataset.itemZuid,
+                  modelZuid: dataset.modelZuid,
+                  label: "",
+                  children: [],
+                };
+                current().node.children.push(fieldNode);
+                suppress = {
+                  node: fieldNode,
+                  studioId: fieldMarker.studioId,
+                  parts: [],
+                };
+              }
+            } else if (
+              fieldMarker.boundary === "end" &&
+              suppress &&
+              suppress.studioId === fieldMarker.studioId
+            ) {
+              if (suppress.node) {
+                // Label the dynamic row with the field's rendered text.
+                suppress.node.label = normalizeLayersText(
+                  suppress.parts.join("")
+                );
+              }
+              suppress = null;
+            }
+          }
+        } else if (child.nodeType === Node.TEXT_NODE) {
+          if (suppress) {
+            suppress.parts.push(child.nodeValue || "");
+          } else {
+            textBuf.value += child.nodeValue || "";
+          }
+        } else if (child.nodeType === Node.ELEMENT_NODE) {
+          if (suppress) {
+            suppress.parts.push(child.textContent || "");
+          } else if (
+            child.tagName !== "SCRIPT" &&
+            child.tagName !== "STYLE" &&
+            child.tagName !== "TEMPLATE"
+          ) {
+            var layoutId = child.getAttribute("data-layout-id");
+            var tagLower = child.tagName.toLowerCase();
+            var elConfig = SUPPORTED_ELEMENTS[tagLower];
+            if (layoutId) {
+              flushStaticText();
+              var codeId = current().codeId;
+              var containerNode = {
+                id: (codeId || "page") + ":" + layoutId,
+                kind: "element",
+                tagName: tagLower,
+                codeId: codeId,
+                layoutId: layoutId,
+                children: [],
+              };
+              // Supported tags (e.g. <img>, <h1>) expose their editable slots
+              // so the host can open the Attributes panel on click.
+              if (elConfig) {
+                var containerPatch = buildElementLayoutPatch(child, codeId);
+                containerNode.slots = buildElementSlots(
+                  child,
+                  elConfig,
+                  containerPatch
+                );
+                containerNode.layoutPatch = containerPatch;
+              }
+              current().node.children.push(containerNode);
+              // A dynamic attribute (e.g. img src) belongs to this element.
+              appendAttributeBinding(child, containerNode, codeId);
+              walk(child, containerNode, codeId, { value: "" });
+            } else if (elConfig) {
+              // A supported tag without its own data-layout-id still gets a
+              // dedicated element node so it is clickable in the layers tree.
+              flushStaticText();
+              var attrCodeId = current().codeId;
+              attrElementCount += 1;
+              var attrStudioId = child.getAttribute("data-studio-id");
+              var attrPatch = buildElementLayoutPatch(child, attrCodeId);
+              var attrElNode = {
+                id:
+                  (attrCodeId || "page") +
+                  ":attrEl:" +
+                  (attrStudioId || tagLower + ":" + attrElementCount),
+                kind: "element",
+                tagName: tagLower,
+                codeId: attrCodeId,
+                layoutId: null,
+                slots: buildElementSlots(child, elConfig, attrPatch),
+                layoutPatch: attrPatch,
+                children: [],
+              };
+              current().node.children.push(attrElNode);
+              // Keep the dynamic attribute field rows under the element node.
+              appendAttributeBinding(child, attrElNode, attrCodeId);
+              walk(child, attrElNode, attrCodeId, { value: "" });
+            } else {
+              // Inline / structural wrapper without its own layout id: recurse
+              // into the same sink so nested layout elements attach to this
+              // level and the wrapper's text joins the surrounding run.
+              flushStaticText();
+              appendAttributeBinding(child, current().node, current().codeId);
+              walk(child, current().node, current().codeId, textBuf);
+            }
+          }
+        }
+
+        child = child.nextSibling;
+      }
+
+      flushStaticText();
+    }
+
+    walk(root, virtualRoot, null, { value: "" });
+
+    // Group nodes outside every code region under one anonymous page root so
+    // the host always renders code-file-level roots.
+    var roots = virtualRoot.children;
+    var strays = roots.filter(function (node) {
+      return node.kind !== "codeFile";
+    });
+    if (strays.length) {
+      roots = [
+        {
+          id: "page",
+          kind: "codeFile",
+          tagName: null,
+          codeId: null,
+          layoutId: null,
+          children: strays,
+        },
+      ].concat(
+        roots.filter(function (node) {
+          return node.kind === "codeFile";
+        })
+      );
+    }
+
+    return roots;
+  }
+
+  function postLayersTree(force) {
+    var tree = buildLayersTree();
+    var json = JSON.stringify(tree);
+    if (!force && json === lastLayersTreeJson) return;
+    lastLayersTreeJson = json;
+    post({ type: "LAYERS_TREE", tree: tree });
+  }
+
+  function scheduleLayersTreePost() {
+    if (layersTreeTimer) clearTimeout(layersTreeTimer);
+    layersTreeTimer = setTimeout(function () {
+      layersTreeTimer = null;
+      if (reorderState.dragEl || staticEditState.layoutEl) return;
+      postLayersTree(false);
+    }, 250);
+  }
+
+  function setupLayersTreeObserver() {
+    if (typeof MutationObserver !== "function") return;
+    var observer = new MutationObserver(function () {
+      if (reorderState.dragEl || staticEditState.layoutEl) return;
+      scheduleLayersTreePost();
+    });
+    observer.observe(document.documentElement || document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  document.addEventListener("pointerdown", handleLinkPointerDown, true);
+  document.addEventListener("mousedown", handleLinkPointerDown, true);
+  document.addEventListener("click", handleLinkClick, true);
+  document.addEventListener("auxclick", handleLinkClick, true);
+  document.addEventListener("keydown", handleLinkKeyDown, true);
+  document.addEventListener("submit", handleFormSubmit, true);
+  document.addEventListener("mousedown", handleStudioMouseDown, true);
+  document.addEventListener("click", handleStudioClick, true);
+  document.addEventListener("dblclick", handleStudioDoubleClick, true);
+  document.addEventListener("mousemove", handleStudioMouseMove, true);
+  document.addEventListener("mouseleave", handleStudioMouseLeave, true);
+  document.addEventListener("input", handleEditableInput, true);
+  document.addEventListener("keydown", handleLayoutStaticKeydown, true);
+  document.addEventListener("keydown", handleEscapeKey, true);
+
+  setupPathListeners();
+  window.addEventListener("message", handleIncomingMessage);
+
+  window.ZestyStudioBridge = { __initialized: true };
+  syncInteractionModeClass();
+  // Template source lives in <body>, while the bridge script will execute from <head>.
+  // Wait until the DOM is ready so template[data-code-id] nodes are present before reading them.
+  function postInitialDomState() {
+    postTemplateSourceMap();
+    postLayersTree(true);
+    setupLayersTreeObserver();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", postInitialDomState, {
+      once: true,
+    });
+  } else {
+    postInitialDomState();
+  }
+  post({ type: "BRIDGE_READY" });
+})();

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioAttributesPanel.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioAttributesPanel.tsx
@@ -1,0 +1,376 @@
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Drawer,
+  IconButton,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import { CloseRounded } from "@mui/icons-material";
+import BoltRounded from "@mui/icons-material/BoltRounded";
+import PhotoLibraryRounded from "@mui/icons-material/PhotoLibraryRounded";
+import { ElementSlot } from "../../hooks/studioTypes";
+
+// Title shown for a supported element tag.
+const TAG_TITLES: Record<string, string> = {
+  img: "Image",
+  video: "Video",
+  h1: "Heading 1",
+  h2: "Heading 2",
+  h3: "Heading 3",
+  h4: "Heading 4",
+  h5: "Heading 5",
+  h6: "Heading 6",
+  p: "Paragraph",
+  span: "Text",
+};
+
+// Interchangeable tag families — an element can be switched to any sibling in
+// its family (layout mode only, since it rewrites the underlying code). Each
+// family names the selector shown for it (e.g. "Media Type" for img/video).
+const TAG_FAMILIES: { label: string; tags: string[] }[] = [
+  { label: "Tag", tags: ["h1", "h2", "h3", "h4", "h5", "h6", "p", "span"] },
+  { label: "Media Type", tags: ["img", "video"] },
+];
+
+const getTagFamily = (tag: string): { label: string; tags: string[] } =>
+  TAG_FAMILIES.find((family) => family.tags.includes(tag)) || {
+    label: "Tag",
+    tags: [tag],
+  };
+
+type StudioAttributesPanelProps = {
+  mode: "content" | "layout";
+  // Stable id of the selected element — reseeds the inputs when a different
+  // element is chosen without fighting the user's in-progress typing.
+  elementKey: string;
+  tagName: string;
+  slots: ElementSlot[];
+  // Whether the element's tag can be swapped (layout mode + own layout id).
+  canChangeTag: boolean;
+  onChangeTag: (newTag: string) => void;
+  onClose: () => void;
+  // Content mode: a dynamic slot was clicked — open its field editor.
+  onEditDynamicSlot: (slot: ElementSlot) => void;
+  // Layout mode: a slot value was edited.
+  onChangeSlot: (slot: ElementSlot, value: string) => void;
+  // Layout mode: browse media for an image `src` slot.
+  onBrowseMedia: (slot: ElementSlot) => void;
+  drawerWidth: number;
+  logoSrc: string;
+};
+
+// Repo field pattern: a bold label above a bare input (no MUI floating label),
+// with the test hook on the input element itself.
+const SlotField = ({
+  slot,
+  mode,
+  value,
+  onChangeSlot,
+  onEditDynamicSlot,
+  onBrowseMedia,
+}: {
+  slot: ElementSlot;
+  mode: "content" | "layout";
+  value: string;
+  onChangeSlot: (slot: ElementSlot, value: string) => void;
+  onEditDynamicSlot: (slot: ElementSlot) => void;
+  onBrowseMedia: (slot: ElementSlot) => void;
+}) => {
+  const dataCy = `StudioAttrInput-${slot.key}`;
+
+  // Select-control slots (e.g. boolean video attributes: controls, autoplay).
+  // Editable only in layout mode on an editable element; disabled otherwise.
+  if (slot.control === "select") {
+    return (
+      <Stack gap={0.5}>
+        <Typography variant="body2" fontWeight={600} color="text.primary">
+          {slot.label}
+        </Typography>
+        <TextField
+          select
+          value={value}
+          fullWidth
+          disabled={mode === "content" || !slot.layoutEditable}
+          onChange={(evt) => onChangeSlot(slot, evt.target.value)}
+          inputProps={{ "data-cy": dataCy }}
+        >
+          {(slot.options || []).map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </TextField>
+      </Stack>
+    );
+  }
+
+  const multiline = slot.kind === "text";
+
+  // Content mode is read-only: dynamic slots click through to the content
+  // editor, static slots are disabled.
+  if (mode === "content") {
+    const clickable = slot.isDynamic;
+    return (
+      <Stack gap={0.5}>
+        <Typography variant="body2" fontWeight={600} color="text.primary">
+          {slot.label}
+        </Typography>
+        <TextField
+          value={value}
+          fullWidth
+          multiline={multiline}
+          disabled={!clickable}
+          onClick={clickable ? () => onEditDynamicSlot(slot) : undefined}
+          inputProps={{ "data-cy": dataCy, readOnly: true }}
+          InputProps={{
+            endAdornment: clickable ? (
+              <BoltRounded fontSize="small" sx={{ color: "primary.main" }} />
+            ) : undefined,
+            sx: clickable
+              ? {
+                  cursor: "pointer",
+                  "& textarea, & input": { cursor: "pointer" },
+                }
+              : undefined,
+          }}
+          sx={
+            clickable
+              ? {
+                  "& .MuiOutlinedInput-root": {
+                    backgroundColor: (theme) =>
+                      alpha(theme.palette.primary.main, 0.04),
+                  },
+                }
+              : undefined
+          }
+        />
+      </Stack>
+    );
+  }
+
+  // Layout mode: free-text editing of the underlying template code.
+  const isMediaAttr =
+    slot.kind === "attribute" &&
+    (slot.attr === "src" || slot.attr === "poster");
+  const disabledReason = !slot.layoutEditable
+    ? slot.isDynamic
+      ? "Contains dynamic content — edit in Content mode."
+      : "This element can't be edited here."
+    : null;
+
+  return (
+    <Stack gap={0.5}>
+      <Typography variant="body2" fontWeight={600} color="text.primary">
+        {slot.label}
+      </Typography>
+      <Stack direction="row" gap={1} alignItems="flex-start">
+        <TextField
+          value={value}
+          fullWidth
+          multiline={multiline}
+          minRows={multiline ? 2 : undefined}
+          disabled={!slot.layoutEditable}
+          onChange={(evt) => onChangeSlot(slot, evt.target.value)}
+          inputProps={{ "data-cy": dataCy }}
+        />
+        {isMediaAttr && slot.layoutEditable ? (
+          <Button
+            data-cy={`StudioAttrBrowse-${slot.attr}`}
+            variant="outlined"
+            startIcon={<PhotoLibraryRounded fontSize="small" />}
+            sx={{ mt: 0.5, whiteSpace: "nowrap", flexShrink: 0 }}
+            onClick={() => onBrowseMedia(slot)}
+          >
+            Browse
+          </Button>
+        ) : null}
+      </Stack>
+      {disabledReason ? (
+        <Typography variant="body2" color="text.secondary">
+          {disabledReason}
+        </Typography>
+      ) : null}
+    </Stack>
+  );
+};
+
+export const StudioAttributesPanel = ({
+  mode,
+  elementKey,
+  tagName,
+  slots,
+  canChangeTag,
+  onChangeTag,
+  onClose,
+  onEditDynamicSlot,
+  onChangeSlot,
+  onBrowseMedia,
+  drawerWidth,
+  logoSrc,
+}: StudioAttributesPanelProps) => {
+  // Local input state — layout edits don't re-emit the layers tree, so we own
+  // the displayed value.
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(slots.map((s) => [s.key, s.value]))
+  );
+  // The tag is owned locally too, so the select + title reflect a swap
+  // immediately without waiting for a fresh layers tree.
+  const [tag, setTag] = useState(tagName);
+
+  // Reset inputs + tag when a different element is selected.
+  useEffect(() => {
+    setValues(Object.fromEntries(slots.map((s) => [s.key, s.value])));
+    setTag(tagName);
+    // Keyed on the element id only so in-progress typing isn't clobbered.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elementKey]);
+
+  // Reflect external changes to media-URL slots (src, poster) — e.g. from the
+  // media picker — into their inputs.
+  const mediaSeed = slots
+    .filter((s) => s.key === "src" || s.key === "poster")
+    .map((s) => `${s.key}=${s.value}`)
+    .join("|");
+  useEffect(() => {
+    setValues((prev) => {
+      const next = { ...prev };
+      slots.forEach((s) => {
+        if (s.key === "src" || s.key === "poster") next[s.key] = s.value;
+      });
+      return next;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mediaSeed]);
+
+  // Seed values for slots that newly appear (e.g. after a tag swap) without
+  // clobbering keys the user is already editing.
+  useEffect(() => {
+    setValues((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      slots.forEach((s) => {
+        if (!(s.key in next)) {
+          next[s.key] = s.value;
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [slots]);
+
+  // Update the local displayed value AND commit the change upstream.
+  const handleSlotValueChange = (slot: ElementSlot, value: string) => {
+    setValues((prev) => ({ ...prev, [slot.key]: value }));
+    onChangeSlot(slot, value);
+  };
+
+  const tagFamily = getTagFamily(tag);
+  const tagOptions = tagFamily.tags;
+  const title = TAG_TITLES[tag] || tag;
+
+  return (
+    <Drawer
+      data-cy="StudioAttributesPanel"
+      variant="permanent"
+      anchor="right"
+      PaperProps={{
+        sx: {
+          overflow: "hidden",
+          position: "relative",
+          width: drawerWidth,
+          boxSizing: "border-box",
+          borderLeft: (theme) => `1px solid ${theme.palette.border}`,
+          backgroundColor: (theme) => theme.palette.grey[50],
+        },
+      }}
+    >
+      <Box height="100%" display="flex" flexDirection="column" p={3} gap={2}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          spacing={1}
+        >
+          <Typography variant="subtitle1" fontWeight="600">
+            {title}
+          </Typography>
+          <IconButton
+            data-cy="StudioAttributesPanelClose"
+            aria-label="Close attributes panel"
+            onClick={onClose}
+            size="small"
+          >
+            <CloseRounded />
+          </IconButton>
+        </Stack>
+
+        <Box flex="1" overflow="auto" pr={1}>
+          <Stack gap={2.5}>
+            {tagOptions.length > 1 ? (
+              <Stack gap={0.5}>
+                <Typography
+                  variant="body2"
+                  fontWeight={600}
+                  color="text.primary"
+                >
+                  {tagFamily.label}
+                </Typography>
+                <TextField
+                  select
+                  value={tag}
+                  fullWidth
+                  disabled={!canChangeTag}
+                  onChange={(evt) => {
+                    setTag(evt.target.value);
+                    onChangeTag(evt.target.value);
+                  }}
+                  inputProps={{ "data-cy": "StudioTagSelect" }}
+                >
+                  {tagOptions.map((option) => (
+                    <MenuItem key={option} value={option}>
+                      {TAG_TITLES[option] || option}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </Stack>
+            ) : null}
+            {slots.map((slot) => (
+              <SlotField
+                key={slot.key}
+                slot={slot}
+                mode={mode}
+                value={values[slot.key] ?? ""}
+                onChangeSlot={handleSlotValueChange}
+                onEditDynamicSlot={onEditDynamicSlot}
+                onBrowseMedia={onBrowseMedia}
+              />
+            ))}
+          </Stack>
+        </Box>
+
+        <Box
+          mt="auto"
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          gap={1}
+        >
+          <Box
+            component="img"
+            src={logoSrc}
+            alt="Content One"
+            sx={{ height: 24 }}
+          />
+          <Typography variant="body3" color="text.secondary" textAlign="center">
+            Agentic Studio by Content.One
+          </Typography>
+        </Box>
+      </Box>
+    </Drawer>
+  );
+};

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/studioTypes.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/studioTypes.ts
@@ -6,6 +6,58 @@ export type SelectedElement = {
   modelZuid?: string;
 };
 
+// A single editable slot on an element shown in the Attributes panel — either
+// an attribute (e.g. an <img> src/alt) or the element's text content (e.g. an
+// <h1>'s inner text). When `isDynamic`, the slot is bound to a content field
+// and carries the zuids needed to open the field editor; otherwise it's a
+// static value read straight off the rendered element. `layoutEditable` marks
+// whether the slot can be edited as free text in layout mode (attributes: the
+// element is addressable; text: it's a statically-editable pure-text leaf).
+export type ElementSlot = {
+  kind: "attribute" | "text";
+  // Stable per-slot id within an element: the attribute name, or "text".
+  key: string;
+  // Set for kind === "attribute".
+  attr?: string;
+  label: string;
+  isDynamic: boolean;
+  value: string;
+  layoutEditable: boolean;
+  // How the slot is edited. "text" (default) = free-text input; "select" = a
+  // dropdown of `options` (e.g. a boolean video attribute).
+  control?: "text" | "select";
+  options?: { value: string; label: string }[];
+  // A boolean HTML attribute (presence = on) written by toggling, not by value.
+  booleanAttr?: boolean;
+  studioId?: string;
+  fieldZuid?: string;
+  fieldType?: string;
+  itemZuid?: string;
+  modelZuid?: string;
+};
+
+// Coordinates the host needs to patch an element's attribute back into the
+// cached template source in layout mode. `null` when the element can't be
+// addressed to a code region (no enclosing [data-layout-id]). Addressing is
+// tag-agnostic: `layoutId` locates the nearest layout region, then the element
+// is either that region node itself (`isSelf`) or the `elementIndex`-th
+// `tagName` descendant of it.
+export type ElementLayoutPatch = {
+  codeId: string | null;
+  layoutId: string;
+  isSelf: boolean;
+  tagName: string;
+  elementIndex: number;
+};
+
+// The element whose slots are shown in the right-side Attributes panel.
+export type SelectedAttributeElement = {
+  nodeId: string;
+  tagName: string;
+  slots: ElementSlot[];
+  layoutPatch?: ElementLayoutPatch | null;
+};
+
 export type LayoutBreadcrumbItem = {
   layoutId?: string;
   label: string;
@@ -43,6 +95,11 @@ export type LayersTreeNode = {
   // Rendered content text for "field" / "text" nodes (the bridge resolves
   // dynamic markers to their actual value).
   label?: string;
+  // Editable slots (attributes and/or text) surfaced in the Attributes panel
+  // for supported element tags (e.g. <img>, <h1>). Present on "element" nodes.
+  slots?: ElementSlot[];
+  // Layout-mode patch coordinates for an editable element node.
+  layoutPatch?: ElementLayoutPatch | null;
   children: LayersTreeNode[];
 };
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/useLayoutReorderState.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/useLayoutReorderState.ts
@@ -7,6 +7,21 @@ type LayoutStructureItem = {
   parentLayoutId: string | null;
 };
 
+// Tags the Attributes panel can swap an element to — mirrors the bridge's
+// SUPPORTED_ELEMENTS. Guards createElement against an arbitrary tag name.
+const SWAPPABLE_TAGS = new Set([
+  "img",
+  "video",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "p",
+  "span",
+]);
+
 const isLayoutBreadcrumbItem = (
   segment: unknown
 ): segment is LayoutBreadcrumbItem =>
@@ -788,7 +803,9 @@ export const useLayoutReorderState = ({
       const root = doc.getElementById("studio-el-root");
       if (!root) return;
 
-      const leaf = root.querySelector(`[data-layout-id="${layoutId}"]`);
+      const leaf = root.querySelector(
+        `[data-layout-id="${CSS.escape(layoutId)}"]`
+      );
       if (!leaf) return;
 
       const target = isSelf
@@ -830,7 +847,7 @@ export const useLayoutReorderState = ({
       if (!root) return;
 
       const leaf = root.querySelector(
-        `[data-layout-id="${layoutId}"]`
+        `[data-layout-id="${CSS.escape(layoutId)}"]`
       ) as HTMLElement | null;
       if (!leaf) return;
 
@@ -847,7 +864,8 @@ export const useLayoutReorderState = ({
   // children so nothing else about the element changes.
   const handleLayoutTagUpdate = useCallback(
     (codeId: string, layoutId: string, newTag: string) => {
-      if (!codeId || !layoutId || !newTag) return;
+      // Only createElement a tag the panel exposes — never an arbitrary tag.
+      if (!codeId || !layoutId || !SWAPPABLE_TAGS.has(newTag)) return;
 
       const cached = templateSourceByCodeIdRef.current[codeId];
       if (!cached) return;
@@ -861,7 +879,7 @@ export const useLayoutReorderState = ({
       if (!root) return;
 
       const leaf = root.querySelector(
-        `[data-layout-id="${layoutId}"]`
+        `[data-layout-id="${CSS.escape(layoutId)}"]`
       ) as HTMLElement | null;
       if (!leaf || !leaf.parentNode) return;
 

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/useLayoutReorderState.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/useLayoutReorderState.ts
@@ -716,39 +716,11 @@ export const useLayoutReorderState = ({
     ]
   );
 
-  const handleLayoutImageSrcUpdate = useCallback(
-    (
-      codeId: string,
-      layoutId: string,
-      isLeafImg: boolean,
-      imgIndex: number,
-      newSrc: string
-    ) => {
-      if (!codeId || !layoutId || !newSrc) return;
-
-      const cached = templateSourceByCodeIdRef.current[codeId];
-      if (!cached) return;
-
-      const parser = new DOMParser();
-      const doc = parser.parseFromString(
-        `<div id="studio-img-root">${cached}</div>`,
-        "text/html"
-      );
-      const root = doc.getElementById("studio-img-root");
-      if (!root) return;
-
-      const leaf = root.querySelector(`[data-layout-id="${layoutId}"]`);
-      if (!leaf) return;
-
-      const imgTarget = isLeafImg
-        ? (leaf as HTMLElement)
-        : (Array.from(leaf.querySelectorAll("img"))[imgIndex] as HTMLElement);
-      if (!imgTarget) return;
-
-      imgTarget.setAttribute("src", newSrc);
-
-      const next = root.innerHTML;
-
+  // Write a region's patched source into the cache and stage it for save,
+  // preserving any pending reorder on that region. Shared by the attribute and
+  // text slot updaters.
+  const stageLayoutSourceUpdate = useCallback(
+    (codeId: string, next: string) => {
       templateSourceByCodeIdRef.current = {
         ...templateSourceByCodeIdRef.current,
         [codeId]: next,
@@ -790,6 +762,145 @@ export const useLayoutReorderState = ({
     []
   );
 
+  const handleLayoutElementAttrUpdate = useCallback(
+    (
+      codeId: string,
+      layoutId: string,
+      isSelf: boolean,
+      tagName: string,
+      elementIndex: number,
+      attr: string,
+      value: string,
+      booleanAttr?: boolean
+    ) => {
+      // Unlike `src`, an empty `alt` is a legitimate value, so only guard the
+      // addressing inputs here (not `value`).
+      if (!codeId || !layoutId || !attr) return;
+
+      const cached = templateSourceByCodeIdRef.current[codeId];
+      if (!cached) return;
+
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(
+        `<div id="studio-el-root">${cached}</div>`,
+        "text/html"
+      );
+      const root = doc.getElementById("studio-el-root");
+      if (!root) return;
+
+      const leaf = root.querySelector(`[data-layout-id="${layoutId}"]`);
+      if (!leaf) return;
+
+      const target = isSelf
+        ? (leaf as HTMLElement)
+        : (Array.from(leaf.querySelectorAll(tagName))[
+            elementIndex
+          ] as HTMLElement);
+      if (!target) return;
+
+      if (booleanAttr) {
+        // Presence toggle: "true" adds the bare attribute, "false" removes it.
+        if (value === "true") target.setAttribute(attr, "");
+        else target.removeAttribute(attr);
+      } else {
+        target.setAttribute(attr, value);
+      }
+
+      stageLayoutSourceUpdate(codeId, root.innerHTML);
+    },
+    [stageLayoutSourceUpdate]
+  );
+
+  // Patch a pure-text leaf's inner text into the cached source. Addressed by
+  // its own data-layout-id (text slots are only layout-editable for such
+  // leaves), so setting textContent is safe and escapes automatically.
+  const handleLayoutTextUpdate = useCallback(
+    (codeId: string, layoutId: string, value: string) => {
+      if (!codeId || !layoutId) return;
+
+      const cached = templateSourceByCodeIdRef.current[codeId];
+      if (!cached) return;
+
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(
+        `<div id="studio-el-root">${cached}</div>`,
+        "text/html"
+      );
+      const root = doc.getElementById("studio-el-root");
+      if (!root) return;
+
+      const leaf = root.querySelector(
+        `[data-layout-id="${layoutId}"]`
+      ) as HTMLElement | null;
+      if (!leaf) return;
+
+      leaf.textContent = value;
+
+      stageLayoutSourceUpdate(codeId, root.innerHTML);
+    },
+    [stageLayoutSourceUpdate]
+  );
+
+  // Change an element's tag in the cached source (e.g. h1 → h2, img → video).
+  // Addressed by its own data-layout-id; the replacement carries over every
+  // attribute (including data-layout-id / data-studio-id bindings) and its
+  // children so nothing else about the element changes.
+  const handleLayoutTagUpdate = useCallback(
+    (codeId: string, layoutId: string, newTag: string) => {
+      if (!codeId || !layoutId || !newTag) return;
+
+      const cached = templateSourceByCodeIdRef.current[codeId];
+      if (!cached) return;
+
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(
+        `<div id="studio-el-root">${cached}</div>`,
+        "text/html"
+      );
+      const root = doc.getElementById("studio-el-root");
+      if (!root) return;
+
+      const leaf = root.querySelector(
+        `[data-layout-id="${layoutId}"]`
+      ) as HTMLElement | null;
+      if (!leaf || !leaf.parentNode) return;
+
+      const swapped = doc.createElement(newTag);
+      Array.from(leaf.attributes).forEach((attribute) => {
+        swapped.setAttribute(attribute.name, attribute.value);
+      });
+      swapped.innerHTML = leaf.innerHTML;
+      leaf.parentNode.replaceChild(swapped, leaf);
+
+      stageLayoutSourceUpdate(codeId, root.innerHTML);
+    },
+    [stageLayoutSourceUpdate]
+  );
+
+  // Thin wrapper preserving the existing media-picker call site, which edits an
+  // <img> `src` addressed by the img-specific isLeafImg/imgIndex pair.
+  const handleLayoutImageSrcUpdate = useCallback(
+    (
+      codeId: string,
+      layoutId: string,
+      isLeafImg: boolean,
+      imgIndex: number,
+      newSrc: string
+    ) => {
+      if (!newSrc) return;
+      handleLayoutElementAttrUpdate(
+        codeId,
+        layoutId,
+        isLeafImg,
+        "img",
+        imgIndex,
+        "src",
+        newSrc
+      );
+    },
+    [handleLayoutElementAttrUpdate]
+  );
+
   return {
     pendingLayoutSave,
     pendingLayoutCodeIds,
@@ -801,5 +912,8 @@ export const useLayoutReorderState = ({
     handleReorderOutput,
     handleLayoutContentUpdate,
     handleLayoutImageSrcUpdate,
+    handleLayoutElementAttrUpdate,
+    handleLayoutTextUpdate,
+    handleLayoutTagUpdate,
   };
 };

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioLayersTree.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioLayersTree.ts
@@ -1,9 +1,12 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  ElementLayoutPatch,
+  ElementSlot,
   InteractionMode,
   LayersDropPosition,
   LayersTreeNode,
   LayoutSelection,
+  SelectedAttributeElement,
   SelectedElement,
 } from "./studioTypes";
 
@@ -59,22 +62,38 @@ type Args = {
     layoutId?: string;
     breadcrumb?: { layoutId?: string; label: string }[];
   }) => void;
+  applyAttributeSelection: (next: SelectedAttributeElement) => void;
+  refreshSelectedElementSlots: (
+    nodeId: string,
+    tagName: string,
+    slots: ElementSlot[],
+    layoutPatch: ElementLayoutPatch | null
+  ) => void;
   codeFileNameById: Record<string, string>;
   fieldsState: Record<string, any>;
   selectedElement: SelectedElement | null;
   selectedLayout: LayoutSelection | null;
+  selectedAttributeElement: SelectedAttributeElement | null;
   dndDisabled: boolean;
 };
+
+// An element node that exposes editable slots (e.g. an <img> or <h1>) —
+// clickable in both modes to open the Attributes panel.
+const isAttributeElement = (node: LayersTreeNode) =>
+  node.kind === "element" && !!node.slots && node.slots.length > 0;
 
 export const useStudioLayersTree = ({
   interactionMode,
   postCommandToBridge,
   applyBridgeSelection,
   applyLayoutSelection,
+  applyAttributeSelection,
+  refreshSelectedElementSlots,
   codeFileNameById,
   fieldsState,
   selectedElement,
   selectedLayout,
+  selectedAttributeElement,
   dndDisabled,
 }: Args) => {
   const [tree, setTree] = useState<LayersTreeNode[] | null>(null);
@@ -109,6 +128,9 @@ export const useStudioLayersTree = ({
   }, [tree]);
 
   const selectedNodeId = useMemo(() => {
+    // An open Attributes panel owns the highlight in both modes.
+    if (selectedAttributeElement) return selectedAttributeElement.nodeId;
+
     if (interactionMode === "layout") {
       if (!selectedLayout?.layoutId) return null;
       for (const node of nodeById.values()) {
@@ -147,7 +169,13 @@ export const useStudioLayersTree = ({
       }
     }
     return fallbackId;
-  }, [interactionMode, nodeById, selectedElement, selectedLayout]);
+  }, [
+    interactionMode,
+    nodeById,
+    selectedAttributeElement,
+    selectedElement,
+    selectedLayout,
+  ]);
 
   const toggleNode = useCallback((nodeId: string) => {
     setCollapsedIds((prev) => {
@@ -184,6 +212,9 @@ export const useStudioLayersTree = ({
 
   const isNodeSelectable = useCallback(
     (node: LayersTreeNode) => {
+      // Elements with editable attributes (e.g. <img>) are clickable in both
+      // modes to open the Attributes panel.
+      if (isAttributeElement(node)) return true;
       if (interactionMode === "layout") {
         // Elements select on the canvas; static text rows are clickable to
         // enter inline static editing on their enclosing element.
@@ -265,8 +296,37 @@ export const useStudioLayersTree = ({
     [applyLayoutSelection, parentById, postCommandToBridge]
   );
 
+  // A dynamic slot is bound to a content field — surface the field's name
+  // rather than its resolved value (mirrors the layers-row label).
+  const resolveSlotLabels = useCallback(
+    (slots: ElementSlot[] | undefined): ElementSlot[] =>
+      (slots || []).map((slot) => {
+        if (!slot.isDynamic || !slot.fieldZuid) return slot;
+        const field = fieldsState[slot.fieldZuid];
+        const fieldName = field?.label || field?.name;
+        return fieldName ? { ...slot, value: fieldName } : slot;
+      }),
+    [fieldsState]
+  );
+
   const handleNodeSelect = useCallback(
     (node: LayersTreeNode) => {
+      // Elements with editable attributes (e.g. <img>) open the Attributes
+      // panel in both modes. In layout mode also select the element on the
+      // canvas so the breadcrumb + outline follow.
+      if (isAttributeElement(node)) {
+        if (interactionMode === "layout" && node.layoutId && node.codeId) {
+          selectLayoutElement(node);
+        }
+        applyAttributeSelection({
+          nodeId: node.id,
+          tagName: node.tagName || "element",
+          slots: resolveSlotLabels(node.slots),
+          layoutPatch: node.layoutPatch ?? null,
+        });
+        return;
+      }
+
       // Static content in layout mode → enter inline static editing on the
       // nearest enclosing element (mirrors double-clicking it on the canvas).
       if (interactionMode === "layout" && node.kind === "text") {
@@ -306,15 +366,37 @@ export const useStudioLayersTree = ({
       });
     },
     [
+      applyAttributeSelection,
       applyBridgeSelection,
       interactionMode,
       isNodeSelectable,
       parentById,
       postCommandToBridge,
+      resolveSlotLabels,
       selectLayoutElement,
       toggleNode,
     ]
   );
+
+  // When the tree re-emits (e.g. after a tag swap changes which slots exist),
+  // refresh the open panel's element so it shows the new type's slots.
+  useEffect(() => {
+    const nodeId = selectedAttributeElement?.nodeId;
+    if (!nodeId) return;
+    const node = nodeById.get(nodeId);
+    if (!node || !isAttributeElement(node)) return;
+    refreshSelectedElementSlots(
+      nodeId,
+      node.tagName || "element",
+      resolveSlotLabels(node.slots),
+      node.layoutPatch ?? null
+    );
+  }, [
+    nodeById,
+    refreshSelectedElementSlots,
+    resolveSlotLabels,
+    selectedAttributeElement,
+  ]);
 
   const canDrop = useCallback(
     (
@@ -361,7 +443,9 @@ export const useStudioLayersTree = ({
 
       // Select the dragged element first — canvas drags require selection,
       // and the reorder pipeline re-roots the current selection's breadcrumb.
-      handleNodeSelect(source);
+      // Select it as a layout element directly (not via handleNodeSelect) so a
+      // draggable img doesn't pop open the Attributes panel mid-drag.
+      selectLayoutElement(source);
 
       postCommandToBridge({
         action: "moveLayoutElement",
@@ -372,7 +456,7 @@ export const useStudioLayersTree = ({
         position,
       });
     },
-    [canDrop, handleNodeSelect, nodeById, postCommandToBridge]
+    [canDrop, nodeById, postCommandToBridge, selectLayoutElement]
   );
 
   return {

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioSelection.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioSelection.ts
@@ -1,6 +1,9 @@
 import { useCallback, useState } from "react";
 import {
+  ElementLayoutPatch,
+  ElementSlot,
   LayoutBreadcrumbItem,
+  SelectedAttributeElement,
   SelectedElement,
   LayoutSelection,
 } from "./studioTypes";
@@ -25,10 +28,14 @@ export const useStudioSelection = ({
   const [selectedLayout, setSelectedLayout] = useState<LayoutSelection | null>(
     null
   );
-  const [panelMode, setPanelMode] = useState<"info" | "edit">("info");
+  const [panelMode, setPanelMode] = useState<"info" | "edit" | "attributes">(
+    "info"
+  );
   const [filteredFieldName, setFilteredFieldName] = useState<string | null>(
     null
   );
+  const [selectedAttributeElement, setSelectedAttributeElement] =
+    useState<SelectedAttributeElement | null>(null);
 
   const disableContentEditing = useCallback(
     (studioId?: string, itemZuid?: string) => {
@@ -55,6 +62,46 @@ export const useStudioSelection = ({
     [postCommandToBridge]
   );
 
+  const addContentSelectedClass = useCallback(
+    (studioId?: string, itemZuid?: string) => {
+      if (!studioId) return;
+      postCommandToBridge({
+        action: "addClass",
+        studioId,
+        className: "studio-selected",
+        itemZuid,
+      });
+    },
+    [postCommandToBridge]
+  );
+
+  // Remove whatever canvas highlight an attribute-element selection applied —
+  // either a layout outline (by layoutId) or a content outline (by studioId).
+  const removeAttributeElementHighlight = useCallback(
+    (sel: SelectedAttributeElement | null) => {
+      if (!sel) return;
+      if (sel.layoutPatch?.layoutId && sel.layoutPatch.codeId) {
+        postCommandToBridge({
+          action: "removeClassByLayoutId",
+          codeId: sel.layoutPatch.codeId,
+          layoutId: sel.layoutPatch.layoutId,
+          className: "studio-selected",
+        });
+        return;
+      }
+      const dynamicAttr = sel.slots.find((a) => a.studioId);
+      if (dynamicAttr?.studioId) {
+        postCommandToBridge({
+          action: "removeClass",
+          studioId: dynamicAttr.studioId,
+          className: "studio-selected",
+          itemZuid: dynamicAttr.itemZuid,
+        });
+      }
+    },
+    [postCommandToBridge]
+  );
+
   const clearSelection = useCallback(() => {
     if (selectedElement?.fieldZuid) {
       disableContentEditing(selectedElement.studioId, selectedElement.itemZuid);
@@ -63,10 +110,18 @@ export const useStudioSelection = ({
         selectedElement.itemZuid
       );
     }
+    removeAttributeElementHighlight(selectedAttributeElement);
     setSelectedElement(null);
+    setSelectedAttributeElement(null);
     setFilteredFieldName(null);
     setPanelMode("info");
-  }, [disableContentEditing, removeContentSelectedClass, selectedElement]);
+  }, [
+    disableContentEditing,
+    removeAttributeElementHighlight,
+    removeContentSelectedClass,
+    selectedAttributeElement,
+    selectedElement,
+  ]);
 
   const removeLayoutSelectedClass = useCallback(
     (codeId?: string, layoutId?: string) => {
@@ -115,6 +170,14 @@ export const useStudioSelection = ({
       const layoutId = next.layoutId || "";
       if (!codeId || !layoutId) return;
 
+      // Selecting a layout element closes any open Attributes panel. The <img>
+      // path re-opens it right after via applyAttributeSelection.
+      if (selectedAttributeElement) {
+        removeAttributeElementHighlight(selectedAttributeElement);
+        setSelectedAttributeElement(null);
+        setPanelMode((prev) => (prev === "attributes" ? "info" : prev));
+      }
+
       if (
         selectedLayout?.layoutId &&
         (selectedLayout.layoutId !== layoutId ||
@@ -145,7 +208,9 @@ export const useStudioSelection = ({
     [
       addLayoutSelectedClass,
       codeFileNameById,
+      removeAttributeElementHighlight,
       removeLayoutSelectedClass,
+      selectedAttributeElement,
       selectedLayout,
       withCodeIdBreadcrumbRoot,
     ]
@@ -206,6 +271,17 @@ export const useStudioSelection = ({
     ) => {
       const { studioId, fieldZuid, fieldType, itemZuid, modelZuid } = next;
 
+      // Selecting a field that isn't one of the open attribute element's own
+      // bindings means we've navigated away from it — close the Attributes
+      // panel. Editing one of its dynamic attributes keeps it (for "Back").
+      const editingOwnAttribute = selectedAttributeElement?.slots.some(
+        (a) => a.fieldZuid === fieldZuid
+      );
+      if (!editingOwnAttribute && selectedAttributeElement) {
+        removeAttributeElementHighlight(selectedAttributeElement);
+        setSelectedAttributeElement(null);
+      }
+
       if (selectedElement?.studioId && selectedElement.studioId !== studioId) {
         disableContentEditing(
           selectedElement.studioId,
@@ -254,14 +330,127 @@ export const useStudioSelection = ({
     [
       disableContentEditing,
       postCommandToBridge,
+      removeAttributeElementHighlight,
       removeContentSelectedClass,
+      selectedAttributeElement,
       selectedElement,
     ]
   );
 
+  // Open the Attributes panel for an element (e.g. an <img>). Highlights the
+  // element on the canvas — by layout id when addressable, otherwise by the
+  // studio id of a dynamic attribute binding.
+  const applyAttributeSelection = useCallback(
+    (next: SelectedAttributeElement) => {
+      removeAttributeElementHighlight(selectedAttributeElement);
+      setSelectedAttributeElement(next);
+      setSelectedElement(null);
+      setFilteredFieldName(null);
+      setPanelMode("attributes");
+
+      if (next.layoutPatch?.layoutId && next.layoutPatch.codeId) {
+        addLayoutSelectedClass(
+          next.layoutPatch.codeId,
+          next.layoutPatch.layoutId
+        );
+        return;
+      }
+      const dynamicAttr = next.slots.find((a) => a.studioId);
+      if (dynamicAttr?.studioId) {
+        addContentSelectedClass(dynamicAttr.studioId, dynamicAttr.itemZuid);
+      }
+    },
+    [
+      addContentSelectedClass,
+      addLayoutSelectedClass,
+      removeAttributeElementHighlight,
+      selectedAttributeElement,
+    ]
+  );
+
+  // Return from a dynamic-attribute field edit back to the Attributes panel,
+  // keeping the element selected but dropping the single-field editor state.
+  const returnToAttributes = useCallback(() => {
+    if (selectedElement?.fieldZuid) {
+      disableContentEditing(selectedElement.studioId, selectedElement.itemZuid);
+      removeContentSelectedClass(
+        selectedElement.studioId,
+        selectedElement.itemZuid
+      );
+    }
+    setSelectedElement(null);
+    setFilteredFieldName(null);
+    setPanelMode("attributes");
+    // Re-apply the element highlight the field edit may have cleared.
+    if (
+      selectedAttributeElement?.layoutPatch?.layoutId &&
+      selectedAttributeElement.layoutPatch.codeId
+    ) {
+      addLayoutSelectedClass(
+        selectedAttributeElement.layoutPatch.codeId,
+        selectedAttributeElement.layoutPatch.layoutId
+      );
+    } else {
+      const dynamicAttr = selectedAttributeElement?.slots.find(
+        (a) => a.studioId
+      );
+      if (dynamicAttr?.studioId) {
+        addContentSelectedClass(dynamicAttr.studioId, dynamicAttr.itemZuid);
+      }
+    }
+  }, [
+    addContentSelectedClass,
+    addLayoutSelectedClass,
+    disableContentEditing,
+    removeContentSelectedClass,
+    selectedAttributeElement,
+    selectedElement,
+  ]);
+
+  // Re-sync the open panel's element from a freshly re-emitted layers tree
+  // (same nodeId) — e.g. after a tag swap changes which slots exist (img → video
+  // drops `alt`). No-ops when nothing changed to avoid needless re-renders. The
+  // panel owns its input values locally, so this never clobbers in-progress
+  // typing; it only refreshes the slot set / tag / patch.
+  const refreshSelectedElementSlots = useCallback(
+    (
+      nodeId: string,
+      tagName: string,
+      slots: ElementSlot[],
+      layoutPatch: ElementLayoutPatch | null
+    ) => {
+      setSelectedAttributeElement((prev) => {
+        if (!prev || prev.nodeId !== nodeId) return prev;
+        if (
+          prev.tagName === tagName &&
+          JSON.stringify(prev.slots) === JSON.stringify(slots)
+        ) {
+          return prev;
+        }
+        return { ...prev, tagName, slots, layoutPatch };
+      });
+    },
+    []
+  );
+
+  // Patch a single slot's displayed value on the selected element (e.g. after
+  // picking a new image `src` from the media library), so the panel reflects
+  // it without waiting for a fresh layers tree.
+  const updateSelectedSlotValue = useCallback((key: string, value: string) => {
+    setSelectedAttributeElement((prev) =>
+      prev
+        ? {
+            ...prev,
+            slots: prev.slots.map((s) => (s.key === key ? { ...s, value } : s)),
+          }
+        : prev
+    );
+  }, []);
+
   return {
     selectedElement,
     selectedLayout,
+    selectedAttributeElement,
     panelMode,
     filteredFieldName,
     setSelectedLayout,
@@ -271,5 +460,9 @@ export const useStudioSelection = ({
     handleLayoutBreadcrumbSelect,
     clearHighlightOnly,
     applySelection,
+    applyAttributeSelection,
+    returnToAttributes,
+    updateSelectedSlotValue,
+    refreshSelectedElementSlots,
   };
 };


### PR DESCRIPTION
## What

Clicking an element in the Studio **Layers** panel now opens a right-side **Attributes** panel. The panel is data-driven off editable "slots" the bridge computes per element:

| Element | Slots |
|---|---|
| `img` | `src`, `alt` |
| `video` | `src`, `controls`, `autoplay`, `muted`, `loop`, `poster` |
| `h1`–`h6`, `p`, `span` | `Text` (inner text) |

### Behavior
- **Content mode** is read-only: a **dynamic** slot (bound to a content field) clicks through to the existing single-field content editor and shows the field's name; a **static** slot is disabled.
- **Layout mode** edits the underlying template code — free-text inputs, boolean dropdowns, and a media-picker for `src`/`poster` — staging a pending layout save.
- **Tag / Media Type selector** swaps an element within its family (`h1`↔`h2`, `img`↔`video`), rewriting the tag in source while carrying over all attributes, bindings, and children. The panel re-syncs its slots from the re-emitted layers tree so the new type's attributes appear immediately.
- The four video booleans (`controls`/`autoplay`/`muted`/`loop`) render as Show/Hide · Yes/No dropdowns and write by **toggling attribute presence** (`setAttribute("")` / `removeAttribute`).

Video attribute set + labels come from the Figma spec (Content.One Strategy, node 1127:2651).

## How it's wired
- `bridge.js` (in-iframe) builds the layers tree and each element's `slots` + `layoutPatch`; new `updateElementAttr` / `updateElementText` / `updateElementTag` commands for live preview.
- Host: `useStudioSelection` (attributes panel mode + slot refresh), `useStudioLayersTree` (selectable element nodes + tree re-sync), `useLayoutReorderState` (tag-agnostic source patch helpers), `StudioAttributesPanel.tsx` (new), wired in `StudioWrapper.tsx`.

## Tests
`cypress/e2e/studio/attributes-panel.spec.js` — follows the existing studio pattern: stubs the bridge via `postMessage`, asserts panel slots per element type, and verifies tag swap + boolean toggle persist to the saved view `code`.

## Notes
- `bridge.js` is served to the preview by the rendering engine (not bundled); it's deployed separately.
- No new dependencies. `npx tsc --noEmit` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)