### PR TITLE
Content - Preview sometimes doesn't show the save button (#4204)

### DIFF
--- a/cypress/e2e/content/content.spec.js
+++ b/cypress/e2e/content/content.spec.js
@@ -982,10 +982,7 @@ describe("Content Specs", () => {
       cy.getBySelector("SaveItemButton", options).should("not.exist");
 
       // 4. After the remount, a keystroke still dirties the item — proving the
-      //    baseline was re-established for the new editor instance. Intentionally
-      //    left unsaved: "b" never reaches the server, so it doesn't mutate the
-      //    seeded item. Do not add a save/cleanup step here — that would defeat
-      //    this assertion and write another change to the item.
+      //    baseline was re-established for the new editor instance.
       cy.iframe("#wysiwyg_basic_ifr").should("be.visible").click().type("b");
       cy.getBySelector("SaveItemButton", options).should("exist");
     });

--- a/cypress/e2e/content/content.spec.js
+++ b/cypress/e2e/content/content.spec.js
@@ -982,7 +982,10 @@ describe("Content Specs", () => {
       cy.getBySelector("SaveItemButton", options).should("not.exist");
 
       // 4. After the remount, a keystroke still dirties the item — proving the
-      //    baseline was re-established for the new editor instance.
+      //    baseline was re-established for the new editor instance. Intentionally
+      //    left unsaved: "b" never reaches the server, so it doesn't mutate the
+      //    seeded item. Do not add a save/cleanup step here — that would defeat
+      //    this assertion and write another change to the item.
       cy.iframe("#wysiwyg_basic_ifr").should("be.visible").click().type("b");
       cy.getBySelector("SaveItemButton", options).should("exist");
     });

--- a/cypress/e2e/content/content.spec.js
+++ b/cypress/e2e/content/content.spec.js
@@ -954,4 +954,37 @@ describe("Content Specs", () => {
         .should("not.contain.text", "bulk remove row");
     });
   });
+
+  describe("WYSIWYG dirty detection", () => {
+    before(() => {
+      cy.waitOn("/v1/content/models*", () => {
+        cy.visit(
+          `/content/${Cypress.env("modelZUID")}/${Cypress.env("itemZUID")}`
+        );
+      });
+    });
+
+    it("dirties on the first keystroke and clears after save", () => {
+      // 1. A freshly loaded item is clean — no save button.
+      cy.getBySelector("SaveItemButton", options).should("not.exist");
+
+      // 2. A single character is enough to dirty the item (past the 500ms
+      //    input debounce, which .should() retries through).
+      cy.iframe("#wysiwyg_basic_ifr").should("be.visible").click().type("a");
+      cy.getBySelector("SaveItemButton", options).should("exist");
+
+      // 3. Saving clears the dirty state and it stays clear through the
+      //    post-save version bump + editor remount.
+      cy.waitOn("/v1/content/models/*/items/*", () => {
+        cy.getBySelector("SaveItemButton").should("be.enabled").click();
+      });
+      cy.getBySelector("toast").contains("Item Saved").should("exist");
+      cy.getBySelector("SaveItemButton", options).should("not.exist");
+
+      // 4. After the remount, a keystroke still dirties the item — proving the
+      //    baseline was re-established for the new editor instance.
+      cy.iframe("#wysiwyg_basic_ifr").should("be.visible").click().type("b");
+      cy.getBySelector("SaveItemButton", options).should("exist");
+    });
+  });
 });

--- a/src/shell/components/FieldTypeTinyMCE/index.tsx
+++ b/src/shell/components/FieldTypeTinyMCE/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { Editor } from "@tinymce/tinymce-react";
 import { Box, alpha } from "@mui/material";
 import { theme } from "@zesty-io/material";
