### PR TITLE
[CI] - Stop pre-checking Sentry auto-fix PR reviewers via collaborators endpoint

### DIFF
--- a/.github/workflows/claude-sentry-handler.yml
+++ b/.github/workflows/claude-sentry-handler.yml
@@ -579,9 +579,18 @@ jobs:
           for r in "${candidate_reviewers[@]}"; do
             resp=$(gh api --method POST "repos/$REPO/pulls/$pr_number/requested_reviewers" \
               -f "reviewers[]=$r" 2>/dev/null) || true
-            if ! jq -e --arg r "$r" '(.requested_reviewers // []) | any(.login == $r)' <<<"$resp" >/dev/null 2>&1; then
-              echo "::warning::Reviewer '$r' no longer has access to $REPO — skipping."
+            if jq -e --arg r "$r" '(.requested_reviewers // []) | any(.login == $r)' <<<"$resp" >/dev/null 2>&1; then
+              continue
             fi
+            # A real access problem (e.g. not a collaborator) comes back as a JSON error
+            # with a `.message`; an unknown/misspelled login instead gets silently
+            # dropped from a 200 response with no error at all, so fall back to a
+            # explanatory reason in that case rather than leaving the warning bare.
+            reason=$(jq -r '.message // empty' <<<"$resp" 2>/dev/null)
+            if [ -z "$reason" ]; then
+              reason="GitHub accepted the request but did not add '$r' as a reviewer — the login may not exist."
+            fi
+            echo "::warning::Reviewer '$r' was not added to $REPO: $reason"
           done
 
       # Checkpoint 2: confirm the branch that ran actually produced its outcome on

--- a/.github/workflows/claude-sentry-handler.yml
+++ b/.github/workflows/claude-sentry-handler.yml
@@ -568,9 +568,18 @@ jobs:
           # via org team membership under GITHUB_TOKEN (it 404s even for users who do
           # have push access), so it can't be used as a pre-check. Request each reviewer
           # directly instead and let a genuinely stale login warn without blocking the rest.
+          #
+          # This calls the REST endpoint directly rather than `gh pr edit --add-reviewer`:
+          # that command's GraphQL query pulls the deprecated Projects (classic)
+          # `projectCards` field and fails outright on every invocation in this repo,
+          # regardless of the reviewer. The REST endpoint also returns 200 and silently
+          # drops an unknown login instead of erroring, so success is confirmed by
+          # checking the response body for the login rather than trusting the exit code.
           candidate_reviewers=(agalin920 geodem127 finnar-bin)
           for r in "${candidate_reviewers[@]}"; do
-            if ! gh pr edit "$pr_number" --repo "$REPO" --add-reviewer "$r" >/dev/null 2>&1; then
+            resp=$(gh api --method POST "repos/$REPO/pulls/$pr_number/requested_reviewers" \
+              -f "reviewers[]=$r" 2>/dev/null) || true
+            if ! jq -e --arg r "$r" '(.requested_reviewers // []) | any(.login == $r)' <<<"$resp" >/dev/null 2>&1; then
               echo "::warning::Reviewer '$r' no longer has access to $REPO — skipping."
             fi
           done

--- a/.github/workflows/claude-sentry-handler.yml
+++ b/.github/workflows/claude-sentry-handler.yml
@@ -554,31 +554,26 @@ jobs:
 
           # gh pr create resolves --reviewer logins to IDs before it creates anything —
           # if even one of these three no longer has repo access, the whole PR creation
-          # fails, not just the reviewer request. Check each one first and only request
-          # whichever still have access, so losing one (or all) of them degrades the
-          # review assignment instead of blocking the PR outright.
+          # fails, not just the reviewer request. Create the PR with no reviewers first,
+          # then request each candidate individually so one bad/stale login degrades
+          # gracefully instead of blocking the PR outright.
+          pr_url=$(gh pr create --repo "$REPO" --base dev --title "$title" \
+            --label "sentry-auto-fix" \
+            --body-file pr-description.md)
+          pr_number="${pr_url##*/}"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "✅ Opened auto-fix PR on branch $branch for issue #$ISSUE."
+
+          # GET repos/{owner}/{repo}/collaborators/{username} can't see access granted
+          # via org team membership under GITHUB_TOKEN (it 404s even for users who do
+          # have push access), so it can't be used as a pre-check. Request each reviewer
+          # directly instead and let a genuinely stale login warn without blocking the rest.
           candidate_reviewers=(agalin920 geodem127 finnar-bin)
