### PR TITLE
Manager UI - Replace raw fontSize literals with typography variants

### DIFF
--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/ContentInfo/index.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/ContentInfo/index.js
@@ -53,10 +53,9 @@ export const ContentInfo = (props) => {
           borderColor: "grey.200",
         }}
         titleTypographyProps={{
+          variant: "overline",
           sx: {
             fontWeight: 400,
-            fontSize: "12px",
-            lineHeight: "32px",
             color: "text.primary",
           },
         }}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/ContentInfo/index.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/ContentInfo/index.js
@@ -48,7 +48,6 @@ export const ContentInfo = (props) => {
         sx={{
           p: 0,
           backgroundColor: "transparent",
-          fontSize: "16px",
           color: alpha(theme.palette.text.primary, 0.4),
           borderBottom: 1,
           borderColor: "grey.200",
@@ -89,10 +88,9 @@ export const ContentInfo = (props) => {
             <Box>
               <Stack direction="row" alignItems="center" gap={1} pb={0.5}>
                 <Typography
+                  variant="body2"
                   sx={{
                     fontWeight: 600,
-                    fontSize: "14px",
-                    lineHeight: "20px",
                   }}
                 >
                   ZUID

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/ContentLinks/ContentLinks.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/ContentLinks/ContentLinks.js
@@ -29,7 +29,6 @@ export const ContentLinks = memo(function ContentLinks(props) {
           sx={{
             p: 0,
             backgroundColor: "transparent",
-            fontSize: "16px",
             color: alpha(theme.palette.text.primary, 0.4),
             borderBottom: 1,
             borderColor: "grey.200",

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/ContentLinks/ContentLinks.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/ContentLinks/ContentLinks.js
@@ -34,10 +34,9 @@ export const ContentLinks = memo(function ContentLinks(props) {
             borderColor: "grey.200",
           }}
           titleTypographyProps={{
+            variant: "overline",
             sx: {
               fontWeight: 400,
-              fontSize: "12px",
-              lineHeight: "32px",
               color: "text.primary",
             },
           }}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/Unpublish/Unpublish.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/Unpublish/Unpublish.js
@@ -39,7 +39,6 @@ export const Unpublish = memo(function Unpublish(props) {
         sx={{
           p: 0,
           backgroundColor: "transparent",
-          fontSize: "16px",
           color: alpha(theme.palette.text.primary, 0.4),
           borderBottom: 1,
           borderColor: "grey.200",
@@ -79,8 +78,6 @@ export const Unpublish = memo(function Unpublish(props) {
               variant="body2"
               color="text.secondary"
               sx={{
-                fontSize: "14px",
-                lineHeight: "20px",
                 maxWidth: "595px",
               }}
             >

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/Unpublish/Unpublish.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/Unpublish/Unpublish.js
@@ -44,10 +44,9 @@ export const Unpublish = memo(function Unpublish(props) {
           borderColor: "grey.200",
         }}
         titleTypographyProps={{
+          variant: "overline",
           sx: {
             fontWeight: 400,
-            fontSize: "12px",
-            lineHeight: "32px",
             color: "text.primary",
           },
         }}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
@@ -29,7 +29,6 @@ export const WidgetDeleteItem = memo(function WidgetDeleteItem(props) {
           sx={{
             p: 0,
             backgroundColor: "transparent",
-            fontSize: "16px",
             color: alpha(theme.palette.text.primary, 0.4),
             borderBottom: 1,
             borderColor: "grey.200",
@@ -69,8 +68,6 @@ export const WidgetDeleteItem = memo(function WidgetDeleteItem(props) {
                 variant="body2"
                 color="text.secondary"
                 sx={{
-                  fontSize: "14px",
-                  lineHeight: "20px",
                   maxWidth: "595px",
                 }}
               >

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDeleteItem/WidgetDeleteItem.js
@@ -34,10 +34,9 @@ export const WidgetDeleteItem = memo(function WidgetDeleteItem(props) {
             borderColor: "grey.200",
           }}
           titleTypographyProps={{
+            variant: "overline",
             sx: {
               fontWeight: 400,
-              fontSize: "12px",
-              lineHeight: "32px",
               color: "text.primary",
               textTransform: "uppercase",
             },

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDraftHistory/WidgetDraftHistory.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDraftHistory/WidgetDraftHistory.js
@@ -48,7 +48,6 @@ export default connect((state, props) => {
         sx={{
           p: 0,
           backgroundColor: "transparent",
-          fontSize: "16px",
           color: alpha(theme.palette.text.primary, 0.4),
           borderBottom: 1,
           borderColor: "grey.200",
@@ -97,18 +96,16 @@ export default connect((state, props) => {
                   justifyContent="space-between"
                 >
                   <Typography
+                    variant="body2"
                     sx={{
                       fontWeight: 500,
-                      fontSize: "14px",
-                      lineHeight: "20px",
                       color: "text.primary",
                     }}
                   >{`${log.firstName} ${log.lastName}`}</Typography>
                   <Typography
+                    variant="body2"
                     sx={{
                       fontWeight: 500,
-                      fontSize: "14px",
-                      lineHeight: "20px",
                       color: alpha(theme.palette.text.primary, 0.56),
                     }}
                   >
@@ -131,10 +128,9 @@ export default connect((state, props) => {
         ) : (
           <Typography
             className="noLogs"
+            variant="body2"
             sx={{
               fontWeight: 500,
-              fontSize: "14px",
-              lineHeight: "20px",
               color: "text.primary",
             }}
           >

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDraftHistory/WidgetDraftHistory.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetDraftHistory/WidgetDraftHistory.js
@@ -53,10 +53,9 @@ export default connect((state, props) => {
           borderColor: "grey.200",
         }}
         titleTypographyProps={{
+          variant: "overline",
           sx: {
             fontWeight: 400,
-            fontSize: "12px",
-            lineHeight: "32px",
             color: "text.primary",
           },
         }}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetListed/WidgetListed.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetListed/WidgetListed.js
@@ -40,10 +40,9 @@ export const WidgetListed = memo(function WidgetListed(props) {
           borderColor: "grey.200",
         }}
         titleTypographyProps={{
+          variant: "overline",
           sx: {
             fontWeight: 400,
-            fontSize: "12px",
-            lineHeight: "32px",
             color: "text.primary",
           },
         }}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetListed/WidgetListed.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetListed/WidgetListed.js
@@ -35,7 +35,6 @@ export const WidgetListed = memo(function WidgetListed(props) {
         sx={{
           p: 0,
           backgroundColor: "transparent",
-          fontSize: "16px",
           color: alpha(theme.palette.text.primary, 0.4),
           borderBottom: 1,
           borderColor: "grey.200",

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPublishHistory/WidgetPublishHistory.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPublishHistory/WidgetPublishHistory.js
@@ -57,10 +57,9 @@ export default connect((state) => {
             borderColor: "grey.200",
           }}
           titleTypographyProps={{
+            variant: "overline",
             sx: {
               fontWeight: 400,
-              fontSize: "12px",
-              lineHeight: "32px",
               color: "text.primary",
             },
           }}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPublishHistory/WidgetPublishHistory.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPublishHistory/WidgetPublishHistory.js
@@ -52,7 +52,6 @@ export default connect((state) => {
           sx={{
             p: 0,
             backgroundColor: "transparent",
-            fontSize: "16px",
             color: alpha(theme.palette.text.primary, 0.4),
             borderBottom: 1,
             borderColor: "grey.200",
@@ -99,10 +98,9 @@ export default connect((state) => {
               <Stack gap={1.5}>
                 {Array.isArray(logs) && !logs.length && (
                   <Typography
+                    variant="body2"
                     sx={{
                       fontWeight: 500,
-                      fontSize: "14px",
-                      lineHeight: "20px",
                       color: "text.primary",
                     }}
                   >
@@ -120,18 +118,16 @@ export default connect((state) => {
                         justifyContent="space-between"
                       >
                         <Typography
+                          variant="body2"
                           sx={{
                             fontWeight: 500,
-                            fontSize: "14px",
-                            lineHeight: "20px",
                             color: "text.primary",
                           }}
                         >{`${firstName} ${lastName}`}</Typography>
                         <Typography
+                          variant="body2"
                           sx={{
                             fontWeight: 500,
-                            fontSize: "14px",
-                            lineHeight: "20px",
                             color: alpha(theme.palette.text.primary, 0.56),
                           }}
                         >

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPurgeItem/WidgetPurgeItem.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPurgeItem/WidgetPurgeItem.js
@@ -29,7 +29,6 @@ export const WidgetPurgeItem = memo(function WidgetPurgeItem(props) {
         sx={{
           p: 0,
           backgroundColor: "transparent",
-          fontSize: "16px",
           color: alpha(theme.palette.text.primary, 0.4),
           borderBottom: 1,
           borderColor: "grey.200",
@@ -69,8 +68,6 @@ export const WidgetPurgeItem = memo(function WidgetPurgeItem(props) {
               variant="body2"
               color="text.secondary"
               sx={{
-                fontSize: "14px",
-                lineHeight: "20px",
                 maxWidth: "595px",
               }}
             >

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPurgeItem/WidgetPurgeItem.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetPurgeItem/WidgetPurgeItem.js
@@ -34,10 +34,9 @@ export const WidgetPurgeItem = memo(function WidgetPurgeItem(props) {
           borderColor: "grey.200",
         }}
         titleTypographyProps={{
+          variant: "overline",
           sx: {
             fontWeight: 400,
-            fontSize: "12px",
-            lineHeight: "32px",
             color: "text.primary",
           },
         }}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetQuickShare/WidgetQuickShare.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetQuickShare/WidgetQuickShare.js
@@ -42,10 +42,9 @@ export const WidgetQuickShare = memo(function WidgetQuickShare(props) {
           borderColor: "grey.200",
         }}
         titleTypographyProps={{
+          variant: "overline",
           sx: {
             fontWeight: 400,
-            fontSize: "12px",
-            lineHeight: "32px",
             color: "text.primary",
           },
         }}

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetQuickShare/WidgetQuickShare.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WidgetQuickShare/WidgetQuickShare.js
@@ -37,7 +37,6 @@ export const WidgetQuickShare = memo(function WidgetQuickShare(props) {
         sx={{
           p: 0,
           backgroundColor: "transparent",
-          fontSize: "16px",
           color: alpha(theme.palette.text.primary, 0.4),
           borderBottom: 1,
           borderColor: "grey.200",
@@ -75,10 +74,8 @@ export const WidgetQuickShare = memo(function WidgetQuickShare(props) {
           <Stack
             gap={1.5}
             sx={{
-              fontSize: "14px",
+              typography: "body2",
               fontWeight: 500,
-              lineHeight: "20px",
-              letteSpacing: "0px",
             }}
           >
             <Link

--- a/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WorkflowRequest/WorkflowRequest.js
+++ b/src/apps/content-editor/src/app/views/ItemEdit/Content/Actions/Widgets/WorkflowRequest/WorkflowRequest.js
@@ -155,10 +155,9 @@ ${
             }}
           >
             <Typography
+              variant="overline"
               sx={{
                 fontWeight: 400,
-                fontSize: "12px",
-                lineHeight: "32px",
                 color: "text.primary",
               }}
               textTransform="uppercase"

--- a/src/apps/content-editor/src/app/views/ItemEdit/components/BlockTabs/CodeSample.tsx
+++ b/src/apps/content-editor/src/app/views/ItemEdit/components/BlockTabs/CodeSample.tsx
@@ -23,10 +23,9 @@ export const CodeSample = () => {
       <Box>
         <Stack direction="row" alignItems="center" gap={1} pb={0.5}>
           <Typography
+            variant="body2"
             sx={{
               fontWeight: 600,
-              fontSize: "14px",
-              lineHeight: "20px",
             }}
           >
             Block Selector
@@ -41,10 +40,9 @@ export const CodeSample = () => {
       <Box>
         <Stack direction="row" alignItems="center" gap={1} pb={0.5}>
           <Typography
+            variant="body2"
             sx={{
               fontWeight: 600,
-              fontSize: "14px",
-              lineHeight: "20px",
             }}
           >
             Base Template
@@ -65,10 +63,9 @@ export const CodeSample = () => {
       <Box>
         <Stack direction="row" alignItems="center" gap={1} pb={0.5}>
           <Typography
+            variant="body2"
             sx={{
               fontWeight: 600,
-              fontSize: "14px",
-              lineHeight: "20px",
             }}
           >
             Base Template with Version
@@ -89,10 +86,9 @@ export const CodeSample = () => {
       <Box>
         <Stack direction="row" alignItems="center" gap={1} pb={0.5}>
           <Typography
+            variant="body2"
             sx={{
               fontWeight: 600,
-              fontSize: "14px",
-              lineHeight: "20px",
             }}
           >
             Specific Block Variant

--- a/src/shell/components/GlobalSearch/index.tsx
+++ b/src/shell/components/GlobalSearch/index.tsx
@@ -622,10 +622,10 @@ export const GlobalSearch = () => {
                       pb: 0.5,
                       pt: 0,
                       mt: 1,
-                      fontSize: "12px",
+                      typography: "body3",
+                      // body3 carries display: inline-block; a subheader must stay full width.
+                      display: "list-item",
                       fontWeight: 600,
-                      lineHeight: "18px",
-                      letterSpacing: "0.15px",
                     }}
                     key={option}
                   >
@@ -694,10 +694,10 @@ export const GlobalSearch = () => {
                       pb: 0.5,
                       pt: 0,
                       mt: 1,
-                      fontSize: "12px",
+                      typography: "body3",
+                      // body3 carries display: inline-block; a subheader must stay full width.
+                      display: "list-item",
                       fontWeight: 600,
-                      lineHeight: "18px",
-                      letterSpacing: "0.15px",
                     }}
                     key={option}
                   >


### PR DESCRIPTION
Refs #4287. Covers the sweep everywhere it can be made without changing a rendered value the design system does not already own; what is left is listed at the bottom and the issue stays open.

Two commits, deliberately separable.

**`c48906bd4` — 26 literals, rendered-identical.** 15 sites at `14px`/`20px` become `body2`, the two GlobalSearch `ListSubheader`s become `body3`, and 9 `fontSize: "16px"` declarations on widget `CardHeader` roots are deleted rather than converted — those roots have zero direct text nodes, so the declaration renders nothing. Verified as a `getComputedStyle` before/after diff over the 112 text-bearing elements of the content-item widget rail: **zero differences** in font-size, line-height, letter-spacing, weight, display or box size. `body3` carries `display: inline-block`, which would collapse a sticky full-width subheader, so `display` is pinned beside the variant.

**`8d19d7826` — the 10 `overline` headers, a deliberate rendered change.** The item-editor widget headers hand-rolled `overline` and lost its tracking; they were inheriting `letter-spacing: -0.56px` from `CardHeader`'s default `h5` variant, not `normal` as the issue assumes. Adopting the variant moves all ten to `letter-spacing: 1px` — measured, and it is the only property that changes: font-size stays 12px, line-height 32px, weight 400, colour `rgb(16,24,40)`, and **every box stays 287×32**, so nothing reflows or wraps. Eight headers also pick up `text-transform: uppercase` from the variant with no visible effect, their titles already being literal uppercase strings.

Raw `fontSize` literals in `src/` go **63 → 27 across 24 files**.

**What the 27 remaining occurrences are, and why none of them are in this PR.** 16 are MUI icons or a `Skeleton` and are out of scope by the issue's own Scope section — which also means its "`18px` ×5 — no variant exists" and "`28/20/32` ×5 → `h3`/`h5`/`h2`" rows should not be actioned at all; they would resize glyphs. 5 have no variant to adopt (`10px`/`14px` ×2, and three `ListItem` sites measured at a rendered `14/24`, which is neither `body2` 14/20 nor `subtitle2` 14/22) and go to design under `docs/design-system.md` §4. 4 sit on surfaces I could not reach to measure — two empty states and a `Link` in the code editor's bottom drawer.

The last 2 are **two of the issue's own 19 "exact matches"** and are deliberately left: `CompareDialog.tsx:337` and `PropertiesDialog.tsx:362` set `12px`/`18px` via `secondaryTypographyProps` but, unlike the GlobalSearch pair, carry no `letterSpacing` today, so adopting `body3` would add 0.15px of tracking *and* `display: inline-block`. Both render only in Analytics dialogs that need a connected GA property, so I could not measure the result and did not guess it. **17 of 19, not 19.**

Typecheck 0 errors / 0 in `src/`, unchanged from the branch point. `npm run build:dev` exits 0. `cypress/e2e/content/actions.spec.js` 17/17 and `cypress/e2e/search/search-bar.spec.js` 4/4.

No `reviewer` pass ran on either commit — the session instruction ruled out subagents, so this diff was reviewed only by its author.

<!-- zesty-eng-team -->
