### PR TITLE
Reports - Activity Log user page crashes for a user no longer on the instance

### DIFF
--- a/src/apps/reports/src/app/views/ActivityLog/components/UserHeaderTitle.tsx
+++ b/src/apps/reports/src/app/views/ActivityLog/components/UserHeaderTitle.tsx
@@ -41,7 +41,7 @@ export const UserHeaderTitle = ({
     if (usersRoles) {
       const user = usersRoles?.find((userRole) => userRole.ZUID === id);
       return {
-        name: user ? `${user.firstName} ${user.lastName}` : "Former User",
+        name: user ? `${user.firstName} ${user.lastName}` : "Unknown User",
         imageUrl: `https://www.gravatar.com/avatar/${MD5(
           user?.email
         )}.jpg?s=40`,

--- a/src/apps/reports/src/app/views/ActivityLog/components/UserHeaderTitle.tsx
+++ b/src/apps/reports/src/app/views/ActivityLog/components/UserHeaderTitle.tsx
@@ -41,7 +41,7 @@ export const UserHeaderTitle = ({
     if (usersRoles) {
       const user = usersRoles?.find((userRole) => userRole.ZUID === id);
       return {
-        name: `${user?.firstName} ${user?.lastName}` ?? "",
+        name: user ? `${user.firstName} ${user.lastName}` : "Former User",
         imageUrl: `https://www.gravatar.com/avatar/${MD5(
           user?.email
         )}.jpg?s=40`,
@@ -56,7 +56,7 @@ export const UserHeaderTitle = ({
         ],
       };
     }
-  }, [usersRoles, actionCount]);
+  }, [usersRoles, actionCount, id]);
 
   const isLoading = isLoadingUsersRoles || isLoadingActions;
 

--- a/src/apps/reports/src/app/views/ActivityLog/components/UserHeaderTitle.tsx
+++ b/src/apps/reports/src/app/views/ActivityLog/components/UserHeaderTitle.tsx
@@ -56,7 +56,7 @@ export const UserHeaderTitle = ({
         ],
       };
     }
-  }, [usersRoles, actionCount, id]);
+  }, [usersRoles, actionCount, id, latestActionDateTime]);
 
   const isLoading = isLoadingUsersRoles || isLoadingActions;
 
@@ -105,7 +105,7 @@ export const UserHeaderTitle = ({
               <Skeleton width="100%" />
             ) : (
               <Typography variant="caption" color="text.secondary">
-                {headerData?.subTitle?.join(" • ")}
+                {headerData?.subTitle?.filter(Boolean).join(" • ")}
               </Typography>
             )}
           </Stack>

--- a/src/utility/md5.js
+++ b/src/utility/md5.js
@@ -1,4 +1,7 @@
 export function MD5(s) {
+  if (typeof s !== "string") {
+    s = "";
+  }
   function L(k, d) {
     return (k << d) | (k >>> (32 - d));
   }


### PR DESCRIPTION
Fixes #4201

## Summary
- Guard `MD5(s)` in `src/utility/md5.js` to coerce non-string input to `""` before hashing, instead of letting `undefined` reach the internal `.replace()` call and throw.
- In `UserHeaderTitle.tsx`, when the Activity Log's `:id` route param doesn't match any current user/role (e.g. the log entry belongs to a user later removed from the instance), render the header name as `"Former User"` instead of building `"undefined undefined"` from missing fields.
- Added the missing `id` dependency to the `headerData` `useMemo` in `UserHeaderTitle.tsx` — it read `id` but didn't declare it, so navigating between user detail routes could show stale header data.

## Test plan
- [ ] Open Reports > Activity Log > Users and select a user who is still active on the instance; header name, avatar, and subtitle render as before.
- [ ] Simulate/seed an activity log entry whose user ZUID no longer matches any active user or role, navigate to that user's detail page, and confirm the page renders "Former User" with a default gravatar instead of crashing.
- [ ] Navigate directly between two different user detail routes (changing only the `:id` param) and confirm the header updates correctly instead of showing stale data from the previous user.
- [ ] `npx tsc --noEmit` passes.