-          valid_reviewers=()
           for r in "${candidate_reviewers[@]}"; do
-            if gh api "repos/$REPO/collaborators/$r" >/dev/null 2>&1; then
-              valid_reviewers+=("$r")
-            else
+            if ! gh pr edit "$pr_number" --repo "$REPO" --add-reviewer "$r" >/dev/null 2>&1; then
               echo "::warning::Reviewer '$r' no longer has access to $REPO — skipping."
             fi
           done
-          reviewer_args=()
-          if [ ${#valid_reviewers[@]} -gt 0 ]; then
-            IFS=,
-            reviewer_args=(--reviewer "${valid_reviewers[*]}")
-            unset IFS
-          fi
-
-          pr_url=$(gh pr create --repo "$REPO" --base dev --title "$title" \
-            --label "sentry-auto-fix" \
-            "${reviewer_args[@]}" \
-            --body-file pr-description.md)
-          echo "pr_number=${pr_url##*/}" >> "$GITHUB_OUTPUT"
-          echo "✅ Opened auto-fix PR on branch $branch for issue #$ISSUE."
 
       # Checkpoint 2: confirm the branch that ran actually produced its outcome on
       # GitHub — the action (and the deterministic steps above) can silently no-op.


### PR DESCRIPTION
Fixes #4298

## Summary
- The "Open auto-fix PR" step in `.github/workflows/claude-sentry-handler.yml` used to pre-check each candidate reviewer (`agalin920`, `geodem127`, `finnar-bin`) via `gh api repos/{owner}/{repo}/collaborators/{username}` before calling `gh pr create --reviewer`.
- That endpoint can't see access granted via org team membership under the default `GITHUB_TOKEN`, so it 404'd for all three despite them having real write access through team membership — the pre-check treated them as having no access and silently skipped every reviewer request on every auto-fix PR.
- Fix: create the PR first without `--reviewer`, then request each candidate individually by POSTing directly to `repos/{owner}/{repo}/pulls/{n}/requested_reviewers`.
  - **Not** `gh pr edit --add-reviewer`: confirmed live against this PR that its GraphQL query pulls the deprecated Projects (classic) `projectCards` field, which errors out on *every* invocation in this repo regardless of the reviewer's validity — using it would have warned on every single reviewer, every time, masking valid ones just like the original bug.
  - The REST endpoint has its own quirk: it returns HTTP 200 and silently drops an unknown/nonexistent login instead of erroring, so exit code alone can't detect a bad login.
  - The warning now surfaces the actual reason instead of a generic message: GitHub's `.message` for a real access error (e.g. "not a collaborator"), or an explicit note when the login was silently dropped from a 200 response with no reviewer added.
- Verified against three real response shapes by testing live against this PR (cleaning up each test review request immediately after):
  - valid login, has access → added, appears in `requested_reviewers`, no warning
  - nonexistent login → HTTP 200, silently absent from `requested_reviewers` → warning: "the login may not exist"
  - real user, not a collaborator → HTTP 422 with a message → warning includes that message verbatim
  
  All three are handled correctly, and `set -euo pipefail` does not abort the step on either failure case (the failing command sits inside `resp=$(...) || true`, so it isn't part of any `&&`/pipeline chain that `-e` would catch).
- Single file changed: `.github/workflows/claude-sentry-handler.yml`.

## Test plan
- [x] Validated YAML syntax locally: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-sentry-handler.yml'))"`
- [x] Live-tested the REST reviewer-request call against this PR itself (#4313) for all three outcome shapes (real access, nonexistent login, real user without access), then removed the test review requests immediately after
- [x] Confirmed `gh pr edit --add-reviewer` (and `gh pr edit` in general) fails unconditionally in this repo due to an unrelated Projects (classic) deprecation, which is why the fix avoids it entirely
- [ ] Full end-to-end verification still requires a real `sentry-rca` workflow run that produces a `simple` verdict (per the issue's acceptance criteria), since org team-membership resolution under the Actions `GITHUB_TOKEN` can only be exercised from within Actions
