### PR TITLE
[Shell] - Bypass the CDN cache on the in-app announcements feed

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -63,11 +63,8 @@ Cypress.Commands.add("getBySelector", (selector, ...args) => {
 });
 
 Cypress.Commands.add("blockAnnouncements", () => {
-  // The trailing glob is load-bearing. cy.intercept's string matcher compares
-  // against the full url and against url.parse().path — and `path` includes the
-  // query string, so the bare path stopped matching once #2323 added a
-  // cache-busting `?_=<n>` to the request. Without the glob this intercept
-  // silently misses and the announcement dialog renders over every spec.
+  // Glob is required: cy.intercept matches against a path that includes the
+  // query string, and #2323 added a cache-busting `?_=<n>`.
   cy.intercept("/-/instant/6-90fbdcadfc-4lc0s5.json*", (req) => {
     req.reply({});
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -63,7 +63,12 @@ Cypress.Commands.add("getBySelector", (selector, ...args) => {
 });
 
 Cypress.Commands.add("blockAnnouncements", () => {
-  cy.intercept("/-/instant/6-90fbdcadfc-4lc0s5.json", (req) => {
+  // The trailing glob is load-bearing. cy.intercept's string matcher compares
+  // against the full url and against url.parse().path — and `path` includes the
+  // query string, so the bare path stopped matching once #2323 added a
+  // cache-busting `?_=<n>` to the request. Without the glob this intercept
+  // silently misses and the announcement dialog renders over every spec.
+  cy.intercept("/-/instant/6-90fbdcadfc-4lc0s5.json*", (req) => {
     req.reply({});
   });
 });

--- a/src/shell/services/marketing.ts
+++ b/src/shell/services/marketing.ts
@@ -10,8 +10,27 @@ export const marketingApi = createApi({
   endpoints: (builder) => ({
     // Get announcements via instant api from the marketing instance
     getAnnouncements: builder.query<Announcement[], void>({
+      // #2323: this endpoint is a WebEngine response behind Fastly, and the edge
+      // object is evicted by surrogate-key purge on *publish* — not by a TTL, and
+      // not by deleting a content item. Measured on 2026-08-26: the gzip variant
+      // every browser receives was served as `x-cache: HIT` at `age: 84518`
+      // (23.5h) and still climbing, so a deleted announcement keeps rendering
+      // long after the origin has dropped it. The response's `cache-control:
+      // no-cache` governs client caches only and does not reach the edge object.
+      //
+      // A unique query param is the only lever the client has: it changes the
+      // cache key, so the request misses the edge and reads origin (verified —
+      // same URL with `?_=<n>` returns `x-cache: MISS, MISS`, `age: 0`, same
+      // body). One origin request per app load, since RTK Query keys this
+      // endpoint on its argument and not on the URL.
+      //
+      // Removable once the platform purges on delete. If it is removed, update
+      // `cy.blockAnnouncements()` in cypress/support/commands.js as well — its
+      // matcher is globbed to tolerate the param.
       query: () =>
-        `/-/instant/${__CONFIG__.MARKETING_ANNOUNCEMENT_MODEL_ZUID}.json`,
+        `/-/instant/${
+          __CONFIG__.MARKETING_ANNOUNCEMENT_MODEL_ZUID
+        }.json?_=${Date.now()}`,
       transformResponse: (response: { data: any[] }) => {
         // Filter out other languages if exists, this makes sure that announcements don't get repeatedly shown per language
         return response?.data?.reduce((accu, currVal) => {

--- a/src/shell/services/marketing.ts
+++ b/src/shell/services/marketing.ts
@@ -10,23 +10,8 @@ export const marketingApi = createApi({
   endpoints: (builder) => ({
     // Get announcements via instant api from the marketing instance
     getAnnouncements: builder.query<Announcement[], void>({
-      // #2323: this endpoint is a WebEngine response behind Fastly, and the edge
-      // object is evicted by surrogate-key purge on *publish* — not by a TTL, and
-      // not by deleting a content item. Measured on 2026-08-26: the gzip variant
-      // every browser receives was served as `x-cache: HIT` at `age: 84518`
-      // (23.5h) and still climbing, so a deleted announcement keeps rendering
-      // long after the origin has dropped it. The response's `cache-control:
-      // no-cache` governs client caches only and does not reach the edge object.
-      //
-      // A unique query param is the only lever the client has: it changes the
-      // cache key, so the request misses the edge and reads origin (verified —
-      // same URL with `?_=<n>` returns `x-cache: MISS, MISS`, `age: 0`, same
-      // body). One origin request per app load, since RTK Query keys this
-      // endpoint on its argument and not on the URL.
-      //
-      // Removable once the platform purges on delete. If it is removed, update
-      // `cy.blockAnnouncements()` in cypress/support/commands.js as well — its
-      // matcher is globbed to tolerate the param.
+      // #2323: the feed is edge-cached until a publish purges it, so a deleted
+      // announcement keeps rendering. Unique param = new cache key = origin read.
       query: () =>
         `/-/instant/${
           __CONFIG__.MARKETING_ANNOUNCEMENT_MODEL_ZUID


### PR DESCRIPTION
Closes #2323

The in-app announcement popup outlives the content item because the manager reads the announcements feed from Fastly, not from origin. `https://www.zesty.io/-/instant/6-90fbdcadfc-4lc0s5.json` is a WebEngine response whose edge object is evicted by surrogate-key purge on *publish* — deleting a content item does not purge it, and there is no TTL doing the job either: measured 2026-08-26, the gzip variant that every browser receives came back `x-cache: HIT, HIT` at `age: 84518` (23.5 hours) and still climbing, while an origin read of the same URL returned the current, correct six items. The response's `cache-control: no-cache` governs client caches and does not reach the edge object. This gives the query a unique `?_=<timestamp>` so it changes the Fastly cache key and reads origin — verified on the live endpoint, where the same URL with the param returns `x-cache: MISS, MISS`, `age: 0`, and an identical body. Cost is one origin request per app load, since RTK Query keys this endpoint on its argument rather than on the URL. The proper fix is purge-on-delete at the platform layer; this removes the user-visible symptom until that exists, and the comment says so.

`cy.blockAnnouncements()` had to move with it. Cypress matches a string `url` matcher against the full URL and against `url.parse().path`, and `path` includes the query string — so the bare path silently stopped matching once the param was added, which would have let the announcement dialog render over every spec in the suite. Running Cypress 15.20.1's own `doesRouteMatch` directly confirms it: exact string against the cache-busted URL is `false`, with the trailing glob it is `true`. A throwaway spec then confirmed it at runtime against a local dev server — the intercept fires and the request URL ends in `?_=<digits>`.

Verified locally: typecheck 20 errors / 0 in `src/`, unchanged from the `5dcce6531` baseline; `build:dev` compiles; `cypress/e2e/home/mature.spec.js` 9/9 green against a dev server proven to be serving this branch (the cache-buster is present in the bundle it served). Per-session note: this PR did not get the team's cold `reviewer` pass — subagents were ruled out for this session.

<!-- zesty-eng-team -->
