### PR TITLE
Schema - Point model types doc link at the content model docs

### DIFF
--- a/src/apps/schema/src/app/components/CreateModelDialogue.tsx
+++ b/src/apps/schema/src/app/components/CreateModelDialogue.tsx
@@ -269,7 +269,14 @@ export const CreateModelDialogue = ({
                 </Typography>
                 <Box display="flex" alignItems="center" gap={1} mt={1}>
                   <MenuBookRoundedIcon color="info" />{" "}
-                  <Link variant="body2" href="#" underline="always">
+                  <Link
+                    data-cy="model-types-docs-link"
+                    variant="body2"
+                    href="https://docs.zesty.io/docs/creating-a-content-model#types-of-content-models"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    underline="always"
+                  >
                     Read our docs about different model types and their uses
                   </Link>
                 </Box>


### PR DESCRIPTION
Closes #4175

## Problem

The "Read our docs about different model types and their uses" link in the Create Model dialog was rendered with a placeholder `href="#"`, so clicking it went nowhere.

## Change

`src/apps/schema/src/app/components/CreateModelDialogue.tsx`

- Points the link at `https://docs.zesty.io/docs/creating-a-content-model#types-of-content-models`
- Opens in a new tab (`target="_blank"` + `rel="noopener noreferrer"`), matching the existing doc-link pattern in `ConnectToApi.tsx`
- Adds `data-cy="model-types-docs-link"` so the link is targetable in Cypress

## On the URL choice

The issue thread suggested `docs.zesty.io/docs/content-models-zesty`. I checked both pages: that one is a general overview of content modeling as a practice, while `creating-a-content-model` has an actual **Types of Content Models** section plus **Which Content Model Should I Choose?** — which is what the link text promises. The anchor `#types-of-content-models` was verified to exist on the page.

Neither doc page covers Block models, so that gap remains regardless of which URL we use — probably worth a separate docs ticket.

## Out of scope

Two other placeholder `href="#"` links exist and were left alone since I have no confirmed URLs for them:

- `StarterBlocks/StarterBlocksSelection.tsx:191` — "Learn Blocks basics with a tutorial"
- `FieldsListRight.tsx:325-337` — five doc links in the schema sidebar

## Testing

- `npx tsc --noEmit` — no new errors from this file (pre-existing errors elsewhere in the repo are unchanged)
- No dependency changes; no bundle impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)