### PR TITLE
Cypress - Cut integration field spec runtime

### DIFF
--- a/cypress/e2e/schema/integration.spec.js
+++ b/cypress/e2e/schema/integration.spec.js
@@ -121,9 +121,7 @@ describe("Integration Field", () => {
       });
 
       it("Add HTTP Headers", () => {
-        cy.getBySelector("addHeaderButton").click();
-        cy.getBySelector("addHeaderButton").click();
-        cy.getBySelector("addHeaderButton").click();
+        Cypress._.times(3, () => cy.getBySelector("addHeaderButton").click());
 
         cy.getBySelector("integrationHeadersContainer")
           .children()
@@ -131,19 +129,13 @@ describe("Integration Field", () => {
       });
 
       it("Remove HTTP Headers", () => {
-        cy.getBySelector("addHeaderButton").click();
-        cy.getBySelector("addHeaderButton").click();
-        cy.getBySelector("addHeaderButton").click();
+        Cypress._.times(3, () => cy.getBySelector("addHeaderButton").click());
 
-        cy.getBySelector("integrationHeadersContainerRow-3")
-          .find('[data-cy="removeHeaderButton"]')
-          .click();
-        cy.getBySelector("integrationHeadersContainerRow-2")
-          .find('[data-cy="removeHeaderButton"]')
-          .click();
-        cy.getBySelector("integrationHeadersContainerRow-1")
-          .find('[data-cy="removeHeaderButton"]')
-          .click();
+        [3, 2, 1].forEach((row) => {
+          cy.getBySelector(`integrationHeadersContainerRow-${row}`)
+            .find('[data-cy="removeHeaderButton"]')
+            .click();
+        });
 
         cy.getBySelector("integrationHeadersContainer")
           .children()
@@ -220,26 +212,13 @@ describe("Integration Field", () => {
       // close any JSON viewer left open by a prior test
       cy.get("body").then(($b) => {
         if ($b.find('[data-cy="jsonCodeViewerCloseButton"]').length) {
-          cy.get('[data-cy="jsonCodeViewerCloseButton"]').click({
-            force: true,
-          });
+          cy.getBySelector("jsonCodeViewerCloseButton").click(forceClick);
         }
       });
     });
+
     it("Create Content Item", () => {
-      const modelZUID = Cypress.env("modelZUID");
-      cy.intercept("**/get-url?url=*", {
-        statusCode: 200,
-        body: genericApi,
-      }).as("reconfigureGetUrl");
-
-      cy.visit(`/content/${modelZUID}/new`);
-      cy.getBySelector("field:title").find("input").type(MODEL?.label);
-
-      cy.getBySelector("field:players")
-        .find('[data-cy="integrationSelectItemsButton"]')
-        .click();
-      cy.getBySelector("integrationSelectionFormDialog").should("exist");
+      createContentItemAndOpenSelector(Cypress.env("modelZUID"), MODEL?.label);
     });
 
     it("Search Filter with - results", () => {
@@ -368,23 +347,13 @@ describe("Integration Field", () => {
   });
 
   describe("Search Filter with Non-string KeyPath", () => {
-    it("Does not crash when a configured keyPath resolves to a number", () => {
-      const modelZUID = Cypress.env("modelZUID");
-      cy.intercept("**/get-url?url=*", {
-        statusCode: 200,
-        body: genericApi,
-      }).as("reconfigureGetUrl");
-
+    beforeEach(() => {
       // Deterministic external data (live endpoint drifts from genericApi).
       cy.intercept("POST", "**/get-url*", { body: genericApi });
+    });
 
-      cy.visit(`/content/${modelZUID}/new`);
-      cy.getBySelector("field:title").find("input").type(MODEL?.label);
-
-      cy.getBySelector("field:players")
-        .find('[data-cy="integrationSelectItemsButton"]')
-        .click();
-      cy.getBySelector("integrationSelectionFormDialog").should("exist");
+    it("Does not crash when a configured keyPath resolves to a number", () => {
+      createContentItemAndOpenSelector(Cypress.env("modelZUID"), MODEL?.label);
 
       cy.getBySelector("integrationSelectionFormSearchBox")
         .find("input")
@@ -413,6 +382,19 @@ describe("Integration Field", () => {
         }
       );
     });
+
+    function openSharedContentSelector(apiData = genericApi) {
+      cy.intercept("**/get-url?url=*", {
+        statusCode: 200,
+        body: apiData,
+      }).as("getUrl");
+
+      cy.visit(`/content/${SHARED_MODEL?.ZUID}/${SHARED_CONTENT?.meta?.ZUID}`);
+
+      cy.getBySelector("field:players")
+        .find('[data-cy="integrationSelectItemsButton"]')
+        .click();
+    }
 
     describe("maxValue Lockout", () => {
       it("Disables unselected checkboxes once the maxValue limit is reached", () => {
@@ -448,18 +430,7 @@ describe("Integration Field", () => {
 
     describe("Resync", () => {
       it("shows resync button on a selected item when remote data has changed", () => {
-        cy.intercept("**/get-url?url=*", {
-          statusCode: 200,
-          body: genericApi,
-        }).as("getUrl");
-
-        cy.visit(
-          `/content/${SHARED_MODEL?.ZUID}/${SHARED_CONTENT?.meta?.ZUID}`
-        );
-
-        cy.getBySelector("field:players")
-          .find('[data-cy="integrationSelectItemsButton"]')
-          .click();
+        openSharedContentSelector();
 
         cy.getBySelector("integrationSelectCard")
           .eq(0)
@@ -488,18 +459,7 @@ describe("Integration Field", () => {
       });
 
       it("does not show resync button when remote data matches saved data", () => {
-        cy.intercept("**/get-url?url=*", {
-          statusCode: 200,
-          body: genericApi,
-        }).as("getUrl");
-
-        cy.visit(
-          `/content/${SHARED_MODEL?.ZUID}/${SHARED_CONTENT?.meta?.ZUID}`
-        );
-
-        cy.getBySelector("field:players")
-          .find('[data-cy="integrationSelectItemsButton"]')
-          .click();
+        openSharedContentSelector();
 
         cy.getBySelector("integrationSelectionFormDialog").should("exist");
 
@@ -512,17 +472,7 @@ describe("Integration Field", () => {
       });
 
       it("clicking resync updates the displayed item in the selected list", () => {
-        cy.intercept("**/get-url?url=*", {
-          statusCode: 200,
-          body: genericApi,
-        }).as("getUrl");
-        cy.visit(
-          `/content/${SHARED_MODEL?.ZUID}/${SHARED_CONTENT?.meta?.ZUID}`
-        );
-
-        cy.getBySelector("field:players")
-          .find('[data-cy="integrationSelectItemsButton"]')
-          .click();
+        openSharedContentSelector();
 
         cy.getBySelector("integrationSelectionFormDialog").should("exist");
 
@@ -540,6 +490,8 @@ describe("Integration Field", () => {
         cy.getBySelector("field:players")
           .find('[data-cy="integrationSelectItemsButton"]')
           .click();
+
+        cy.getBySelector("integrationSelectionFormDialog").should("exist");
 
         cy.getBySelector("integrationSelectCard")
           .eq(0)
@@ -563,17 +515,29 @@ describe("Integration Field", () => {
   });
 
   describe("Reconfigure Display Options", () => {
-    it("Persists keyPath changes when updating an integration field", () => {
+    function openFieldForReconfigure({
+      apiData = genericApi,
+      selector = "Field_text",
+      matchByText = false,
+    } = {}) {
       cy.intercept("**/get-url?url=*", {
         statusCode: 200,
-        body: genericApi,
+        body: apiData,
       }).as("reconfigureGetUrl");
 
       cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
 
-      cy.getBySelector("Field_text").click();
+      if (matchByText) {
+        cy.contains('[data-cy^="Field_"]', selector).click();
+      } else {
+        cy.getBySelector(selector).click();
+      }
 
       cy.wait("@reconfigureGetUrl");
+    }
+
+    it("Persists keyPath changes when updating an integration field", () => {
+      openFieldForReconfigure();
 
       cy.intercept("PUT", "**/content/models/*/fields/*").as("updateField");
 
@@ -606,70 +570,53 @@ describe("Integration Field", () => {
     });
 
     it("Cancelling mid-reconfigure leaves the displayed type unchanged", () => {
-      cy.intercept("**/get-url?url=*", {
-        statusCode: 200,
-        body: genericApi,
-      }).as("reconfigureGetUrl");
+      openFieldForReconfigure();
 
-      cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
-      cy.get('[data-cy="Field_text"]').click();
-      cy.wait("@reconfigureGetUrl");
-
-      cy.get('[data-cy="integrationDisplayType"] input')
+      cy.getBySelector("integrationDisplayType")
+        .find("input")
         .invoke("val")
         .as("originalType");
 
-      cy.get('[data-cy="integrationConfigureButton"]').click();
-      cy.get('[data-cy="integrationFormDialog"]').should("exist");
+      cy.getBySelector("integrationConfigureButton").click();
+      cy.getBySelector("integrationFormDialog").should("exist");
 
-      cy.get('[data-cy="integrationDisplayOption-simple"]').click(forceClick);
+      cy.getBySelector("integrationDisplayOption-simple").click(forceClick);
       cy.contains("button", "Cancel").click();
-      cy.get('[data-cy="integrationFormDialog"]').should("not.exist");
+      cy.getBySelector("integrationFormDialog").should("not.exist");
 
       cy.get("@originalType").then((originalType) => {
-        cy.get('[data-cy="integrationDisplayType"] input').should(
-          "have.value",
-          originalType
-        );
+        cy.getBySelector("integrationDisplayType")
+          .find("input")
+          .should("have.value", originalType);
       });
     });
 
     it("Updates the displayed type after a successful reconfigure", () => {
-      cy.intercept("**/get-url?url=*", {
-        statusCode: 200,
-        body: genericApi,
-      }).as("reconfigureGetUrl");
-
-      cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
-      cy.get('[data-cy="Field_text"]').click();
-      cy.wait("@reconfigureGetUrl");
+      openFieldForReconfigure();
 
       cy.intercept("PUT", "**/content/models/*/fields/*").as("updateField");
 
-      cy.get('[data-cy="integrationConfigureButton"]').click();
-      cy.get('[data-cy="integrationFormDialog"]').should("exist");
+      cy.getBySelector("integrationConfigureButton").click();
+      cy.getBySelector("integrationFormDialog").should("exist");
 
-      cy.get('[data-cy="integrationDisplayOption-simple"]').click(forceClick);
-      cy.get('[data-cy="integrationConfigureOptionNextButton"]').click();
+      cy.getBySelector("integrationDisplayOption-simple").click(forceClick);
+      cy.getBySelector("integrationConfigureOptionNextButton").click();
 
-      cy.get('[data-cy="integrationKeyPathSelector-itemId"]').click();
+      cy.getBySelector("integrationKeyPathSelector-itemId").click();
       cy.get(`.MuiAutocomplete-listbox li:contains("playerId")`).click(
         forceClick
       );
 
-      cy.get('[data-cy="integrationKeyPathSelector-heading"]').click();
+      cy.getBySelector("integrationKeyPathSelector-heading").click();
       cy.get(`.MuiAutocomplete-listbox li:contains("name")`).click(forceClick);
 
-      cy.get(
-        '[data-cy="integrationConfigureDisplayOptionsDoneButton"]'
-      ).click();
+      cy.getBySelector("integrationConfigureDisplayOptionsDoneButton").click();
 
-      cy.get('[data-cy="integrationDisplayType"] input').should(
-        "have.value",
-        "simple"
-      );
+      cy.getBySelector("integrationDisplayType")
+        .find("input")
+        .should("have.value", "simple");
 
-      cy.get('[data-cy="FieldFormAddFieldBtn"]').click();
+      cy.getBySelector("FieldFormAddFieldBtn").click();
       cy.wait("@updateField").then(({ request }) => {
         expect(request.body.settings.integrationFieldConfig.type).to.equal(
           "simple"
@@ -681,14 +628,7 @@ describe("Integration Field", () => {
       const NEW_ENDPOINT =
         "https://8xbq19z1-dev.preview.stage.zesty.io/api/generic-v2.json";
 
-      cy.intercept("**/get-url?url=*", {
-        statusCode: 200,
-        body: genericApi,
-      }).as("reconfigureGetUrl");
-
-      cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
-      cy.getBySelector("Field_text").click();
-      cy.wait("@reconfigureGetUrl");
+      openFieldForReconfigure();
 
       cy.intercept("PUT", "**/content/models/*/fields/*").as("updateField");
 
@@ -729,14 +669,7 @@ describe("Integration Field", () => {
     });
 
     it("Edit API URL opens the Connect to API step; Edit Display Options still opens the Display Type step", () => {
-      cy.intercept("**/get-url?url=*", {
-        statusCode: 200,
-        body: genericApi,
-      }).as("reconfigureGetUrl");
-
-      cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
-      cy.getBySelector("Field_text").click();
-      cy.wait("@reconfigureGetUrl");
+      openFieldForReconfigure();
 
       // "Edit Display Options" preserves the original behavior — opens directly
       // at the Display Type step.
@@ -778,14 +711,11 @@ describe("Integration Field", () => {
       cy.getBySelector("FieldFormAddFieldBtn").click();
       cy.wait("@getModelFields");
 
-      cy.intercept("**/get-url?url=*", {
-        statusCode: 200,
-        body: specialApi,
-      }).as("initialGetUrl");
-
-      cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
-      cy.contains('[data-cy^="Field_"]', fieldLabel).click();
-      cy.wait("@initialGetUrl");
+      openFieldForReconfigure({
+        apiData: specialApi,
+        selector: fieldLabel,
+        matchByText: true,
+      });
 
       cy.getBySelector("integrationEditApiUrlButton").click();
       cy.getBySelector("integrationFormDialog").should("exist");
@@ -820,14 +750,7 @@ describe("Integration Field", () => {
       // Generic display types (simple/text/image/video/details) store an
       // empty rootPath — the response array itself is the root. This
       // specifically pins the fix for the case that was previously skipped.
-      cy.intercept("**/get-url?url=*", {
-        statusCode: 200,
-        body: genericApi,
-      }).as("reconfigureGetUrl");
-
-      cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
-      cy.getBySelector("Field_text").click();
-      cy.wait("@reconfigureGetUrl");
+      openFieldForReconfigure();
 
       cy.getBySelector("integrationEditApiUrlButton").click();
       cy.getBySelector("integrationFormDialog").should("exist");
@@ -1048,4 +971,16 @@ function addGenericField(type) {
   cy.getBySelector("integrationDisplayType")
     .find("input")
     .should("have.value", type);
+}
+
+function createContentItemAndOpenSelector(modelZUID, label) {
+  cy.intercept("**/get-url?url=*", { statusCode: 200, body: genericApi });
+
+  cy.visit(`/content/${modelZUID}/new`);
+  cy.getBySelector("field:title").find("input").type(label);
+
+  cy.getBySelector("field:players")
+    .find('[data-cy="integrationSelectItemsButton"]')
+    .click();
+  cy.getBySelector("integrationSelectionFormDialog").should("exist");
 }

--- a/cypress/e2e/schema/integration.spec.js
+++ b/cypress/e2e/schema/integration.spec.js
@@ -55,12 +55,33 @@ describe("Integration Field", () => {
 
   describe("Add Field", () => {
     context("Generic Display Types", () => {
-      genericTypes.forEach((valueType) => {
+      // One visit for the whole block: each iteration re-opens the Add
+      // Field dialog (via AddFieldBtn) rather than reloading the page.
+      before(() => {
+        cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
+      });
+
+      // Hit the real endpoint exactly once so this suite still exercises a
+      // genuine end-to-end connection; every remaining display type replays
+      // that captured response instead of paying for another live request.
+      let liveGenericApiResponse = null;
+
+      genericTypes.forEach((valueType, index) => {
         it(`${valueType}`.toUpperCase(), () => {
-          connectToEndpoint(FIELD_DATA.endpoint, valueType, genericApi);
+          if (index === 0) {
+            connectToEndpoint(FIELD_DATA.endpoint, null, {
+              visit: false,
+              onResponse: (body) => {
+                liveGenericApiResponse = body;
+              },
+            });
+          } else {
+            connectToEndpoint(FIELD_DATA.endpoint, liveGenericApiResponse, {
+              visit: false,
+            });
+          }
           addGenericField(valueType);
-        });
-        it(`Submit Generic Type Field- ${valueType})`, () => {
+
           cy.intercept(`**/v1/content/models/**`).as("getModelFields");
 
           cy.getBySelector("FieldFormInput_label")
@@ -81,12 +102,17 @@ describe("Integration Field", () => {
     });
 
     context("Special Display Types", () => {
+      before(() => {
+        cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
+      });
+
       specialTypes.forEach((valueType) => {
         it(`${valueType}`.toUpperCase(), () => {
-          connectToEndpoint(ENDPOINTS[valueType], valueType, specialApi);
+          connectToEndpoint(ENDPOINTS[valueType], specialApi, {
+            visit: false,
+          });
           addSpecialField(valueType);
-        });
-        it(`Submit Special Type Field - ${valueType})`, () => {
+
           cy.intercept(`**/v1/content/models/**`).as("getModelFields");
 
           cy.getBySelector("FieldFormInput_label")
@@ -108,7 +134,7 @@ describe("Integration Field", () => {
     });
 
     context("HTTP Headers", () => {
-      beforeEach(() => {
+      before(() => {
         cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
         cy.getBySelector("AddFieldBtn").click();
         cy.getBySelector("FieldItem_integration").click();
@@ -120,16 +146,12 @@ describe("Integration Field", () => {
           .type(ENDPOINTS.generic);
       });
 
-      it("Add HTTP Headers", () => {
+      it("Adds and removes HTTP Headers", () => {
         Cypress._.times(3, () => cy.getBySelector("addHeaderButton").click());
 
         cy.getBySelector("integrationHeadersContainer")
           .children()
           .should("have.length", 4);
-      });
-
-      it("Remove HTTP Headers", () => {
-        Cypress._.times(3, () => cy.getBySelector("addHeaderButton").click());
 
         [3, 2, 1].forEach((row) => {
           cy.getBySelector(`integrationHeadersContainerRow-${row}`)
@@ -160,17 +182,23 @@ describe("Integration Field", () => {
         },
       ];
 
+      // One visit for the whole block: the "keep user on Connect step"
+      // assertion below means each iteration already leaves the dialog on
+      // the endpoint-input step, ready for the next shape without reloading.
+      before(() => {
+        cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
+        cy.getBySelector("AddFieldBtn").click();
+        cy.getBySelector("FieldItem_integration").click();
+        cy.getBySelector("integrationConfigureButton").click();
+        cy.getBySelector("integrationFormDialog").should("exist");
+      });
+
       invalidShapes.forEach(({ name, body }) => {
         it(`blocks advancing and shows an error for: ${name}`, () => {
           cy.intercept("**/get-url?url=*", { statusCode: 200, body }).as(
             "getUrl"
           );
 
-          cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
-          cy.getBySelector("AddFieldBtn").click();
-          cy.getBySelector("FieldItem_integration").click();
-          cy.getBySelector("integrationConfigureButton").click();
-          cy.getBySelector("integrationFormDialog").should("exist");
           cy.getBySelector("integrationEndpointInput")
             .find("input")
             .clear()
@@ -699,7 +727,7 @@ describe("Integration Field", () => {
       // the field's `name` is not guaranteed to match the typed label/type.
       const fieldLabel = "reconfigure shopify test field";
 
-      connectToEndpoint(ENDPOINTS.shopify, "shopify", specialApi);
+      connectToEndpoint(ENDPOINTS.shopify, specialApi);
       addSpecialField("shopify");
 
       cy.intercept(`**/v1/content/models/**`).as("getModelFields");
@@ -843,16 +871,26 @@ describe("Integration Field", () => {
   });
 });
 
-function connectToEndpoint(endpoint, type, apiData) {
-  // Mock data for special display types since we don't have endpoints for these types:
-  if (specialTypes.includes(type)) {
-    cy.intercept("/get-url?url=*", {
+function connectToEndpoint(
+  endpoint,
+  apiData,
+  { visit = true, onResponse } = {}
+) {
+  // Mock the API response so most calls are deterministic and don't pay for
+  // a real network round trip. Pass apiData=null to let this one request hit
+  // the real endpoint instead (paired with onResponse to capture it).
+  if (apiData) {
+    cy.intercept("**/get-url?url=*", {
       statusCode: 200,
       body: apiData,
-    });
+    }).as("getUrl");
+  } else {
+    cy.intercept("**/get-url?url=*").as("getUrl");
   }
 
-  cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
+  if (visit) {
+    cy.visit(`/schema/${Cypress.env("modelZUID")}/fields`);
+  }
 
   cy.getBySelector("AddFieldBtn").click();
 
@@ -865,11 +903,11 @@ function connectToEndpoint(endpoint, type, apiData) {
     .clear()
     .type(endpoint);
 
-  cy.intercept("**/get-url?url=*").as("getUrl");
-
   cy.getBySelector("integrationConnectButton").click();
 
-  cy.wait("@getUrl");
+  cy.wait("@getUrl").then((interception) => {
+    onResponse?.(interception.response?.body);
+  });
 
   cy.getBySelector("integrationConnectionStatusContainer").should("exist");
 


### PR DESCRIPTION
## Summary

`cypress/e2e/schema/integration.spec.js` was slower than it needed to be: most of its ~30 tests each did a full `cy.visit()` (a full SPA reload), and the five generic-type "Add Field" tests each hit a real live staging endpoint instead of a fixture. Neither was needed to keep the coverage genuine.

- **Fewer full-page reloads.** In the "Add Field" section, "Generic Display Types" and "Special Display Types" each now visit the fields page once per context and reopen the Add Field dialog per iteration (`AddFieldBtn`) instead of reloading; their per-type "create" and "submit" tests are merged into one. "Invalid Response Shape" reuses the dialog's own documented behavior of returning to the Connect step after an error, so all 7 shape checks share one visit instead of one each. "HTTP Headers" collapses its two tests (sharing a `beforeEach` visit) into one test with a single `before` visit.
- **One real network call instead of five.** The generic-type endpoint (`8xbq19z1-dev.preview.stage.zesty.io`) is now hit for real exactly once (the first generic-type test), and that captured response is replayed for the remaining four generic-type tests — still a genuine end-to-end connection, without four redundant live round trips per run. `KEY_PATHS.generic` stays hardcoded to the fixture's expected shape by design: if the live endpoint's shape ever drifts, these tests fail loudly and immediately rather than silently passing on stale assumptions.
- **Not touched:** the "Resync" and "Reconfigure Display Options" blocks still do a fresh visit per test. Both chain real PUT calls that mutate live dev-instance state between steps, and collapsing them the same way needs to be verified against the live instance to confirm the UI reflects those mutations without a reload — left as a follow-up rather than risking new flakiness.

## Test runtime summary

Measured by actually running `./node_modules/.bin/cypress run --spec "cypress/e2e/schema/integration.spec.js"` against the dev instance, before and after this change:

| | Before | After | Change |
|---|---|---|---|
| Duration | 8m 18.571s | **3m 52s** | **−53.4%** (−4m 26s) |
| Tests | 50 | 40 | −10 (create+submit pairs, headers, and invalid-shape structure merged; same assertions, fewer test boundaries) |
| Passing | 50 | 40 | 0 failures in either run |

Within just the sections touched (Add Field: Generic/Special Display Types, HTTP Headers, Invalid Response Shape): full page visits/reloads went from 18 to 4, and real external network calls from 5 to 1.

The slowest single test post-change is the first generic-type test (`SIMPLE`, ~14.4s) — the one real live-endpoint connection everything else in that block replays. Every other generic/special-type test dropped to the 3s range. The largest remaining chunk of runtime is now the untouched Resync/Reconfigure Display Options blocks (one test spikes to ~15.6s) — a candidate for further optimization in a follow-up if needed.

## Test plan

- [x] Ran `cypress/e2e/schema/integration.spec.js` against the dev instance — 40/40 passing, 0 failures
- [x] Confirmed the generic-type "Add Field" tests correctly assert field creation for all 5 display types (simple/text/image/video/details) sharing one captured live response
- [x] Confirmed "Invalid Response Shape" correctly blocks advancing for all 7 malformed shapes when run back-to-back without a reload between them
- [x] Confirmed total spec runtime vs. the `dev` branch baseline (8m 18.571s → 3m 52s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