@@ -123,6 +123,14 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE({
   const effectiveCompact = compact && !isFullscreen;
   const toolbar = effectiveCompact ? compactToolbar : normalToolbar;
 
+  // The Editor remounts whenever this key changes (version bump on save,
+  // compact/fullscreen toggle). The baseline is tagged with the key of the
+  // editor instance that captured it, so a remounted instance's normalization
+  // pass isn't compared against a stale baseline and can't re-dirty a just-saved
+  // item.
+  const editorKey = `${effectiveCompact}-${version}`;
+  const baselineRef = useRef<{ key: string; content: string } | null>(null);
+
   const EDITOR_HEIGHT = effectiveCompact
     ? COMPACT_EDITOR_HEIGHT
     : NORMAL_EDITOR_HEIGHT;
@@ -184,17 +192,24 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE({
         <Editor
           // key must change whenever effectiveCompact or version changes
           // to update toolbar and value
-          key={`${effectiveCompact}-${version}`}
+          key={editorKey}
           id={name}
           onFocusIn={onFocus}
           onFocusOut={onBlur}
           initialValue={initialValue}
           onEditorChange={(content, editor) => {
-            // Only propagate genuine user edits. TinyMCE fires onEditorChange
-            // while parsing/normalizing the initial HTML on init; isDirty() is
-            // false for those programmatic changes and true once the user edits,
-            // so this prevents marking the item dirty on load.
-            if (editor.isDirty()) {
+            // Only propagate genuine user edits. `content` is editor.getContent(),
+            // the same call that seeds the baseline in onInit, so this compares
+            // like-for-like. A baseline whose key doesn't match this editor
+            // instance (initial load, or a not-yet-initialized remount) is
+            // treated as absent, so TinyMCE's initial normalization pass never
+            // dirties the item on load. Once initialized, any content that
+            // differs from the baseline is a real edit — this fires on the first
+            // keystroke and on code-dialog/media inserts, where isDirty() lags.
+            if (
+              baselineRef.current?.key === editorKey &&
+              content !== baselineRef.current.content
+            ) {
               onChange(content, name, datatype);
             }
 
@@ -205,11 +220,15 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE({
           }}
           onInit={(_, editor) => {
             // Establish a clean baseline after the initial content loads so the
-            // normalization pass above isn't treated as a user edit.
+            // normalization pass above isn't treated as a user edit. Captured
+            // via getContent() (post-normalization) and tagged with this
+            // instance's key so a remount starts fresh.
+            baselineRef.current = {
+              key: editorKey,
+              content: editor.getContent(),
+            };
 
             setInitialValue(value ?? "");
-
-            editor.setDirty(false);
 
             const charCount =
               editor.plugins?.wordcount?.body?.getCharacterCount() ?? 0;

--- a/src/shell/components/FieldTypeTinyMCE/index.tsx
+++ b/src/shell/components/FieldTypeTinyMCE/index.tsx
@@ -198,18 +198,14 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE({
           onFocusOut={onBlur}
           initialValue={initialValue}
           onEditorChange={(content, editor) => {
-            // Only propagate genuine user edits. `content` is editor.getContent(),
-            // the same call that seeds the baseline in onInit, so this compares
-            // like-for-like. A baseline whose key doesn't match this editor
-            // instance (initial load, or a not-yet-initialized remount) is
-            // treated as absent, so TinyMCE's initial normalization pass never
-            // dirties the item on load. Once initialized, any content that
-            // differs from the baseline is a real edit — this fires on the first
-            // keystroke and on code-dialog/media inserts, where isDirty() lags.
+            // Baseline tracks the last content sent to the parent (see onInit):
+            // the key guard skips TinyMCE's pre-init normalization, while any
+            // later change — including undo back to the loaded value — syncs.
             if (
               baselineRef.current?.key === editorKey &&
               content !== baselineRef.current.content
             ) {
+              baselineRef.current.content = content;
               onChange(content, name, datatype);
             }
 
@@ -219,10 +215,8 @@ export const FieldTypeTinyMCE = React.memo(function FieldTypeTinyMCE({
             onCharacterCountChange && onCharacterCountChange(charCount);
           }}
           onInit={(_, editor) => {
-            // Establish a clean baseline after the initial content loads so the
-            // normalization pass above isn't treated as a user edit. Captured
-            // via getContent() (post-normalization) and tagged with this
-            // instance's key so a remount starts fresh.
+            // Seed the baseline with the loaded (post-normalization) content,
+            // tagged with this instance's key so a remount starts fresh.
             baselineRef.current = {
               key: editorKey,
               content: editor.getContent(),


### PR DESCRIPTION
## Why

Fixes #4204. Editing a WYSIWYG didn't reliably show the save button in the preview: a single character often required a **second** input to register, and editing raw HTML via the `code` dialog didn't register at all.

## Root cause

The field gated `onChange` behind `editor.isDirty()`. But the tinymce-react wrapper fires `onEditorChange` off `keyup`/`setcontent`, which happens **before** TinyMCE commits the typing undo level that flips its dirty flag. So on the first keystroke `isDirty()` is still `false` and the change is dropped; by the second keystroke the first undo level has committed. The `code`-dialog save fails for the same reason from the programmatic `setContent` side.

## What

- Replace the racy `isDirty()` read with a deterministic comparison against the content loaded into **this** editor instance. A baseline is captured in `onInit` (`editor.getContent()`, post-normalization) and tagged with the editor's remount `key`; `onChange` fires whenever current content differs from it.
  - Preserves #4168's intent — TinyMCE's initial normalization pass equals the baseline, so a fresh load never dirties the item.
  - Fires on the **first** genuine edit through every input path (keystroke, `code` dialog, media/image inserts).
  - The key tag prevents a post-save remount (version bump) from re-dirtying a just-saved item.
- Remove the now-dead `editor.setDirty(false)` — nothing reads TinyMCE's dirty flag anymore, and the wrapper resets it internally.

