### PR TITLE
CI - Raise the auto-reviewer turn and time budget

### DIFF
--- a/.github/workflows/claude-auto-reviewer.yml
+++ b/.github/workflows/claude-auto-reviewer.yml
@@ -15,7 +15,7 @@ jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     concurrency:
       group: claude-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -80,7 +80,7 @@ jobs:
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Write,Grep,Glob"
             --model claude-sonnet-4-6
-            --max-turns 50
+            --max-turns 100
 
       # Always post a NEW verdict comment (never update in place): each push's verdict lands in
       # the PR timeline between the commits it reviewed, preserving the review history.


### PR DESCRIPTION
Raises the auto-reviewer's budget so it stops dying before it can post a review.

## What happened

The auto-review of #4275 (+965/−189 across 15 files) failed with **`Reached maximum number of turns (50)`** after **12m56s**, and posted `No buffered inline comments`. That PR has had no bot review since.

Worth separating from the failure mode we already knew about: this was **not** the 15-minute timeout — the run finished under it. It exhausted `--max-turns` first.

## The change

- `--max-turns` 50 → 100
- `timeout-minutes` 15 → 30

**Both have to move together.** 50 turns took 12m56s — roughly 15.5s per turn — so 100 turns would run past the 15-minute wall and fail the same way with a different message. Raising turns alone would look like a fix and not be one.

`timeout-minutes: 30` is sized from that single measurement, not from a distribution. A review that spends its turns on `Read` rather than `Bash(gh pr diff)` will be faster. Worth revisiting once a few large reviews have run under it rather than treating 30 as derived.

## What this does not fix

This raises the ceiling; it does not address the cause. The auto-reviewer has completed on every normally-sized PR — #4271, #4268, and the first two pushes of #4275. What exhausted it was a diff carrying three phases of a feature in one PR.

If large PRs stay the exception, the old limits were arguably a useful signal that a diff had grown too big to review, and this trades that signal for a slower gate on every PR. Landing it because the immediate cost — a permission-boundary change shipping with no bot review — is worse than the slower gate.

<!-- zesty-eng-team -->