### PR TITLE
Schema - Fix crash when editing a field with a null description

### DIFF
--- a/src/apps/schema/src/app/utils/index.ts
+++ b/src/apps/schema/src/app/utils/index.ts
@@ -111,7 +111,12 @@ export const getErrorMessage = ({
       return "A field with this API/Parsley Reference already exists";
     }
 
-    if (validate.includes("length") && maxLength && value.length > maxLength) {
+    if (
+      validate.includes("length") &&
+      maxLength &&
+      value &&
+      value.length > maxLength
+    ) {
       return `Shorten to less than ${maxLength} characters (${value.length}/${maxLength})`;
     }
 


### PR DESCRIPTION
## Summary

Editing (or opening the Add/Edit modal for) a Schema field whose `description` is `null` crashes the app with:

```
TypeError: Cannot read properties of null (reading 'length')
    at getErrorMessage (src/apps/schema/src/app/utils/index.ts:114)
    at FieldFormProvider.tsx (validation effect)
```

`description` is `null` for legacy and API-created fields (the API only stores a string once one is entered). Most fields created before the description field existed have `null` here.

## Root cause

PR #4127 ("Schema: Add frontend validation for description field length", merged to `dev` 2025-05-28, reached `stable` 2025-07-01) added `maxLength: 500` and `validate: ["length"]` to the `description` config entry. That routed `description`'s value through `getErrorMessage` for the first time. `description` is the only validated input whose hydrated form value can be `null` (`name`/`label` are required non-null; `tooltip` is explicitly coerced to `""`). The length check called `value.length` without a null guard.

## Fix

Guard the length check in `getErrorMessage` so a `null`/empty value is treated as no error. This is the actual crash site and protects any nullable validated field, not just `description`.

closes https://github.com/zesty-io/manager-ui/issues/4196