### PR TITLE
Schema - Fix crash when editing a field with a null description (stable hotfix)

### DIFF
--- a/src/apps/schema/src/app/utils/index.ts
+++ b/src/apps/schema/src/app/utils/index.ts
@@ -111,7 +111,12 @@ export const getErrorMessage = ({
       return "A field with this API/Parsley Reference already exists";
     }
 
-    if (validate.includes("length") && maxLength && value.length > maxLength) {
+    if (
+      validate.includes("length") &&
+      maxLength &&
+      value &&
+      value.length > maxLength
+    ) {
       return `Shorten to less than ${maxLength} characters (${value.length}/${maxLength})`;
     }
 


### PR DESCRIPTION


**Hotfix to `stable`** for a live production crash. Editing (or opening the Add/Edit modal for) a Schema field whose `description` is `null` crashes the app:

```
TypeError: Cannot read properties of null (reading 'length')
    at getErrorMessage (src/apps/schema/src/app/utils/index.ts:114)
```

`description` is `null` for legacy and API-created fields — most fields created before the description field existed. This has been live on `stable` since the 2026-07-01 Stable Release (#4177).

## Root cause

PR #4127 added `validate: ["length"]` to the `description` config entry, routing its value through `getErrorMessage` for the first time. `description` is the only validated input whose hydrated value can be `null`, and the length check called `value.length` without a null guard.

## Fix

Guard the length check in `getErrorMessage` so a `null`/empty value is treated as no error. Same one-line fix as the `dev` PR (#4197); this hotfix stops the bleeding on `stable` directly rather than waiting for the `dev → stage → beta → stable` cascade.

closes https://github.com/zesty-io/manager-ui/issues/4196
