### PR TITLE
CI - Make Claude review and QA PR comments concise and non-overlapping

### DIFF
--- a/.github/workflows/claude-auto-reviewer.yml
+++ b/.github/workflows/claude-auto-reviewer.yml
@@ -1,4 +1,10 @@
 name: Claude Auto Review
+
+# Code-level review on every non-draft PR into dev: bugs, security, performance, and CLAUDE.md
+# "Review red flags" only. The Claude Change Verifier workflow owns "what does this change do"
+# and acceptance-criteria QA — this workflow must never duplicate that. Findings land as inline
+# comments; one single-line verdict comment is created and updated in place.
+
 on:
   pull_request:
     branches: [dev]
@@ -22,26 +28,82 @@ jobs:
 
       - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
         with:
-          use_sticky_comment: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            You are the CODE reviewer for this pull request. A separate "QA Review" workflow
+            already summarizes what the change does and validates it against the linked issue's
+            acceptance criteria. Do not duplicate it: no change summary, no restating the diff,
+            no judging whether the PR satisfies its issue, no test-coverage suggestions.
 
-            Please review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
+            Inputs:
+              REPO        = ${{ github.repository }}
+              PR_NUMBER   = ${{ github.event.pull_request.number }}
+              REPORT_FILE = ${{ github.workspace }}/review-comment.md
 
-            Note: The PR branch is already checked out in the current working directory.
+            Read the diff (gh pr diff <PR_NUMBER> --repo <REPO>) and the checked-out source, and
+            look only for, in priority order:
+              1. Bugs — logic errors, crashes, broken edge cases, regressions.
+              2. Security issues.
+              3. Performance problems (re-render perf matters in this repo — see CLAUDE.md).
+              4. Violations of the "Review red flags" list in CLAUDE.md.
 
-            Use `gh pr comment` for top-level feedback.
-            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
-            Only post GitHub comments - don't submit review text as messages.
+            Report only findings you are confident are real. No style nits, no praise, no
+            speculative "consider…" advice without a concrete failure mode. An empty review is
+            a valid and common outcome.
+
+            For each finding, post one inline comment with
+            mcp__github_inline_comment__create_inline_comment (confirmed: true), shaped as:
+              **<🔴 or 🟡> <one-line finding>**
+              <at most 3 sentences: what breaks and when, then the fix — a sentence or a short
+               code block.>
+            Severity: 🔴 Blocker — will break something. 🟡 Warning — likely problem or a
+            red-flag violation.
+
+            Then write the verdict to REPORT_FILE with the Write tool. It is exactly two lines
+            (keep the HTML marker verbatim as the first line) and nothing else — no table, no
+            list of findings, no prose:
+
+              <!-- claude-code-review -->
+              ## Code Review — <verdict>
+
+            where <verdict> is exactly one of:
+              ✅ No blockers
+              ✅ No blockers · 🟡 M warning(s) — see inline comments
+              🔴 N blocker(s) · 🟡 M warning(s) — see inline comments
+            Never write a zero count — omit that segment instead.
+
+            The inline comments ARE the review; the verdict comment only answers "can this
+            merge?". Do not post the verdict comment yourself and do not reply in chat.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Write,Grep,Glob"
             --model claude-sonnet-4-6
             --max-turns 20
+
+      # Post the summary, or update the existing review comment in place so pushes don't stack
+      # a new comment each run.
+      - name: Post or update review summary
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          FILE="$GITHUB_WORKSPACE/review-comment.md"
+          if [ ! -s "$FILE" ] || ! grep -q '<!-- claude-code-review -->' "$FILE"; then
+            echo "::warning::review-comment.md missing or malformed; skipping summary comment."
+            exit 0
+          fi
+          BODY=$(cat "$FILE")
+          PAYLOAD=$(BODY="$BODY" python3 -c 'import os,json,sys; sys.stdout.write(json.dumps({"body": os.environ["BODY"]}))')
+          CID=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- claude-code-review -->")) | .id' | head -n1)
+          if [ -n "${CID:-}" ]; then
+            printf '%s' "$PAYLOAD" | gh api -X PATCH "repos/$REPO/issues/comments/$CID" --input - --silent
+            echo "Updated review summary comment $CID."
+          else
+            printf '%s' "$PAYLOAD" | gh api -X POST "repos/$REPO/issues/$PR/comments" --input - --silent
+            echo "Created review summary comment."
+          fi

