### PR TITLE
CI - Unify the Claude workflow and job names

### DIFF
--- a/.github/workflows/claude-auto-reviewer.yml
+++ b/.github/workflows/claude-auto-reviewer.yml
@@ -1,10 +1,11 @@
-name: Claude Auto Review
+name: "Claude: Code Review"
 
 # Code-level review on every non-draft PR into dev: bugs, security, performance, and CLAUDE.md
-# "Review red flags" only. The Claude Change Verifier workflow owns "what does this change do"
-# and acceptance-criteria QA — this workflow must never duplicate that. Findings land as inline
-# comments; each run posts a fresh single-line verdict comment (deliberately NOT updated in
-# place) so the PR timeline shows the review history: "1 blocker" → fix commits → "no blockers".
+# "Review red flags" only. The "Claude: Acceptance Criteria QA" workflow owns "what does this
+# change do" and acceptance-criteria QA — this workflow must never duplicate that. Findings
+# land as inline comments; each run posts a fresh single-line verdict comment (deliberately
+# NOT updated in place) so the PR timeline shows the review history: "1 blocker" → fix
+# commits → "no blockers".
 
 on:
   pull_request:
@@ -13,6 +14,7 @@ on:
 
 jobs:
   review:
+    name: Claude Code Review
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -36,10 +38,11 @@ jobs:
           # rejects the run outright before it ever reads the diff.
           allowed_bots: "github-actions"
           prompt: |
-            You are the CODE reviewer for this pull request. A separate "QA Review" workflow
-            already summarizes what the change does and validates it against the linked issue's
-            acceptance criteria. Do not duplicate it: no change summary, no restating the diff,
-            no judging whether the PR satisfies its issue, no test-coverage suggestions.
+            You are the CODE reviewer for this pull request. A separate "Claude: Acceptance
+            Criteria QA" workflow already summarizes what the change does and validates it
+            against the linked issue's acceptance criteria. Do not duplicate it: no change
+            summary, no restating the diff, no judging whether the PR satisfies its issue,
+            no test-coverage suggestions.
 
             Inputs:
               REPO        = ${{ github.repository }}

--- a/.github/workflows/claude-change-verifier.yml
+++ b/.github/workflows/claude-change-verifier.yml
@@ -1,4 +1,4 @@
-name: Claude Change Verifier
+name: "Claude: Acceptance Criteria QA"
 
 # Static QA on every non-draft, same-repo PR into dev. Reads the PR diff, the changed source, and
 # the linked issue, judges the change against the issue's acceptance criteria from the code, and
@@ -18,6 +18,7 @@ on:
 
 jobs:
   verify:
+    name: Claude Acceptance Criteria QA
     # Fork PRs don't get ANTHROPIC_API_KEY; this uses pull_request (not pull_request_target).
     if: >-
       github.event.pull_request.draft == false &&
@@ -73,7 +74,7 @@ jobs:
             the checked-out source. There is no running app or browser, so never claim to have observed
             runtime behavior.
 
-            A separate "Claude Auto Review" workflow already reviews this PR for bugs, security,
+            A separate "Claude: Code Review" workflow already reviews this PR for bugs, security,
             performance, and code conventions. Do not duplicate it: your only job is to judge the
             change against the linked issue's acceptance criteria. Mention a code-level problem
             only when it directly causes a criterion to fail.
@@ -105,7 +106,7 @@ jobs:
             markers verbatim). Do not post a comment or reply in chat.
 
               <!-- cv-verifier -->
-              ## QA Review — <✅ PASS | ❌ FAIL | ⚠️ INCONCLUSIVE>
+              ## Acceptance Criteria QA — <✅ PASS | ❌ FAIL | ⚠️ INCONCLUSIVE>
               <If an issue: "Validates #<n>: <title>". Else: "No linked issue found — change-only QA.">
 
               1. ✅ <criterion in one line>
@@ -177,6 +178,6 @@ jobs:
             exit 1
           fi
           if [ "$V" = "FAIL" ]; then
-            echo "::error::QA found an unmet criterion or a clear bug — see the QA Review comment."
+            echo "::error::QA found an unmet criterion or a clear bug — see the Acceptance Criteria QA comment."
             exit 1
           fi

--- a/.github/workflows/claude-issue-critique.yml
+++ b/.github/workflows/claude-issue-critique.yml
@@ -1,4 +1,4 @@
-name: Claude Issue Triage
+name: "Claude: Issue Triage"
 on:
   issues:
     # `edited` is needed for the duplicate-check job (re-evaluate when title/body
@@ -14,6 +14,7 @@ jobs:
   # when the title or body actually changed (see the `if`) — closes
   # zesty-io/manager-ui#4229.
   duplicate-check:
