### PR TITLE
CI - Pin Claude Change Verifier to Sonnet 5

### DIFF
--- a/.github/workflows/claude-change-verifier.yml
+++ b/.github/workflows/claude-change-verifier.yml
@@ -60,8 +60,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Pinned so the model can't drift with the action's default. Sonnet is enough for
-          # reading a diff against acceptance criteria; the deeper review runs in Auto Review.
           claude_args: |
             --model claude-sonnet-5
             --max-turns 50

--- a/.github/workflows/claude-change-verifier.yml
+++ b/.github/workflows/claude-change-verifier.yml
@@ -60,7 +60,10 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Pinned so the model can't drift with the action's default. Sonnet is enough for
+          # reading a diff against acceptance criteria; the deeper review runs in Auto Review.
           claude_args: |
+            --model claude-sonnet-5
             --max-turns 50
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Read,Write,Grep,Glob"
           prompt: |


### PR DESCRIPTION
## What

Pins `claude-change-verifier.yml` to `--model claude-sonnet-5` in `claude_args`.

## Why

The change verifier had no `--model` at all, so it ran on whatever `anthropics/claude-code-action` defaults to opus model