### PR TITLE
Content - Fix flaky media lazy-load intersection check and repeater bulk-remove test race

### DIFF
--- a/cypress/e2e/content/content.spec.js
+++ b/cypress/e2e/content/content.spec.js
@@ -914,12 +914,17 @@ describe("Content Specs", () => {
       cy.getBySelector("subfield:single_line_text")
         .find("input")
         .clear()
-        .type("bulk remove row");
+        .type("bulk remove row")
+        .should("have.value", "bulk remove row");
       cy.getBySelector("subfield:url")
         .find("input")
         .clear()
-        .type("https://zesty.io");
-      cy.getBySelector("SaveRepeaterRowItemBtn").scrollIntoView().click();
+        .type("https://zesty.io")
+        .should("have.value", "https://zesty.io");
+      cy.getBySelector("SaveRepeaterRowItemBtn")
+        .scrollIntoView()
+        .should("be.enabled")
+        .click();
 
       cy.getBySelector("field:repeater")
         .find(".MuiDataGrid-row")

--- a/src/apps/content-editor/src/app/components/FieldTypeMedia.tsx
+++ b/src/apps/content-editor/src/app/components/FieldTypeMedia.tsx
@@ -676,9 +676,9 @@ export const MediaItem = ({
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const effectiveHideDrag = compact || hideDrag;
   const intersection = useIntersection(mediaItemContainerRef, {
-    threshold: 1,
+    threshold: 0,
   });
-  const isInView = intersection && intersection.intersectionRatio >= 1;
+  const isInView = intersection && intersection.intersectionRatio > 0;
   const { data, isFetching } = useGetFileQuery(imageZUID, {
     skip: imageZUID?.substr(0, 4) === "http" || !isInView,
   });


### PR DESCRIPTION
## Summary
- The media field's lazy-load `IntersectionObserver` used `threshold: 1`, requiring 100% unoccluded visibility before fetching a media item. That bar is fragile enough to rarely (if ever) resolve in CI, so `Content Specs > Media field > renders an image with a url from a template` timed out waiting for an `<img>` that never loaded. Lowered to `threshold: 0` — the fetch still defers until the item enters the viewport at all, preserving the original goal (avoid fetching every media item eagerly) without the near-impossible exact-visibility requirement. (`src/apps/content-editor/src/app/components/FieldTypeMedia.tsx`)
- `Content Specs > Repeater Field > should bulk remove checked rows` was exposed to the same type-then-save race already diagnosed and fixed for its sibling tests in #4168 (`cy.type()` can resolve just before React's state commits the value, so an immediate Save click can submit before the required field registers, leaving the row un-added). Added the same `.should("have.value", ...)` / `.should("be.enabled")` guards used elsewhere in this describe block. (`cypress/e2e/content/content.spec.js`)

Investigated from this failing run: https://github.com/zesty-io/manager-ui/actions/runs/32920890676/job/98034221705

## Test plan
- [ ] CI (`ci.yaml`) passes on this PR, specifically `content/content.spec.js`
- [ ] Manually verify in a browser that images in the media field of a content item still render, and that lazy-loading (no eager fetch of far-offscreen media items) still works