--- a/.github/workflows/claude-auto-reviewer.yml
+++ b/.github/workflows/claude-auto-reviewer.yml
@@ -3,7 +3,8 @@ name: Claude Auto Review
 # Code-level review on every non-draft PR into dev: bugs, security, performance, and CLAUDE.md
 # "Review red flags" only. The Claude Change Verifier workflow owns "what does this change do"
 # and acceptance-criteria QA — this workflow must never duplicate that. Findings land as inline
-# comments; one single-line verdict comment is created and updated in place.
+# comments; each run posts a fresh single-line verdict comment (deliberately NOT updated in
+# place) so the PR timeline shows the review history: "1 blocker" → fix commits → "no blockers".
 
 on:
   pull_request:
@@ -81,9 +82,9 @@ jobs:
             --model claude-sonnet-4-6
             --max-turns 20
 
-      # Post the summary, or update the existing review comment in place so pushes don't stack
-      # a new comment each run.
-      - name: Post or update review summary
+      # Always post a NEW verdict comment (never update in place): each push's verdict lands in
+      # the PR timeline between the commits it reviewed, preserving the review history.
+      - name: Post review verdict
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -93,17 +94,10 @@ jobs:
           set -euo pipefail
           FILE="$GITHUB_WORKSPACE/review-comment.md"
           if [ ! -s "$FILE" ] || ! grep -q '<!-- claude-code-review -->' "$FILE"; then
-            echo "::warning::review-comment.md missing or malformed; skipping summary comment."
+            echo "::warning::review-comment.md missing or malformed; skipping verdict comment."
             exit 0
           fi
           BODY=$(cat "$FILE")
           PAYLOAD=$(BODY="$BODY" python3 -c 'import os,json,sys; sys.stdout.write(json.dumps({"body": os.environ["BODY"]}))')
-          CID=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- claude-code-review -->")) | .id' | head -n1)
-          if [ -n "${CID:-}" ]; then
-            printf '%s' "$PAYLOAD" | gh api -X PATCH "repos/$REPO/issues/comments/$CID" --input - --silent
-            echo "Updated review summary comment $CID."
-          else
-            printf '%s' "$PAYLOAD" | gh api -X POST "repos/$REPO/issues/$PR/comments" --input - --silent
-            echo "Created review summary comment."
-          fi
+          printf '%s' "$PAYLOAD" | gh api -X POST "repos/$REPO/issues/$PR/comments" --input - --silent
+          echo "Posted review verdict comment."

--- a/.github/workflows/claude-change-verifier.yml
+++ b/.github/workflows/claude-change-verifier.yml
@@ -115,16 +115,12 @@ jobs:
 
               <!-- qa-verdict: <PASS_OR_FAIL_OR_INCONCLUSIVE> -->
 
-            Use plain ordered lists for criteria (refer to them as "criterion 1"); never write `#1`
-            (GitHub auto-links it). The only `#<n>` allowed is the "Validates #<n>" header. Write the
-            `<!-- qa-verdict: ... -->` marker exactly once, as the final line — never quote it or the
-            `<!-- cv-verifier -->` marker anywhere else in the report.
-
-            The report is exactly: the verdict header, the issue line, the criteria list, and the
-            collapsed Cypress block. No summary section, no "gaps & concerns" section, no extra
-            prose — the "— why" clause on a ⚠️/❌ criterion is the only place for explanation.
-            The criteria list must read pass/fail at a glance. In change-only mode, ✅ lines with
-            no clause are the norm — add words only where something is wrong.
+            Rules: the report contains nothing beyond the template — no summary or extra sections.
+            The "— why" clause on a ⚠️/❌ line is the only place for explanation; ✅ lines get none.
+            In change-only mode the numbered list is the checks you performed. Never write `#<n>`
+            except in the "Validates #<n>" line (GitHub auto-links it). Write the
+            `<!-- qa-verdict: ... -->` marker exactly once, as the final line, and never quote
+            either HTML marker elsewhere in the report.
 
       # Post the report, or update the existing QA comment in place. Reads the verdict for the gate.
       - name: Post or update QA comment

--- a/.github/workflows/claude-change-verifier.yml
+++ b/.github/workflows/claude-change-verifier.yml
@@ -68,6 +68,11 @@ jobs:
             the checked-out source. There is no running app or browser, so never claim to have observed
             runtime behavior.
 
+            A separate "Claude Auto Review" workflow already reviews this PR for bugs, security,
+            performance, and code conventions. Do not duplicate it: your only job is to judge the
+            change against the linked issue's acceptance criteria. Mention a code-level problem
+            only when it directly causes a criterion to fail.
+
             Inputs:
               REPO         = ${{ github.repository }}
               PR_NUMBER    = ${{ github.event.pull_request.number }}
