### PR TITLE
CI - Add sentry to allowed_bots list

### DIFF
--- a/.github/workflows/claude-sentry-handler.yml
+++ b/.github/workflows/claude-sentry-handler.yml
@@ -125,6 +125,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "sentry"
           claude_args: |
             --model claude-sonnet-5
             --max-turns 80


### PR DESCRIPTION
Add "sentry" to the allowed_bots list in the Claude: Sentry Handler workflow so the pipeline runs for tickets created by the sentry bot.
Failing run this addresses: https://github.com/zesty-io/manager-ui/actions/runs/32907601399