### PR TITLE
Studio - Layers panel resize, canvas selection opens Inspector, one-level default expansion

### DIFF
--- a/cypress/e2e/studio/inspector-panel.spec.js
+++ b/cypress/e2e/studio/inspector-panel.spec.js
@@ -334,6 +334,13 @@ describe("Studio Inspector Panel", () => {
         children: [hello],
       });
 
+      // The tree defaults to one level: the host wraps `hello` in a Text
+      // placeholder (div → No Tag → hello), which starts collapsed. Expand it
+      // via its chevron — clicking the row itself would open ITS panel.
+      cy.get(`[data-cy="StudioLayersRow"][data-node-id="${hello.id}:noTag"]`)
+        .find('[data-cy="StudioLayersRowChevron"]')
+        .click();
+
       // This run had no slot at all before it was addressable — the panel could
       // not reach text that shared its element with another node.
       openPanelFor(hello);

--- a/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/StudioWrapper.tsx
@@ -28,6 +28,7 @@ import Editor from "../../components/Editor/Editor";
 import { FieldError } from "../../components/Editor/FieldError";
 import { PendingEditsModal } from "../../components/PendingEditsModal";
 import { DirtyCodeModal } from "../../../../../../shell/components/DirtyCodeModal";
+import { ResizableContainer } from "../../../../../../shell/components/ResizeableContainer";
 import contentOneLogoOnly from "../../../../../../../public/images/contentOneLogoOnly.webp";
 import contentOneLogo from "../../../../../../../public/images/contentOneLogo.webp";
 import {
@@ -1170,6 +1171,7 @@ export const StudioWrapper = () => {
     resetTree: resetLayersTree,
     toggleNode: toggleLayersNode,
     handleNodeSelect: handleLayersNodeSelect,
+    openInspectorForLayoutElement,
     canDrop: canDropLayersNode,
     handleNodeDrop: handleLayersNodeDrop,
   } = useStudioLayersTree({
@@ -1195,6 +1197,22 @@ export const StudioWrapper = () => {
     }
   }, [isNavigating, isRefreshing, resetLayersTree]);
 
+  // Canvas layout selection (bridge mousedown/dblclick) selects the element
+  // AND opens its Inspector panel, mirroring a click on its layers-tree row.
+  const handleBridgeLayoutSelection = useCallback(
+    (next: {
+      codeId?: string;
+      layoutId?: string;
+      breadcrumb?: LayoutBreadcrumbItem[];
+    }) => {
+      applyLayoutSelection(next);
+      if (next.codeId && next.layoutId) {
+        openInspectorForLayoutElement(next.codeId, next.layoutId);
+      }
+    },
+    [applyLayoutSelection, openInspectorForLayoutElement]
+  );
+
   const { handlePreviewLoad } = useStudioBridge({
     dispatch,
     interactionMode,
@@ -1204,7 +1222,7 @@ export const StudioWrapper = () => {
     handleReorderOutput,
     handleLayoutContentUpdate,
     handleLayersTree,
-    applyLayoutSelection,
+    applyLayoutSelection: handleBridgeLayoutSelection,
     clearLayoutSelection,
     applySelection: applyBridgeSelection,
     fieldNameByZuid,
@@ -1545,15 +1563,23 @@ export const StudioWrapper = () => {
             logoSrc={contentOneLogoOnly}
           />
           <Box display="flex" flex="1" minHeight={0} width="100%">
-            <StudioLayersPanel
-              hasTree={hasLayersTree}
-              flatRows={layersFlatRows}
-              selectedNodeId={selectedLayersNodeId}
-              onToggle={toggleLayersNode}
-              onSelect={handleLayersNodeSelect}
-              canDrop={canDropLayersNode}
-              onDrop={handleLayersNodeDrop}
-            />
+            <ResizableContainer
+              id="studioLayersPanel"
+              defaultWidth={220}
+              minWidth={220}
+              maxWidth={400}
+              collapsible={false}
+            >
+              <StudioLayersPanel
+                hasTree={hasLayersTree}
+                flatRows={layersFlatRows}
+                selectedNodeId={selectedLayersNodeId}
+                onToggle={toggleLayersNode}
+                onSelect={handleLayersNodeSelect}
+                canDrop={canDropLayersNode}
+                onDrop={handleLayersNodeDrop}
+              />
+            </ResizableContainer>
             <StudioPreview
               iframeRef={iframeRef}
               iframeSrc={iframeSrc}

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersPanel.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/StudioWrapper/StudioLayersPanel.tsx
@@ -138,8 +138,8 @@ export const StudioLayersPanel = ({
   return (
     <Box
       data-cy="StudioLayersPanel"
-      width={220}
-      flexShrink={0}
+      width="100%"
+      height="100%"
       display="flex"
       flexDirection="column"
       gap={1.25}

--- a/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioLayersTree.ts
+++ b/src/apps/content-editor/src/app/views/ItemEdit/hooks/useStudioLayersTree.ts
@@ -154,6 +154,30 @@ const isPanelNode = (node: LayersTreeNode, interactionMode: InteractionMode) =>
     node.kind === "text" ||
     (node.kind === "field" && interactionMode === "layout"));
 
+// A leaf element's single addressable content row — the text run or bound
+// field carrying its Text ("Value") slot. Recognized by its layoutPatch
+// addressing the leaf element (that's how the bridge marks a leaf's own runs),
+// so a nested element's text never matches. Returns null when the element has
+// no such row, or has several — each run is then reachable only through its
+// own tree row.
+const findLoneTextSlotChild = (node: LayersTreeNode): LayersTreeNode | null => {
+  const matches: LayersTreeNode[] = [];
+  const visit = (children: LayersTreeNode[]) => {
+    children.forEach((child) => {
+      if (
+        child.layoutPatch?.layoutId === node.layoutId &&
+        child.layoutPatch?.codeId === node.codeId &&
+        (child.slots || []).some((slot) => slot.kind === "text")
+      ) {
+        matches.push(child);
+      }
+      visit(child.children);
+    });
+  };
+  visit(node.children);
+  return matches.length === 1 ? matches[0] : null;
+};
+
 export const useStudioLayersTree = ({
   interactionMode,
   postCommandToBridge,
@@ -169,9 +193,11 @@ export const useStudioLayersTree = ({
   dndDisabled,
 }: Args) => {
   const [tree, setTree] = useState<LayersTreeNode[] | null>(null);
-  // Everything is expanded by default; we only track what the user explicitly
-  // collapses, so nodes that appear on later re-emits start open too.
-  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
+  // Rows the user has flipped AWAY from their default expansion. Root rows
+  // default OPEN (a fresh panel shows one level); everything else defaults
+  // CLOSED. Storing the delta rather than an absolute set keeps both defaults
+  // applying to nodes that first appear in later re-emits.
+  const [toggledIds, setToggledIds] = useState<Set<string>>(new Set());
 
   const handleLayersTree = useCallback((msg: any) => {
     const nextTree: LayersTreeNode[] = Array.isArray(msg?.tree)
@@ -182,7 +208,7 @@ export const useStudioLayersTree = ({
 
   const resetTree = useCallback(() => {
     setTree(null);
-    setCollapsedIds(new Set());
+    setToggledIds(new Set());
   }, []);
 
   const { nodeById, parentById } = useMemo(() => {
@@ -198,6 +224,20 @@ export const useStudioLayersTree = ({
     index(tree || [], null);
     return { nodeById: byId, parentById: parents };
   }, [tree]);
+
+  // Whether a row is expanded before the user ever touches it: only the
+  // tree's root rows (no parent) are open, showing one level; everything
+  // below starts closed.
+  const isDefaultOpen = useCallback(
+    (node: LayersTreeNode) => !parentById.get(node.id),
+    [parentById]
+  );
+
+  const isNodeExpanded = useCallback(
+    (node: LayersTreeNode) =>
+      isDefaultOpen(node) ? !toggledIds.has(node.id) : toggledIds.has(node.id),
+    [isDefaultOpen, toggledIds]
+  );
 
   const selectedNodeId = useMemo(() => {
     // An open Inspector panel owns the highlight in both modes.
@@ -249,8 +289,34 @@ export const useStudioLayersTree = ({
     selectedLayout,
   ]);
 
+  // A selection (canvas click, drill-down, inspector open) can land on a row
+  // whose ancestors are collapsed — expand them so the selected row actually
+  // renders; the panel's scroll-into-view can't reach an unrendered row.
+  // Deliberately NOT keyed on toggledIds: collapsing an ancestor of the
+  // current selection afterwards is a user choice this must not fight.
+  useEffect(() => {
+    if (!selectedNodeId) return;
+    setToggledIds((prev) => {
+      const next = new Set(prev);
+      let changed = false;
+      let parent = parentById.get(selectedNodeId) || null;
+      while (parent) {
+        // Force-expand relative to each row's default: a default-open row
+        // expands by REMOVING its toggle, a default-closed one by ADDING it.
+        if (isDefaultOpen(parent)) {
+          if (next.delete(parent.id)) changed = true;
+        } else if (!next.has(parent.id)) {
+          next.add(parent.id);
+          changed = true;
+        }
+        parent = parentById.get(parent.id) || null;
+      }
+      return changed ? next : prev;
+    });
+  }, [isDefaultOpen, parentById, selectedNodeId]);
+
   const toggleNode = useCallback((nodeId: string) => {
-    setCollapsedIds((prev) => {
+    setToggledIds((prev) => {
       const next = new Set(prev);
       if (next.has(nodeId)) {
         next.delete(nodeId);
@@ -311,7 +377,7 @@ export const useStudioLayersTree = ({
     ) => {
       nodes.forEach((node) => {
         const hasChildren = node.children.length > 0;
-        const expanded = !collapsedIds.has(node.id);
+        const expanded = isNodeExpanded(node);
         rows.push({
           node,
           depth,
@@ -337,9 +403,9 @@ export const useStudioLayersTree = ({
     return rows;
   }, [
     dndDisabled,
-    collapsedIds,
     getRowLabel,
     interactionMode,
+    isNodeExpanded,
     isNodeSelectable,
     selectedNodeId,
     tree,
@@ -396,6 +462,48 @@ export const useStudioLayersTree = ({
         return fieldName ? { ...slot, value: fieldName } : slot;
       }),
     [fieldsState, interactionMode]
+  );
+
+  // Open the Inspector for a canvas-selected layout element, mirroring the
+  // layers tree (layout mode only — content-mode canvas clicks route straight
+  // to the field editor). Which panel opens depends on the element:
+  //   - An element with its own attribute slots (an <img>'s src, an <a>'s
+  //     href) opens ITS panel, like clicking its tree row.
+  //   - A bare text leaf (an <h1>, a <p> — no attribute slots) opens its lone
+  //     text run's / bound field's panel — titled "Text", holding the Value
+  //     input — like clicking that child's tree row. The canvas can't select
+  //     the child directly, so the element click stands in for it.
+  // No-op when the tree hasn't arrived yet or nothing is panel-worthy; the
+  // selection stands and any open Inspector was already closed by
+  // applyLayoutSelection.
+  const openInspectorForLayoutElement = useCallback(
+    (codeId: string, layoutId: string) => {
+      if (interactionMode !== "layout") return;
+      for (const node of nodeById.values()) {
+        if (
+          node.kind === "element" &&
+          node.layoutId === layoutId &&
+          node.codeId === codeId
+        ) {
+          const textChild = node.slots?.length
+            ? null
+            : findLoneTextSlotChild(node);
+          const target =
+            textChild && isPanelNode(textChild, interactionMode)
+              ? textChild
+              : node;
+          if (!isPanelNode(target, interactionMode)) return;
+          applyInspectorSelection({
+            nodeId: target.id,
+            tagName: target.tagName || "",
+            slots: resolveSlotValues(target.slots),
+            layoutPatch: target.layoutPatch ?? null,
+          });
+          return;
+        }
+      }
+    },
+    [applyInspectorSelection, interactionMode, nodeById, resolveSlotValues]
   );
 
   const handleNodeSelect = useCallback(
@@ -563,6 +671,7 @@ export const useStudioLayersTree = ({
     resetTree,
     toggleNode,
     handleNodeSelect,
+    openInspectorForLayoutElement,
     canDrop,
     handleNodeDrop,
   };

--- a/src/shell/components/ResizeableContainer.tsx
+++ b/src/shell/components/ResizeableContainer.tsx
@@ -12,6 +12,7 @@ type Props = {
   maxWidth: number;
   defaultWidth: number;
   id: string;
+  collapsible?: boolean;
 };
 
 export const ResizableContainer = ({
@@ -20,6 +21,7 @@ export const ResizableContainer = ({
   maxWidth,
   defaultWidth,
   id,
+  collapsible = true,
 }: Props) => {
   const [isResizing, setIsResizing] = useState(false);
   const [initialPos, setInitialPos] = useState(0);
@@ -35,6 +37,10 @@ export const ResizableContainer = ({
     false
   );
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+
+  // A non-collapsible container ignores any stored collapsed state so it can
+  // never render stuck at width 0 with no button to expand it.
+  const isCollapsed = collapsible && collapsed;
 
   const handleMouseDown = (e: React.MouseEvent) => {
     setIsResizing(true);
@@ -77,9 +83,9 @@ export const ResizableContainer = ({
   const MemoizedChildren = useMemo(() => children, [children]);
 
   return (
-    <Box width={collapsed ? 0 : width} position="relative">
+    <Box width={isCollapsed ? 0 : width} position="relative">
       <Box
-        overflow={collapsed ? "hidden" : "visible"}
+        overflow={isCollapsed ? "hidden" : "visible"}
         height="100%"
         width="inherit"
       >
@@ -100,60 +106,62 @@ export const ResizableContainer = ({
           },
         }}
         onMouseDown={handleMouseDown}
-        display={collapsed ? "none" : "block"}
+        display={isCollapsed ? "none" : "block"}
       />
-      <Tooltip
-        title={collapsed ? "Expand Sidebar" : "Collapse Sidebar"}
-        placement="right-start"
-        enterDelay={1000}
-        enterNextDelay={1000}
-        open={isTooltipOpen && isHoveringCollapseButton}
-        onOpen={() => setIsTooltipOpen(true)}
-        onClose={() => setIsTooltipOpen(false)}
-      >
-        <IconButton
-          data-cy="collapseAppSideBar"
-          onClick={() => {
-            setIsTooltipOpen(false);
-            setCollapsed(!collapsed);
-            setIsHoveringCollapseButton(false);
-          }}
-          onMouseOver={() => setIsHoveringCollapseButton(true)}
-          sx={{
-            borderRadius: "50%",
-            borderColor: "grey.600",
-            borderStyle: "solid",
-            borderWidth: "1px",
-            backgroundColor: "grey.900",
-
-            width: "24px",
-            height: "24px",
-
-            position: "absolute",
-            top: "32px",
-            right: "-12px",
-            zIndex: (theme) => theme.zIndex.appBar,
-
-            "&:hover": {
+      {collapsible && (
+        <Tooltip
+          title={collapsed ? "Expand Sidebar" : "Collapse Sidebar"}
+          placement="right-start"
+          enterDelay={1000}
+          enterNextDelay={1000}
+          open={isTooltipOpen && isHoveringCollapseButton}
+          onOpen={() => setIsTooltipOpen(true)}
+          onClose={() => setIsTooltipOpen(false)}
+        >
+          <IconButton
+            data-cy="collapseAppSideBar"
+            onClick={() => {
+              setIsTooltipOpen(false);
+              setCollapsed(!collapsed);
+              setIsHoveringCollapseButton(false);
+            }}
+            onMouseOver={() => setIsHoveringCollapseButton(true)}
+            sx={{
+              borderRadius: "50%",
+              borderColor: "grey.600",
+              borderStyle: "solid",
+              borderWidth: "1px",
               backgroundColor: "grey.900",
 
-              ".MuiSvgIcon-root": {
-                color: "common.white",
+              width: "24px",
+              height: "24px",
+
+              position: "absolute",
+              top: "32px",
+              right: "-12px",
+              zIndex: (theme) => theme.zIndex.appBar,
+
+              "&:hover": {
+                backgroundColor: "grey.900",
+
+                ".MuiSvgIcon-root": {
+                  color: "common.white",
+                },
               },
-            },
-          }}
-        >
-          <SvgIcon
-            component={
-              collapsed ? KeyboardDoubleArrowRight : KeyboardDoubleArrowLeft
-            }
-            fontSize="small"
-            sx={{
-              color: "grey.500",
             }}
-          />
-        </IconButton>
-      </Tooltip>
+          >
+            <SvgIcon
+              component={
+                collapsed ? KeyboardDoubleArrowRight : KeyboardDoubleArrowLeft
+              }
+              fontSize="small"
+              sx={{
+                color: "grey.500",
+              }}
+            />
+          </IconButton>
+        </Tooltip>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

Three Studio layers-panel / canvas-selection improvements:

- **Resizable layers panel** — wrapped in the shared `ResizableContainer` (220–400px, width persisted per user). Adds an optional `collapsible` prop to the shared component (default `true`, other consumers unaffected) so the layers panel can opt out of the collapse button; a non-collapsible container also ignores any stale stored collapsed state so it can never render stuck at width 0.
- **Canvas selection opens the Inspector** (layout mode) — a canvas `mousedown`/`dblclick` layout selection now opens the Inspector panel, mirroring a click on the matching layers-tree row: attribute-bearing elements (`img`, `a`, `video`…) open their own panel; bare text leaves (`h1`, `p`…) open their lone text run's / bound field's "Value" panel via `findLoneTextSlotChild`. Content-mode canvas clicks still route straight to the field editor; tree drag-and-drop still never pops the panel.
- **Layers tree defaults to one level** — root rows open, everything below collapsed. `toggledIds` stores only deviations from that default, so both defaults keep applying to nodes that first appear in later tree re-emits and user choices stick. Selecting a row (canvas click, drill-down, inspector open) auto-expands its collapsed ancestors so the selected row always renders and can scroll into view.

## Not included on purpose

`bridge.js` (untracked) has companion fixes — link `mousedown` swallowing that made elements inside `<a>` unselectable/unreorderable from the canvas, and drill-down starting on un-addressable base-template ancestors (dead first click) — but it deploys separately to GCS (`instudio-dev/bridge.js`). ⚠️ When deploying it: the bucket copy currently contains a boolean-attr/Parsley change that is **not** in the local file — sync that down first or it will be clobbered.

## Test plan

- Verified live against the dev instance via browser automation: panel resize + no collapse button; canvas click → Inspector opens with the right panel per element kind; fresh load shows exactly one tree level; selection auto-reveals; layers-panel drag reorder of adjacent elements still works end-to-end (save bar appears; change discarded after).
- `npx tsc --noEmit` clean (CI has no type gate).
- No new Cypress specs: these flows depend on the Studio bridge injected by the preview server, which the CI instance's specs don't currently exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)