@@ -77,8 +82,9 @@ jobs:
             1. If ISSUE_NUMBER is set, read it (gh issue view <ISSUE_NUMBER> --repo <REPO> --json
                title,body,comments,labels) and derive a short numbered list of acceptance criteria.
                If empty, run change-only mode: no criteria, just assess whether the change is correct.
-            2. Read the diff (gh pr diff <PR_NUMBER> --repo <REPO>), open the changed files, and
-               summarize in plain language what the change does.
+            2. Read the diff (gh pr diff <PR_NUMBER> --repo <REPO>) and open the changed files to
+               understand what the change does. This is for your judgment only — the report does
+               not include a change summary.
             3. Judge each criterion from the code as one of:
                  ✅ Satisfied    — the code clearly implements it.
                  ⚠️ Inconclusive — can't tell from the code alone. Not a failure.
@@ -94,20 +100,18 @@ jobs:
             markers verbatim). Do not post a comment or reply in chat.
 
               <!-- cv-verifier -->
-              ## QA Review — <PASS | FAIL | INCONCLUSIVE>
+              ## QA Review — <✅ PASS | ❌ FAIL | ⚠️ INCONCLUSIVE>
               <If an issue: "Validates #<n>: <title>". Else: "No linked issue found — change-only QA.">
 
-              ### Acceptance criteria
-              <numbered list; each line starts with ✅ / ⚠️ / ❌. Change-only mode: list what you checked.>
+              1. ✅ <criterion in one line>
+              2. ❌ <criterion in one line> — <why it fails, one clause>
+              3. ⚠️ <criterion in one line> — <what couldn't be confirmed, one clause>
 
-              ### What this change does
-              <plain-language summary>
+              <details>
+              <summary>Suggested Cypress coverage</summary>
 
-              ### Gaps & concerns
-              <unmet criteria, missing edge cases, regression risk — or "None observed">
-
-              ### Suggested Cypress coverage
               <real spec file name + prose cases>
+              </details>
 
               <!-- qa-verdict: <PASS_OR_FAIL_OR_INCONCLUSIVE> -->
 
@@ -115,6 +119,12 @@ jobs:
             (GitHub auto-links it). The only `#<n>` allowed is the "Validates #<n>" header. Write the
             `<!-- qa-verdict: ... -->` marker exactly once, as the final line — never quote it or the
             `<!-- cv-verifier -->` marker anywhere else in the report.
+
+            The report is exactly: the verdict header, the issue line, the criteria list, and the
+            collapsed Cypress block. No summary section, no "gaps & concerns" section, no extra
+            prose — the "— why" clause on a ⚠️/❌ criterion is the only place for explanation.
+            The criteria list must read pass/fail at a glance. In change-only mode, ✅ lines with
+            no clause are the norm — add words only where something is wrong.
 
       # Post the report, or update the existing QA comment in place. Reads the verdict for the gate.
       - name: Post or update QA comment


### PR DESCRIPTION
## What

Restructures the two Claude PR workflows so they no longer overlap and their output is scannable at a glance:

**Claude Auto Review** — code findings only (bugs, security, perf, CLAUDE.md red flags). Explicitly banned from summarizing the change, judging acceptance criteria, or suggesting tests. Findings go in inline comments (max 3 sentences each); the summary comment is a single verdict line (`✅ No blockers` / `🔴 N blocker(s) · 🟡 M warning(s) — see inline comments`) written via a marker file and updated in place, so pushes no longer stack a new comment per run.

**Claude Change Verifier** — acceptance-criteria QA only. Explicitly banned from code-quality/security/perf commentary. Report is now just the verdict header, the issue line, and a numbered ✅/⚠️/❌ criteria checklist — explanation allowed only as a one-clause "— why" on failing/inconclusive lines. The "What this change does" and "Gaps & concerns" sections are removed; Cypress suggestions collapse into a `<details>` block.

## Unchanged

Triggers, concurrency, permissions, the `cv-verifier`/`qa-verdict` markers, and the FAIL gate logic are untouched.

## Why

Both workflows previously summarized "what changed" and produced long free-form comments, so reviewers read the same information twice and had to dig for the verdict.

Since `pull_request` workflows run from the PR's merge commit, this PR's own review comments are produced by the new prompts — check them to evaluate the format.

