### PR TITLE
CI - Move every Claude workflow to claude-sonnet-5

### DIFF
--- a/.github/workflows/claude-auto-reviewer.yml
+++ b/.github/workflows/claude-auto-reviewer.yml
@@ -83,7 +83,7 @@ jobs:
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Write,Grep,Glob"
-            --model claude-sonnet-4-6
+            --model claude-sonnet-5
             --max-turns 100
 
       # Always post a NEW verdict comment (never update in place): each push's verdict lands in

--- a/.github/workflows/claude-issue-critique.yml
+++ b/.github/workflows/claude-issue-critique.yml
@@ -330,7 +330,7 @@ jobs:
   triage:
     needs: duplicate-check
     # Skip bot-authored issues, non-`opened` events, and HIGH-confidence
-    # duplicates (avoids wasting an Opus run on a likely-duplicate ticket).
+    # duplicates (avoids spending a full triage run on a likely-duplicate ticket).
     # `always()` is required: without it, a duplicate-check failure would
     # skip triage too. The explicit `result != 'success'` check matters
     # because `outputs.tier` isn't reliably empty on failure: if the model
@@ -463,14 +463,13 @@ jobs:
               Never remove a label already on the issue, even one you disagree
               with, and never edit the issue's own title or body.
 
-          # claude-opus-4-8 is the current Opus model and is intentional — do not downgrade to claude-opus-4-7.
           # Write is unscoped (not `Write(triage-comment.md)`): the Write tool
           # always checks the absolutized file_path, so a path-scoped rule
           # never reliably matches (anthropics/claude-code#67849) — this was
           # silently dropping some runs' comments/labels entirely.
           claude_args: |
             --allowedTools "Bash(gh issue comment:*),Bash(gh issue view:*),Bash(gh issue edit:*),Write,Read,Grep,Glob"
-            --model claude-opus-4-8
+            --model claude-sonnet-5
             --max-turns 100
 
       # The Claude action reports success even when the model fails to post its


### PR DESCRIPTION
## What

Two model pins, in two commits:

| File | Job | Before | After |
|---|---|---|---|
| `claude-auto-reviewer.yml` | review | `claude-sonnet-4-6` | `claude-sonnet-5` |
| `claude-issue-critique.yml` | triage | `claude-opus-4-8` | `claude-sonnet-5` |

After this, all six `claude-code-action` invocations in the repo run `claude-sonnet-5`, and no invocation relies on the action's default model. `grep -i opus .github/workflows/` returns nothing.

## Why

**auto-reviewer** was the last workflow on `claude-sonnet-4-6`. That pin dates to #4150, the commit that first added a `--model` flag to the file; nothing since bumped it while the other four workflows moved to sonnet-5.

**issue-critique triage** was the only job deliberately on Opus. Changed on the Director's instruction. Two comments in that file justified the Opus pin and are updated with it:

- the `# claude-opus-4-8 ... do not downgrade` line above `claude_args` is removed — it no longer describes the file;
- the `if:` gate rationale above the `triage` job said the HIGH-duplicate skip "avoids wasting an Opus run". The skip still stands on its own merits, so the condition is unchanged and only the cost framing is reworded.

`--max-turns 100` and `timeout-minutes: 20` are untouched on both jobs.

## Not verified

A model flag only takes effect on the next event that triggers its workflow, so nothing here demonstrates that either job runs green on `claude-sonnet-5`. If a model string is rejected by the pinned action version, it surfaces as a failed job on the first PR (auto-reviewer) or the first opened issue (triage) after merge.

Related, not addressed: `claude-auto-reviewer.yml` carries the repo's oldest action pin, `anthropics/claude-code-action@1dc994e` (v1.0.127), against v1.0.184/185 elsewhere.

## Conflicts

None with #4307, which edits lines 1-14 and 36-48 of `claude-auto-reviewer.yml`; this touches line 86. #4307 also edits `claude-issue-critique.yml`, at the workflow/job `name:` keys, not `claude_args`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
