### PR TITLE
Shell - Prevent crash from malformed language data

### DIFF
--- a/src/shell/hooks/useSearchBlocksByKeyword.ts
+++ b/src/shell/hooks/useSearchBlocksByKeyword.ts
@@ -47,9 +47,9 @@ export const useSearchBlocksByKeyword = ({
   const languages: Language[] = useSelector(
     (state: AppState) => state?.languages
   );
-  const defaultLanguage = languages?.find(
-    (lang: Language) => lang?.default && lang?.active
-  );
+  const defaultLanguage = Array.isArray(languages)
+    ? languages.find((lang: Language) => lang?.default && lang?.active)
+    : undefined;
 
   const models = useSelector((state: AppState) => state?.models);
   const contents = useSelector((state: AppState) => state?.content);
@@ -68,8 +68,9 @@ export const useSearchBlocksByKeyword = ({
 
   const languageMap = useMemo<LanguageMap>(
     () =>
-      !!languages?.length &&
-      Object.fromEntries(languages?.map((lang) => [lang?.ID, lang])),
+      Array.isArray(languages) &&
+      !!languages.length &&
+      Object.fromEntries(languages.map((lang) => [lang?.ID, lang])),
     [languages]
   );
 
@@ -96,7 +97,9 @@ export const useSearchBlocksByKeyword = ({
     }
 
     const blockModelZUIDs = new Set(blocks.map((block) => block?.ZUID));
-    const validLangIDs = new Set(languages.map((lang) => lang?.ID));
+    const validLangIDs = new Set(
+      Array.isArray(languages) ? languages.map((lang) => lang?.ID) : []
+    );
 
     return contentItems.filter(
       (content: ContentItem) =>

--- a/src/shell/hooks/useSearchBlocksByKeyword.ts
+++ b/src/shell/hooks/useSearchBlocksByKeyword.ts
@@ -68,9 +68,9 @@ export const useSearchBlocksByKeyword = ({
 
   const languageMap = useMemo<LanguageMap>(
     () =>
-      Array.isArray(languages) &&
-      !!languages.length &&
-      Object.fromEntries(languages.map((lang) => [lang?.ID, lang])),
+      Array.isArray(languages) && languages.length
+        ? Object.fromEntries(languages.map((lang) => [lang?.ID, lang]))
+        : {},
     [languages]
   );
 

--- a/src/shell/store/languages.js
+++ b/src/shell/store/languages.js
@@ -4,7 +4,16 @@ export function languages(state = [], action) {
   switch (action.type) {
     case "LOADED_LOCAL_LANGUAGES":
     case "FETCH_LANGUAGES_SUCCESS":
-      return Array.isArray(action.payload) ? action.payload : state;
+      if (!Array.isArray(action.payload)) {
+        console.warn(
+          "languages reducer: invalid payload (expected array, got",
+          typeof action.payload,
+          "), keeping previous state:",
+          action.payload
+        );
+        return state;
+      }
+      return action.payload;
     default:
       return state;
   }

--- a/src/shell/store/languages.js
+++ b/src/shell/store/languages.js
@@ -4,7 +4,7 @@ export function languages(state = [], action) {
   switch (action.type) {
     case "LOADED_LOCAL_LANGUAGES":
     case "FETCH_LANGUAGES_SUCCESS":
-      return action.payload;
+      return Array.isArray(action.payload) ? action.payload : state;
     default:
       return state;
   }


### PR DESCRIPTION
Fixes #3971

## Summary
- `src/shell/store/languages.js`: the `languages` reducer now validates `Array.isArray(action.payload)` for both `FETCH_LANGUAGES_SUCCESS` and `LOADED_LOCAL_LANGUAGES` before accepting the payload, falling back to the previous state otherwise. Previously it returned `action.payload` unchecked, so a malformed API response or a bad IndexedDB cache hydration could set `state.languages` to a non-array.
- `src/shell/hooks/useSearchBlocksByKeyword.ts`: added `Array.isArray(languages)` guards at the three call sites that used `languages` directly (`.find` for `defaultLanguage`, `.map` for `languageMap`, `.map` for `validLangIDs`), as defense-in-depth for users who already have a poisoned value cached locally.
- Root cause: Sentry reported `TypeError: d?.find is not a function` in `useSearchBlocksByKeyword`, 287 occurrences across 18 users since 2026-01-19. Once `state.languages` went non-array, `src/shell/store/middleware/local-storage.js` persisted that bad value back to IndexedDB, so affected users hit a crash-reload-crash loop until the cache was manually cleared. The reducer fix self-heals this: a stale non-array cached value is now rejected on next boot and the previous good state is kept instead.

## Test plan
- [x] `npx tsc --noEmit` run clean on both touched files
- [ ] Simulate a malformed `FETCH_LANGUAGES_SUCCESS` / `LOADED_LOCAL_LANGUAGES` payload (e.g. an object instead of an array) and confirm `state.languages` stays an array and the app no longer crashes
- [ ] Confirm normal language list loading/switching still works with a valid array payload
- [ ] Confirm a previously-poisoned IndexedDB `languages` cache entry no longer propagates into state on reload