### PR TITLE
CI - Add workflow_dispatch to Claude Sentry Handler for manual re-runs

### DIFF
--- a/.github/workflows/claude-sentry-handler.yml
+++ b/.github/workflows/claude-sentry-handler.yml
@@ -12,13 +12,19 @@ name: "Claude: Sentry Handler"
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to run the Sentry RCA handler against (manual re-run/testing — issue must still look Sentry-origin to the Detect step, i.e. bot-authored with the Sentry permalink first line)"
+        required: true
+        type: number
 
 jobs:
   sentry-rca:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:
-      group: claude-sentry-handler-${{ github.event.issue.number }}
+      group: claude-sentry-handler-${{ github.event.inputs.issue_number || github.event.issue.number }}
       cancel-in-progress: true
     permissions:
       contents: write
@@ -27,12 +33,14 @@ jobs:
     steps:
       # Always re-fetch the body via `gh issue view` rather than trusting
       # github.event.issue.body, so the detection logic has one source of truth.
+      # ISSUE falls back to github.event.issue.number for the normal `issues`
+      # trigger; workflow_dispatch has no event.issue, only the manual input.
       - name: Detect Sentry-origin issue
         id: detect
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          ISSUE: ${{ github.event.issue.number }}
+          ISSUE: ${{ github.event.inputs.issue_number || github.event.issue.number }}
         run: |
           set -euo pipefail
           echo "number=$ISSUE" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` trigger (with a required `issue_number` input) to `claude-sentry-handler.yml`, alongside the existing `issues: [opened]` trigger.
- The concurrency group and the `Detect Sentry-origin issue` step's `ISSUE` env now resolve from `github.event.inputs.issue_number || github.event.issue.number`, so both trigger types share the rest of the job unchanged.

## Why
`issues: opened` only fires once per issue, so there was no way to re-exercise this workflow against an issue that already exists — e.g. to verify #4290's `allowed_bots` fix without waiting for a new Sentry-origin issue. This adds a manual escape hatch for that.

Note: manually dispatching against an issue still requires it to look Sentry-origin to the `Detect` step (bot-authored, first line matching the Sentry permalink format) — this doesn't bypass that check, it just lets you pick which existing issue to re-run against.

## Test plan
- [ ] Run this workflow manually (Actions tab → Claude: Sentry Handler → Run workflow) with `issue_number: 4289` and confirm it reaches the `investigate` step instead of failing at bot detection.
- [ ] Confirm the normal `issues: opened` trigger still works unaffected.