### PR TITLE
Content - Fix crash editing item when model is undefined (invalid /blocks/:modelZUID/:itemZUID route)

### DIFF
--- a/src/apps/content-editor/src/app/components/UsedBlocks/BlockPreview.tsx
+++ b/src/apps/content-editor/src/app/components/UsedBlocks/BlockPreview.tsx
@@ -104,6 +104,7 @@ export const BlockPreview = ({
           <IconButton
             data-cy="EditBlock"
             size="small"
+            disabled={isLoadingBlockModel}
             onClick={() =>
               history.push(
                 `/blocks/${variantData?.meta?.contentModelZUID}/${variantData?.meta?.ZUID}`

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Content.js
@@ -349,7 +349,7 @@ export default function Content(props) {
               hasErrors={props.hasErrors}
               isLoadingItem={isLoadingItem}
             />
-            {props.model.type !== "block" && (
+            {props?.model?.type !== "block" && (
               <UsedBlocks
                 blockReferences={blockReferences}
                 isBuildingReferences={isBuildingReferences}

--- a/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/ItemEdit.js
@@ -279,6 +279,7 @@ export default function ItemEdit() {
       }
     } catch (err) {
       console.error("ItemEdit:load:error", err);
+      setNotFound(err?.message || "Item not found");
       throw err;
     } finally {
       if (isMounted.current) {


### PR DESCRIPTION
Fixes #4203

## Summary

Production crash reported via Sentry: `TypeError: Cannot read properties of undefined (reading 'type')` at `Content.js:352`. Root cause is a three-part gap when a user reaches `/blocks/:modelZUID/:itemZUID` with invalid/undefined ZUID segments (most likely by clicking "Edit Block" on a used-block preview before its model data has finished loading):

1. **`Content.js:352`** — `props.model.type !== "block"` crashed when `props.model` was undefined. Changed to `props?.model?.type !== "block"`, matching the existing guarded pattern already used 3 lines away (`props?.model?.type === "block"` at line 83). This is a defensive guard inside `Content` itself — it doesn't render a fallback, it just prevents the crash if `Content` ever renders with an undefined model.
2. **`BlockPreview.tsx`** — added `disabled={isLoadingBlockModel}` to the "Edit Block" `IconButton`, matching its two sibling icon buttons which already have this guard. This stops users from navigating to a URL with literal `"undefined"` ZUID segments while block model data is still loading.
3. **`ItemEdit.js`** — in `load()`'s catch block, added `setNotFound(err?.message || "Item not found")` before the rethrow. Previously, if `fetchItem` threw (rather than resolving with a 404/400 status), `notFound` state was never set, so the `<NotFound />` check at line 497 (`!isLoadingFields && !loading && notFound`) never triggered, and the tree fell through to render `Content` with an undefined model. Now a thrown fetch correctly routes to `<NotFound />`.

## Test plan

- [ ] Navigate directly to `/blocks/undefined/undefined` — should show `<NotFound />` instead of crashing.
- [ ] Open an item with used blocks while block model data is still loading — the "Edit Block" icon button should be disabled and not navigable.
- [ ] Once block model data has loaded, clicking "Edit Block" (`data-cy="EditBlock"`) should still navigate to `/blocks/:modelZUID/:itemZUID` normally.