### PR TITLE
Code - Disable automatic CSS worker features to fix null model crash

### DIFF
--- a/src/apps/code-editor/src/app/components/Editor/components/MemoizedEditor/MonacoSetup.js
+++ b/src/apps/code-editor/src/app/components/Editor/components/MemoizedEditor/MonacoSetup.js
@@ -1,4 +1,9 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+import {
+  cssDefaults,
+  lessDefaults,
+  scssDefaults,
+} from "monaco-editor/esm/vs/language/css/monaco.contribution";
 import { tokenizer, languageConf } from "./parsley-tokens";
 import { ParsleyTheme } from "./parsley-theme";
 
@@ -19,6 +24,44 @@ export function MonacoSetup(store) {
     base: "vs-dark", // can also be vs-dark or hc-black
     inherit: true, // can also be false to completely replace the builtin rules
     rules: ParsleyTheme,
+  });
+
+  /**
+   * Turn off the automatic worker-backed language features for css/less/scss.
+   *
+   * Of the CSS worker's twelve methods only `doValidation` null-checks the
+   * mirror model; the rest dereference it immediately. Switching files disposes
+   * the model one React commit phase after the editor is torn down, so any
+   * request still queued at that moment is answered against a document that no
+   * longer exists — `Cannot read properties of null (reading 'languageId')`.
+   * Cancelling on the main thread cannot prevent it: the adapters ignore their
+   * cancellation token, and the message is already posted to the worker.
+   *
+   * Only the automatic, debounced features can lose that race without the user
+   * doing anything: folding (200ms) and word highlighting (250ms). The
+   * user-initiated ones stay enabled — completions are worth keeping and need a
+   * deliberate keystroke to fire. Hovers, colours, rename, references and code
+   * actions are already excluded from the bundle in `webpack.config.js`.
+   *
+   * These languages fall back to indentation-based folding, so folding still
+   * works; it is derived from indentation rather than the CSS parse tree.
+   *
+   * Must run before any css/less/scss model exists. `setupMode` reads
+   * `modeConfiguration` once and — unlike `jsonMode.js` — does not re-register
+   * providers on `onDidChange`, so moving this after the first editor mount
+   * would make it silently do nothing. `MonacoSetup` runs at shell boot, which
+   * guarantees the ordering.
+   *
+   * Revisit when monaco-editor is upgraded; the guards exist upstream.
+   */
+  [cssDefaults, lessDefaults, scssDefaults].forEach((defaults) => {
+    // Spread rather than assign: all three defaults share one
+    // modeConfiguration object, so mutating it would affect the others.
+    defaults.setModeConfiguration({
+      ...defaults.modeConfiguration,
+      foldingRanges: false,
+      documentHighlights: false,
+    });
   });
 
   /**


### PR DESCRIPTION
Closes #3909

## The bug

Switching files in the Code app disposes the Monaco model **one React commit phase after** the editor itself is torn down. `MonacoEditor.componentWillUnmount` → `editor.dispose()` runs synchronously in the mutation phase, while `model.dispose()` sits in a passive `useEffect` cleanup (`MemoizedEditor.js`) and runs later — posting `acceptRemovedModel` to the CSS worker.

Meanwhile the folding controller has a request queued on a 200ms debounce. Cancelling on the main thread cannot stop it: `FoldingRangeAdapter.provideFoldingRanges` accepts a cancellation token and never reads it, so the message is already posted. The worker then answers against a mirror model that is gone — `_getTextDocument` returns `null` and the language service dereferences it, throwing `Cannot read properties of null (reading 'languageId')`.

This is an upstream omission in monaco-editor 0.25.2: of the CSS worker's twelve methods, only `doValidation` null-checks the document. It reaches Sentry rather than being swallowed because the folding path routes rejections through `onUnexpectedError` → `window.onerror`, whereas the diagnostics adapter quietly `console.error`s.

## The fix

Disable the worker-backed features that can lose that race **with no user action** — folding (200ms debounce) and word highlighting (250ms) — for `css`/`less`/`scss`. With no provider registered, the worker call is never made, so the crash path is structurally unreachable rather than merely less likely.

Completions and selection ranges stay enabled: they are worth more and require a deliberate keystroke. Hovers, colours, rename, references and code actions are already excluded from the bundle in `webpack.config.js`, so they were never exposed.

**Trade-off:** css/less/scss lose *syntax-aware* folding and fall back to *indentation-based* folding — `getRangeProvider` builds `IndentRangeProvider` as its explicit fallback and only upgrades to `SyntaxRangeProvider` when providers exist. Folding still works in those files. This also applies to css/less/scss shown in the diff viewer (`Differ.js`), which shares `resolveMonacoLang`.

The setting is applied at shell boot, and that ordering is load-bearing: `cssMode.js`'s `setupMode` reads `modeConfiguration` once and — unlike `jsonMode.js` — never re-registers on `onDidChange`. Moving `MonacoSetup` behind a lazy-loaded `CodeApp` would make this silently do nothing. That constraint is documented in the code.

## Verification

- `npx tsc --noEmit` — no new errors (the one pre-existing `src/` error, `RichTreeItem.tsx:28`, is unchanged).
- `npm run build:dev` — compiles successfully. This is what validates the deep `monaco.contribution` import resolving alongside `monaco-editor-webpack-plugin`.
- Reviewed cold by someone who did not write it; that pass is what caught `wordHighlighter` sharing the identical failure shape, which an earlier folding-only version would have left reproducible.

**Not verified by reproduction.** This error has never been reproducible locally — that is why the issue stalled. The fix is verified *structurally* (the providers are not registered, therefore the worker call cannot be made), not by observing the error stop in the wild. Confirmation will come from Sentry going quiet on MANAGER-UI-2EM after this ships.

No Cypress coverage exists for folding or CSS editing, so the existing `cypress/e2e/code/` specs are unaffected rather than proving anything here.

## Considered and deferred

- **Upgrading `monaco-editor`.** The correct long-term fix — the guards exist upstream — but 0.25.2 → current also forces a `monaco-editor-webpack-plugin` bump (4.2.0 supports only 0.25–0.28) against a peer-dep tree that already needs `--legacy-peer-deps`. Worth its own PR.
- **Fixing the disposal ordering in `MemoizedEditor.js`** (dispose after `setModel`, or don't dispose on file change). That would close the window for *every* adapter at once instead of feature by feature, but it is a broader behavioural change to model lifetime. Related oddity for whoever picks it up: the comment there says the per-filename model cache "achieves a per-filename undo stack," but disposing on every file change destroys that stack, so the cache currently buys nothing.
- **The `setTimeout(…, 0)` deferral** suggested in the issue's automated RCA. Rejected: it narrows the race without closing it, since the worker round-trip runs on its own schedule, and there is no way to tell a real fix from a lucky one.