### PR TITLE
Manager UI - Collapse the second editor black onto background.editor

### DIFF
--- a/src/apps/code-editor/src/app/components/BottomDrawer/FileCard.tsx
+++ b/src/apps/code-editor/src/app/components/BottomDrawer/FileCard.tsx
@@ -30,8 +30,7 @@ const FileCard: React.FC<FileCardProps> = ({
     <Card
       sx={{
         boxSizing: "border-box",
-        // Temporary: will be updated once the design is final
-        bgcolor: "#0D1116",
+        bgcolor: "background.editor",
         color: "grey.400",
         width: "100%",
         px: 2,

--- a/src/apps/code-editor/src/app/components/RecentFiles/index.tsx
+++ b/src/apps/code-editor/src/app/components/RecentFiles/index.tsx
@@ -80,7 +80,7 @@ export const RecentFiles = ({ openCreateFileDialog }: RecentFilesProps) => {
       <Box
         width="100%"
         height="calc(100% - 84px)"
-        bgcolor="#0D1116"
+        bgcolor="background.editor"
         color="grey.300"
         display="flex"
         flexDirection="row"


### PR DESCRIPTION
Two code-editor surfaces described the editor background as the literal `#0D1116` while `src/shell/index.js:87` declares `background.editor` as `#0F0F0F` and eight other call sites consume it.

- `BottomDrawer/FileCard.tsx:34` — carried `// Temporary: will be updated once the design is final`
- `RecentFiles/index.tsx:83` — sits inside a parent `Box` two elements up that already uses the token

Both now consume `background.editor`. `docs/design-system.md` §3 (#4283) is the rule: *being the odd one out is not drift — the question is whether the design system claims to own the value.* It owns the editor background.

**This is a rendered-value change, which is why it is not part of #4284.** `#0D1116` → `#0F0F0F` is a shift of 2/2/7 out of 255 on a near-black, on two panels already sitting on token-painted backgrounds. #4264's acceptance criteria require every substitution to be value-identical, so this one does not belong in that sweep even though it came out of the same audit. Split out on that basis.

Requested by @agalin920 after the audit surfaced the two disagreeing values.

`tsc --noEmit` at baseline: 20 errors, 0 in `src/`.

<!-- zesty-eng-team -->
