### PR TITLE
SEO - Fix crash when pressing ArrowLeft in the redirects target search field

### DIFF
--- a/cypress/e2e/seo/redirects/redirects.spec.js
+++ b/cypress/e2e/seo/redirects/redirects.spec.js
@@ -166,9 +166,7 @@ describe("Redirects", () => {
       cy.getElement('[data-cy="RedirectsSearchFieldInput"] input')
         .should("exist")
         .then(() => {
-          if (uncaughtError) {
-            expect(uncaughtError.message).to.not.contain("focus");
-          }
+          expect(uncaughtError, "no uncaught exception").to.be.null;
         });
 
       cy.getBySelector("RedirectsFormCancelButton").click();

--- a/cypress/e2e/seo/redirects/redirects.spec.js
+++ b/cypress/e2e/seo/redirects/redirects.spec.js
@@ -128,6 +128,52 @@ describe("Redirects", () => {
         { matchCase: false }
       );
     });
+    it("Selecting a target and pressing ArrowLeft does not crash (regression for #4247)", () => {
+      // The support file's global `uncaught:exception` handler always
+      // returns false, so an in-app crash wouldn't otherwise fail this test.
+      // Capture the error explicitly instead.
+      let uncaughtError = null;
+      cy.on("uncaught:exception", (err) => {
+        uncaughtError = err;
+        return false;
+      });
+
+      cy.getElement('[data-cy="RedirectActionCreateButton"]').click();
+
+      cy.getElement('[data-cy="RedirectsFieldPath"]:eq(0) input').type(
+        "arrow-left-regression/---test"
+      );
+
+      cy.getElement('[data-cy="RedirectsSearchFieldInput"] input').click();
+      cy.getElement('[data-cy="RedirectsSearchFieldInput"] input').type(
+        TEST_REDIRECTS_DATA[0]?.target
+      );
+
+      cy.getElement('[data-cy="RedirectsTargetOptionsContainer"] ul li')
+        .contains("/page/otherpage/all-field-types/", {
+          ...options,
+          matchCase: false,
+        })
+        .click();
+
+      // Regression for #4247: MUI's Autocomplete intercepts ArrowLeft to
+      // focus the rendered selected value (`renderValue`); if that node
+      // isn't wired up with MUI's item props, this throws.
+      cy.getElement('[data-cy="RedirectsSearchFieldInput"] input')
+        .focus()
+        .type("{leftarrow}");
+
+      cy.getElement('[data-cy="RedirectsSearchFieldInput"] input')
+        .should("exist")
+        .then(() => {
+          if (uncaughtError) {
+            expect(uncaughtError.message).to.not.contain("focus");
+          }
+        });
+
+      cy.getBySelector("RedirectsFormCancelButton").click();
+    });
+
     it("External", () => {
       cy.getElement('[data-cy="RedirectActionCreateButton"]').click();
 

--- a/src/apps/seo/src/app/components/RedirectsDialogProvider/CreateRedirects/SearchField.tsx
+++ b/src/apps/seo/src/app/components/RedirectsDialogProvider/CreateRedirects/SearchField.tsx
@@ -15,8 +15,18 @@ import { debounce } from "lodash";
 export const ListOption: React.FC<
   // `data-cy` is declared rather than left to the `...props` spread: it is set
   // explicitly by the caller, and JSX excess-property checking rejects an
-  // attribute a component's props type does not name.
-  ContentItemProps & { isListItem?: boolean; "data-cy"?: string }
+  // attribute a component's props type does not name. The same reasoning
+  // covers the fields below, which MUI's `renderValue` `getItemProps()`
+  // spreads onto the rendered value node (see SearchField's `renderValue`).
+  Omit<ContentItemProps, "onDelete"> & {
+    isListItem?: boolean;
+    "data-cy"?: string;
+    className?: string;
+    disabled?: boolean;
+    "data-item-index"?: number;
+    tabIndex?: number;
+    onDelete?: (event?: unknown) => void;
+  }
 > = ({
   label,
   path,
@@ -258,8 +268,9 @@ const SearchField: React.FC<SearchFieldProps> = ({
               />
             );
           }}
-          renderValue={(data: ContentItemProps | null) => (
+          renderValue={(data: ContentItemProps | null, getItemProps) => (
             <ListOption
+              {...getItemProps()}
               label={data?.label}
               path={data?.path}
               ZUID={data?.ZUID}

--- a/src/apps/seo/src/app/components/RedirectsDialogProvider/CreateRedirects/SearchField.tsx
+++ b/src/apps/seo/src/app/components/RedirectsDialogProvider/CreateRedirects/SearchField.tsx
@@ -271,6 +271,7 @@ const SearchField: React.FC<SearchFieldProps> = ({
           renderValue={(data: ContentItemProps | null, getItemProps) => (
             <ListOption
               {...getItemProps()}
+              data-cy={`${dataCy}Value`}
               label={data?.label}
               path={data?.path}
               ZUID={data?.ZUID}


### PR DESCRIPTION
Fixes #4247

## Summary
- Fixes `TypeError: Cannot read properties of null (reading 'focus')` (Sentry MANAGER-UI-3DT), thrown from MUI's `useAutocomplete.js` `focusItem`.
- This refines the automated Sentry RCA already posted on the issue, which theorized (low confidence, unverified) that `react-window` virtualization was dropping option row 0 from the DOM on scroll. Reading MUI's `useAutocomplete.js` source directly shows the real cause is unrelated to the options listbox entirely: MUI's ArrowLeft handler for single-value `renderValue` autocompletes runs `if (!multiple && renderValue) { focusItem(0); }`, which does `anchorEl.querySelector('[data-item-index="0"]').focus()`.
- The redirects target search field (`src/apps/seo/src/app/components/RedirectsDialogProvider/CreateRedirects/SearchField.tsx`) supplies a `renderValue` callback that renders the selected item's `ListOption` chip but never spread MUI's second callback argument (`getItemProps()`) onto it, so the rendered chip never received the `data-item-index` attribute MUI's querySelector depends on, and the querySelector returned `null`.
- Fix: `renderValue={(data, getItemProps) => <ListOption {...getItemProps()} .../>}`, plus widening `ListOption`'s prop type (`Omit<ContentItemProps, "onDelete"> & {...}`) to accept the extra attributes MUI's `getItemProps()` spreads on (`data-item-index`, `tabIndex`, `className`, `disabled`, and a widened `onDelete` signature).
- Also added `data-cy` to the rendered target-value node (the exact node this fix wires up for `.focus()`), which was flagged as untestable by this PR's own negative-QA pass.

## Why this differs from the automated RCA

The change-verifier's QA review came back **inconclusive** on two points; here's the reasoning that should resolve both:

**1. "The Sentry trace is 100% vendor code, so it can't be confirmed this was the actual production trigger."**
The reported stack is `focusItem` → `apply (…useAutocomplete.js:680:13)`. Line 680 in the installed `@mui/material` version is exactly `case 'ArrowLeft': if (!multiple && renderValue) { focusItem(0); }` — the frame number isn't a coincidence, it's the specific branch this fix addresses. `SearchField.tsx` is the only autocomplete in the app that passes `renderValue` for a single (non-`multiple`) value, so this is the only call site in the codebase that can reach that branch at all. I also reproduced this directly: reverting the fix locally and running the new Cypress regression test throws the *identical* error text Sentry captured (`Cannot read properties of null (reading 'focus')`), which stops occurring once the fix is applied — this isn't just source-reading, it's an observed before/after repro.

**2. "The diff doesn't address the RCA's own react-window/virtualization theory."**
That theory and this fix's root cause are two different code paths in `useAutocomplete.js`, not two explanations for the same one:
- The virtualization theory is about *navigating the open options listbox* — `validOptionIndex`/`moveHighlight`, which query `listboxRef.current.querySelector('[data-option-index="N"]')` against the virtualized `react-window` list (`ListboxComponent` in `SearchField.tsx`).
- The actual crash is about *focusing the already-selected value* on `ArrowLeft` — `focusItem(0)`, which queries `anchorEl.querySelector('[data-item-index="0"]')` against the `renderValue` node, entirely outside the listbox/virtualization.
- These use different query targets (`data-option-index` vs. `data-item-index`), different DOM subtrees (`listboxRef` vs. `anchorEl`), and are only reachable via different code branches. The virtualization theory's mechanism can't produce this exact stack frame (`useAutocomplete.js:680`) at all — that line is unconditional on `renderValue`, not on listbox scroll state. The RCA rated its own theory low-confidence for good reason; it wasn't wrong to flag, but it isn't what's happening here, so no listbox/`ListboxComponent` change was needed.

## Deferred (unrelated) finding
This PR's negative-QA pass also flagged that an existing internal-target redirect's target field can be cleared and reassigned via the clear icon when edited from the SEO app's `/redirects` table, despite visually reading as locked. Traced this to `isInternal` (the flag that drives the field's lock state) never being tied to `isEdit` or `targetType` anywhere — it's only set by two content-editor auto-create-redirect flows, not by the table's generic Edit action. Whether that's a bug or intended is a product/UX call outside this crash fix's scope, so it's deferred to #4292 rather than changed here.

## Test plan
- [x] Added a Cypress regression test in `cypress/e2e/seo/redirects/redirects.spec.js` ("Selecting a target and pressing ArrowLeft does not crash (regression for #4247)") that selects a target, presses ArrowLeft, and asserts no uncaught exception occurs at all.
- [x] Confirmed this test fails with the exact Sentry error message on the pre-fix code, and passes cleanly with the fix.
- [x] Ran the full `redirects.spec.js` suite (14 tests) against the dev instance — all pass.
- [x] `npx tsc --noEmit` is clean for the changed files.