+    name: Claude Duplicate Issue Check
     if: >-
       github.event.issue.user.type != 'Bot' &&
       (github.event.action == 'opened' ||
@@ -328,6 +329,7 @@ jobs:
           echo "✅ Duplicate-check completed as expected for tier $TIER (has_body=$HAS_BODY)."
 
   triage:
+    name: Claude Issue Triage
     needs: duplicate-check
     # Skip bot-authored issues, non-`opened` events, and HIGH-confidence
     # duplicates (avoids wasting an Opus run on a likely-duplicate ticket).

--- a/.github/workflows/claude-negative-qa.yml
+++ b/.github/workflows/claude-negative-qa.yml
@@ -1,7 +1,7 @@
-name: Claude Negative QA
+name: "Claude: Adversarial Browser QA"
 
 # Drives the real app in a browser and attacks the PR's changed surface, as the dynamic
-# counterpart to Claude Change Verifier. Advisory only — it never fails the build.
+# counterpart to "Claude: Acceptance Criteria QA". Advisory only — it never fails the build.
 
 # Runs on every push: a once-per-PR report goes stale silently and a stale finding reads
 # exactly like a live one. Costs ~9 min of agent time per push, serialized; advisory, so a
@@ -28,6 +28,7 @@ concurrency:
 
 jobs:
   negative-qa:
+    name: Claude Adversarial Browser QA (advisory)
     # Fork PRs get neither secret; pull_request (not _target) means no path to leak them.
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -122,10 +123,10 @@ jobs:
               BASE_URL    = http://${{ env.QA_INSTANCE_ZUID }}.manager.dev.zesty.io:8080
               REPORT_FILE = ${{ github.workspace }}/negative-qa-comment.md
 
-            A separate "QA Review" workflow already validates this PR against its issue's
-            acceptance criteria from the code. Do not duplicate it: no change summary, no
-            restating the diff, no judging whether the PR satisfies its issue, no test
-            suggestions. Your job is to find inputs and sequences that break it.
+            A separate "Claude: Acceptance Criteria QA" workflow already validates this PR
+            against its issue's acceptance criteria from the code. Do not duplicate it: no
+            change summary, no restating the diff, no judging whether the PR satisfies its
+            issue, no test suggestions. Your job is to find inputs and sequences that break it.
 
             STEP 1 — Scope.
             Read the diff (gh pr diff <PR_NUMBER> --repo <REPO>) and the checked-out source.
@@ -200,8 +201,8 @@ jobs:
 
               <!-- negative-qa -->
 
-            Then "## Negative QA", then STRAIGHT INTO THE FINDINGS. Do NOT write an overview,
-            preamble, or summary paragraph — no recap of what the diff changes, no description
+            Then "## Adversarial Browser QA", then STRAIGHT INTO THE FINDINGS. Do NOT write
+            an overview, preamble, or summary paragraph — no recap of what the diff changes, no description
             of what you attacked, no verdict sentence. A reviewer opens this to see what broke;
             anything above the first finding pushes that off the screen. One section each:
 
@@ -232,8 +233,9 @@ jobs:
             Keep the blank lines after <summary> and before </details> — GitHub will not render
             the markdown inside without them.
 
-            If you found nothing, the report is the marker line, "## Negative QA", the single
-            line "No reproducible edge-case failures found on the surfaces this PR changes.",
+            If you found nothing, the report is the marker line, "## Adversarial Browser QA",
+            the single line "No reproducible edge-case failures found on the surfaces this PR
+            changes.",
             and the collapsed details block. AN EMPTY REPORT IS A VALID AND COMMON OUTCOME.
             Never pad it with speculative or unreproduced findings, and never report a finding
             you did not screenshot.

--- a/.github/workflows/claude-sentry-handler.yml
+++ b/.github/workflows/claude-sentry-handler.yml
@@ -1,4 +1,4 @@
-name: "Claude: Sentry Handler"
+name: "Claude: Sentry Triage & Auto-Fix"
 
 # For a real Sentry-origin issue (detected by a cheap regex step, everything else is a
 # no-op), Claude investigates via the Sentry MCP server and attempts a trial fix, then
@@ -21,6 +21,7 @@ on:
 
 jobs:
   sentry-rca:
+    name: Claude Sentry Triage & Auto-Fix
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:


### PR DESCRIPTION
Names the five Claude workflows for what they do, and makes the Actions list and the PR check list read the same way.

| file | workflow name | check name |
|---|---|---|
| `claude-auto-reviewer.yml` | `Claude: Code Review` | Claude Code Review |
| `claude-change-verifier.yml` | `Claude: Acceptance Criteria QA` | Claude Acceptance Criteria QA |
| `claude-issue-critique.yml` | `Claude: Issue Triage` | Claude Duplicate Issue Check / Claude Issue Triage |
| `claude-negative-qa.yml` | `Claude: Adversarial Browser QA` | Claude Adversarial Browser QA (advisory) |
| `claude-sentry-handler.yml` | `Claude: Sentry Triage & Auto-Fix` | Claude Sentry Triage & Auto-Fix |

Two names were wrong against behaviour, not just inconsistent:

- **Sentry.** "RCA" names only the `complex` branch. #4231 specifies two processes, and the workflow implements both: `:509` posts an RCA-only comment on `verdict == complex`, `:526` opens an auto-fix PR against `dev` on `verdict == simple`.
- **Negative QA.** The prompt is entirely attack sequences — delete-while-referenced, double-submit, navigate-mid-save — with a two-reproductions rule. "Browser QA" named the mechanism and dropped the intent.

Three prompts also referenced a workflow called `"QA Review"`, which has never existed under that name; they now name the real sibling workflows. The comment headings each workflow posts are aligned to the same names (`## QA Review` → `## Acceptance Criteria QA`, `## Negative QA` → `## Adversarial Browser QA`).

### Scope

No trigger, permission, secret, model, or step-logic change. Job **ids** are untouched, so `needs:`, `workflow_dispatch`, and `gh workflow run claude-negative-qa.yml` all keep working. The HTML markers (`<!-- cv-verifier -->`, `<!-- negative-qa -->`, `<!-- claude-code-review -->`) are untouched, so comment upsert and every downstream grep still match.

### Verification

- All five parse under `YAML.load`; `prettier --check` clean.
- Adding a job `name:` changes the check-run names on PRs. Ruleset `16667349` (dev) requires only `all_tests_passed`, so no required check is affected.
- Not reviewed by the `reviewer` subagent — subagents were unavailable this session.

<!-- zesty-eng-team -->
