### PR TITLE
[Content] - Fix crash when images/files field value is not a string

### DIFF
--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
@@ -464,10 +464,14 @@ export const Field = memo(
 
       case "files":
       case "images":
-        const images = useMemo(
-          () => ((value as string) || "").split(",").filter((el: string) => el),
-          [value]
-        );
+        const images = useMemo(() => {
+          if (Array.isArray(value)) {
+            return value.filter(Boolean);
+          }
+          return typeof value === "string"
+            ? value.split(",").filter((el: string) => el)
+            : [];
+        }, [value]);
         const error = errors && Object.values(errors)?.some((error) => !!error);
 
         return (

--- a/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
+++ b/src/apps/content-editor/src/app/components/Editor/Field/Field.tsx
@@ -466,7 +466,10 @@ export const Field = memo(
       case "images":
         const images = useMemo(() => {
           if (Array.isArray(value)) {
-            return value.filter(Boolean);
+            return value.filter(
+              (el: unknown): el is string =>
+                typeof el === "string" && Boolean(el)
+            );
           }
           return typeof value === "string"
             ? value.split(",").filter((el: string) => el)


### PR DESCRIPTION
Fixes #4202

## Summary

- The `images`/`files` datatype case in `Field.tsx` built its media list via `((value as string) || "").split(",")...`, which only guards against a falsy `value`.
- `value` comes from `item?.data?.[field.name]` and is typed `any`. When the stored content data for that field was a truthy non-string (array, object, number, or boolean — likely written directly via the content API, which has no awareness of the Schema app's client-side field datatype validation), `.split` is not a function and the whole content editor crashes, caught only by the top-level Sentry ErrorBoundary (Sentry issue MANAGER-UI-3DD).

## Fix

`images` now branches on the value's actual shape:
- arrays are filtered for truthy entries and passed through
- strings are split as before
- anything else (number/boolean/object) falls back to an empty array

This matches what `FieldTypeMedia.tsx` expects (`images: string[]`) — an empty array renders that component's existing "no media / add from media" empty state, which is non-destructive: the stored bad value is only overwritten if the user subsequently interacts with the field (selecting/uploading/removing media triggers `onChange`).

This is a defensive one-line guard, not a refactor.

## Test plan

- [ ] Open a content item with an existing `images`/`files` field populated with a normal comma-separated string value — confirm it still renders the selected media as before.
- [ ] Manually set a field's stored value to a non-string (array/object) via the content API and confirm the content editor no longer crashes — the field renders its empty "add media" state instead.