### PR TITLE
Content - Replace twirldown expand/collapse icon with chevron

### DIFF
--- a/src/shell/components/NavTree/components/RichTreeItem.tsx
+++ b/src/shell/components/NavTree/components/RichTreeItem.tsx
@@ -64,6 +64,10 @@ export const RichTreeItem = memo(
                     color: "common.white",
                   },
 
+                ".MuiTreeItem-iconContainer svg": {
+                  color: "action.active",
+                },
+
                 borderRadius: 0,
                 "&.Mui-selected": {
                   borderLeft: "2px solid",

--- a/src/shell/components/NavTree/index.tsx
+++ b/src/shell/components/NavTree/index.tsx
@@ -4,8 +4,8 @@ import { useHistory } from "react-router-dom";
 
 import { RichTreeItem } from "./components/RichTreeItem";
 import { ContentNavItem } from "../../services/types";
-import ArrowDropDownRoundedIcon from "@mui/icons-material/ArrowDropDownRounded";
-import ArrowRightRoundedIcon from "@mui/icons-material/ArrowRightRounded";
+import KeyboardArrowDownRoundedIcon from "@mui/icons-material/KeyboardArrowDownRounded";
+import KeyboardArrowRightRoundedIcon from "@mui/icons-material/KeyboardArrowRightRounded";
 import { Stack, Box, Skeleton } from "@mui/material";
 import { isValid as zuidIsValid } from "zuid";
 
@@ -138,8 +138,8 @@ export const NavTree: FC<Readonly<Props>> = ({
           selectedItems={[selected]}
           expansionTrigger={isDirectoryNavigation ? "content" : "iconContainer"}
           slots={{
-            collapseIcon: ArrowDropDownRoundedIcon,
-            expandIcon: ArrowRightRoundedIcon,
+            collapseIcon: KeyboardArrowDownRoundedIcon,
+            expandIcon: KeyboardArrowRightRoundedIcon,
             item: RichTreeItem,
           }}
           slotProps={{


### PR DESCRIPTION

### Summary

- Replaces the Content nav tree's expand/collapse icon (`ArrowDropDownRounded`/`ArrowRightRounded`) with a chevron pair (`KeyboardArrowDownRounded`/`KeyboardArrowRightRounded`), per the direction agreed in #4232 after enlarging the existing icon was tried and rejected.
- Adds an explicit base-state icon color (`action.active`) alongside the existing selected-state override, matching the precedent already shipped in Studio's layers panel (`StudioLayersTreeItem.tsx`).
- Change lives entirely in the shared `NavTree` component, so it applies to all five consumers (Content, Schema, Media, Code, Settings) — no per-app scoping, since nothing in the issue thread restricted it to Content only.

Fixes #4232

---
### Screen Recording
https://github.com/user-attachments/assets/34ae45d8-0d36-4d95-8e3b-42bc5a720096


---

### Requirement → Verification traceability

| Requirement (from issue #4232) | Implementation | Verified by |
|---|---|---|
| Replace rounded arrow icons with a chevron pair | `src/shell/components/NavTree/index.tsx` — `slots.collapseIcon`/`expandIcon` swapped to `KeyboardArrowDownRoundedIcon`/`KeyboardArrowRightRoundedIcon` | Live DOM check: `data-testid=KeyboardArrowDownRoundedIcon`; screenshot of rendered chevron |
| Do not enlarge — keep current footprint (explicitly rejected by maintainer) | No `fontSize` override added; icon left at MUI default | Row height measured at 28px (normal single-line), no layout push in screenshots |
| Selected-row icon color still works | `RichTreeItem.tsx` — added base `action.active` rule alongside, not replacing, the existing `.Mui-selected` → `primary.main` override; CSS-specificity checked (`.Mui-selected` combinator wins) | Measured computed color `rgb(255, 93, 10)` on a selected row |
| `expansionTrigger="iconContainer"` still holds — icon expands, label navigates | No prop touched | `aria-expanded` toggles on icon click; unchanged on label click |
| No regression in shared consumers | Change is global by design (single config point) | Cypress `content/navigation.spec.js` (8 passing/1 pending) and `code/sidebar.spec.js` (1 passing) re-run post-change, identical to pre-change baseline |
| TypeScript correctness | — | `npx tsc --noEmit` clean, 0 errors |
| Verified visually against a page with child items | — | Playwright screenshot + video against seeded item `/content/6-bac9f3bcbe-b7s4bv/7-f88ad8bcc3-1z83ht` |

### Diff

- `src/shell/components/NavTree/index.tsx` — icon imports + `slots` config (4 lines changed)
- `src/shell/components/NavTree/components/RichTreeItem.tsx` — base-state icon color rule (+4 lines)

No logic, layout, or API changes.

### Open item for reviewer

The issue never explicitly confirmed whether this should apply to Content only or globally to all `NavTree` consumers (Schema/Media/Code/Settings). This PR defaults to **global**, since the icon slot is configured in one shared place and nothing in the thread pushed back on a broader change. Flag if Content-only was actually intended — reverting to scoped would require forking the icon config per consumer.

### Test plan

- [x] `cypress/e2e/content/navigation.spec.js` — passing
- [x] `cypress/e2e/code/sidebar.spec.js` — passing
- [x] `npx tsc --noEmit` — clean
- [x] Manual/automated visual verification (Playwright) against Content tab, expand/collapse/select interactions
- [x] Reviewer: spot-check Schema, Media, Settings nav trees for visual acceptability (not covered by existing Cypress specs)