### PR TITLE
Content - Hoist REQUIRED_FIELDS out of a useMemo in the meta editor

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Meta/index.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Meta/index.tsx
@@ -110,6 +110,9 @@ export const DYNAMIC_META_FIELD_NAMES = [
   "tc_image",
 ];
 
+// The web fields every content item must have a value for before it can be saved.
+const REQUIRED_FIELDS = ["metaTitle", "parentZUID", "pathPart"];
+
 type Errors = Record<string, Error>;
 type MetaProps = {
   isSaving: boolean;
@@ -180,12 +183,6 @@ export const Meta = forwardRef(
 
       return {};
     }, [fields]);
-
-    const REQUIRED_FIELDS = useMemo(() => {
-      const fields = ["metaTitle", "parentZUID", "pathPart"];
-
-      return fields;
-    }, [model]);
 
     const isHomepage = useMemo(() => {
       if (!homepageItem) return false;


### PR DESCRIPTION
## What

`REQUIRED_FIELDS` in the item meta editor was a `useMemo` returning a constant array:

```js
const REQUIRED_FIELDS = useMemo(() => {
  const fields = ["metaTitle", "parentZUID", "pathPart"];
  return fields;
}, [model]);
```

Three problems in six lines: the memo guards nothing (the array is a literal), the `[model]` dependency is never read inside it, and the inner `fields` binding shadows the outer `fields` used by another memo two declarations above.

Hoisted to a module-level constant. **No behaviour change** — the array contents and every use site are identical.

## Why it's its own PR

This was originally carried in #4228 (the negative-QA workflow) purely to give that agent a frontend surface to probe. It has nothing to do with CI, so it's split out to keep both diffs single-purpose.

## Worth knowing

While exercising this file, two pre-existing bugs were found on the code path this constant drives. Neither is touched or fixed here, and neither is a regression from this change — the `!value` check and every use site are unchanged — but both are real and currently untracked:

1. **Whitespace-only values pass required-field validation.** `MISSING_REQUIRED: !value` is falsy only for `""`/`null`/`undefined`, so a Meta Title of `"   "` passes, saves (`PUT` → 200) and persists across a reload.
2. **`Save & Publish` can publish from a blocked save.** `ItemEdit.js` throws on validation failure *before* `setSaving(true)` runs, so the effect in `ItemEditHeaderActions.tsx` — guarded by `!saving`, commented "if the item was successfully saved" — cannot distinguish "save finished" from "save never started". The publish confirmation modal opens over the validation error banner, and confirming it issues a real `POST .../publishings` → 201.

No Cypress spec covers either; `cypress/e2e/content/failures.spec.js:8` is a skipped `it.skip("Fails to save without filling all required fields")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)